### PR TITLE
fix: eg-356 update list-laboratories API to query results to a specific organizationId

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/list-laboratories.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/list-laboratories.lambda.ts
@@ -10,7 +10,11 @@ export const handler: Handler = async (
 ): Promise<APIGatewayProxyResult> => {
   console.log('EVENT: \n' + JSON.stringify(event, null, 2));
   try {
-    const response: Laboratory[] = await laboratoryService.list();
+    // Get Query Parameter
+    const organizationId: string | undefined = event.queryStringParameters?.organizationId;
+    if (!organizationId) throw new Error('Required organizationId is missing');
+
+    const response: Laboratory[] = await laboratoryService.queryByOrganizationId(organizationId);
 
     if (response) {
       return buildResponse(200, JSON.stringify(response), event);

--- a/packages/back-end/src/infra/constructs/iam-construct.ts
+++ b/packages/back-end/src/infra/constructs/iam-construct.ts
@@ -218,8 +218,11 @@ export class IamConstruct extends Construct {
       '/easy-genomics/laboratory/list-laboratories',
       [
         new PolicyStatement({
-          resources: [`arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table`],
-          actions: ['dynamodb:Scan'],
+          resources: [
+            `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table`,
+            `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table/index/*`,
+          ],
+          actions: ['dynamodb:Query'],
           effect: Effect.ALLOW,
         }),
       ],


### PR DESCRIPTION
This modification introduces a query parameter `?organizationId=...` and modifies the laboratory-service implementation to execute a query instead of scanning all results.

The Super User / System Admin user will be able to use the query parameter to access the list of laboratories for any given organizationId.