### PR TITLE
fix(EG-385): remove S3 public access settings conflicting with static web hosting throu CloudFront

### DIFF
--- a/packages/front-end/src/infra/constructs/www-hosting-construct.ts
+++ b/packages/front-end/src/infra/constructs/www-hosting-construct.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import path from 'path';
 import { S3Construct } from '@easy-genomics/shared-lib/src/infra/constructs/s3-construct';
 import { MainStackProps } from '@easy-genomics/shared-lib/src/infra/types/main-stack';
-import { CfnOutput, Duration, RemovalPolicy } from "aws-cdk-lib";
+import { CfnOutput, Duration, RemovalPolicy } from 'aws-cdk-lib';
 import { Certificate, ICertificate } from 'aws-cdk-lib/aws-certificatemanager';
 import {
   AllowedMethods,
@@ -99,14 +99,11 @@ export class WwwHostingConstruct extends Construct {
     const wwwBucketName: string = applicationUri; // Must be globally unique
     new CfnOutput(this, 'SiteApplicationUrl', { key: 'SiteApplicationUrl', value: `https://${applicationUri}` });
 
-    // Create S3 Bucket with custom props to support static website hosting
+    // Create S3 Bucket for static website hosting through CloudFront distribution
     const wwwBucket: Bucket = s3.createBucket(
       wwwBucketName,
       {
         accessControl: BucketAccessControl.PRIVATE,
-        publicReadAccess: true,
-        blockPublicAccess: undefined,
-        websiteIndexDocument: 'index.html',
         removalPolicy: RemovalPolicy.DESTROY,
       },
       this.props.devEnv,


### PR DESCRIPTION
This PR removes the S3 public access settings which is conflicting with the CloudFront distribution for the static web hosting for the S3 bucket.
