### PR TITLE
fix(EG-382): fix tables UI for empty state

### DIFF
--- a/packages/front-end/src/app/pages/labs.vue
+++ b/packages/front-end/src/app/pages/labs.vue
@@ -104,7 +104,7 @@
     </UTable>
   </UCard>
 
-  <div class="text-muted flex h-16 flex-wrap items-center justify-between" v-if="!isLoading || hasNoData">
+  <div class="text-muted flex h-16 flex-wrap items-center justify-between" v-if="!isLoading && !hasNoData">
     <div class="text-xs leading-5">Showing {{ pageFrom }} to {{ pageTo }} results</div>
     <div class="flex justify-end px-3" v-if="pageTotal > pageCount">
       <UPagination v-model="page" :page-count="10" :total="labData.length" />

--- a/packages/front-end/src/app/pages/organizations.vue
+++ b/packages/front-end/src/app/pages/organizations.vue
@@ -104,10 +104,10 @@
     </UTable>
   </UCard>
 
-  <div class="text-muted flex h-16 flex-wrap items-center justify-between" v-if="!isLoading || hasNoData">
+  <div class="text-muted flex h-16 flex-wrap items-center justify-between" v-if="!isLoading && !hasNoData">
     <div class="text-xs leading-5">Showing {{ pageFrom }} to {{ pageTo }} results</div>
     <div class="flex justify-end px-3" v-if="pageTotal > pageCount">
-      <UPagination v-model="page" :page-count="10" :total="labData.length" />
+      <UPagination v-model="page" :page-count="10" :total="orgData.length" />
     </div>
   </div>
 </template>


### PR DESCRIPTION
Fixes faulty display logic when an empty data set is returned for the Org/Labs tables causing the labs table to appear below the empty messaging.

Also adds the following UX improvements to tables:

1. loading indicator bar as API is being queried
2. consistent table column widths alignment 
