### PR TITLE
fix: eg-380 update laboratory lambdas to call queryByLaboratoryId()

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/delete-laboratory.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/delete-laboratory.lambda.ts
@@ -18,7 +18,7 @@ export const handler: Handler = async (
     if (id === '') throw new Error('Required id is missing');
 
     // Lookup by LaboratoryId to confirm existence before deletion
-    const existingLaboratory: Laboratory = await laboratoryService.query(id);
+    const existingLaboratory: Laboratory = await laboratoryService.queryByLaboratoryId(id);
 
     // Check LaboratoryUsers are empty before deletion
     const existingLaboratoryUsers: LaboratoryUser[] = await laboratoryUserService.queryByLaboratoryId(existingLaboratory.LaboratoryId);

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/read-laboratory.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/read-laboratory.lambda.ts
@@ -15,7 +15,7 @@ export const handler: Handler = async (
     if (id === '') throw new Error('Required id is missing');
 
     // Lookup by GSI Id for convenience
-    const existing: Laboratory = await laboratoryService.query(id);
+    const existing: Laboratory = await laboratoryService.queryByLaboratoryId(id);
     return buildResponse(200, JSON.stringify(existing), event);
   } catch (err: any) {
     console.error(err);

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/update-laboratory.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/update-laboratory.lambda.ts
@@ -25,7 +25,7 @@ export const handler: Handler = async (
     if (!UpdateLaboratorySchema.safeParse(request).success) throw new Error('Invalid request');
 
     // Lookup by LaboratoryId to confirm existence before updating
-    const existing: Laboratory = await laboratoryService.query(id);
+    const existing: Laboratory = await laboratoryService.queryByLaboratoryId(id);
     const updated: Laboratory = await laboratoryService.update({
       ...existing,
       ...request,


### PR DESCRIPTION
This PR fixes bugs in the following Laboratory API endpoints:
- read-laboratory
- update-laboratory
- delete-laboratory

in trying to verify the Laboratory object exists before operating on it.