### PR TITLE
fix(EG-387): add missing IAM policies for additional data lookups for add-laboratory-user API

### DIFF
--- a/packages/back-end/src/infra/constructs/iam-construct.ts
+++ b/packages/back-end/src/infra/constructs/iam-construct.ts
@@ -370,7 +370,10 @@ export class IamConstruct extends Construct {
       '/easy-genomics/laboratory/user/add-laboratory-user',
       [
         new PolicyStatement({
-          resources: [`arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table`],
+          resources: [
+            `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table`,
+            `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table/index/*`,
+          ],
           actions: ['dynamodb:Query'],
           effect: Effect.ALLOW,
         }),


### PR DESCRIPTION
This PR adds the missing IAM policies for additional data lookups for add-laboratory-user API.