### PR TITLE
fix(EG-392): enforce light mode in nuxt config

### DIFF
--- a/packages/front-end/nuxt.config.ts
+++ b/packages/front-end/nuxt.config.ts
@@ -4,7 +4,12 @@ import Icons from 'unplugin-icons/vite';
 import Components from 'unplugin-vue-components/vite';
 
 export default defineNuxtConfig({
+  colorMode: {
+    preference: 'light',
+  },
+
   devtools: { enabled: true },
+
   modules: ['@nuxt/ui'],
 
   srcDir: 'src/app/',


### PR DESCRIPTION
Enforces light mode as a config option in Nuxt.

This setting is set as the browser localstorage value `nuxt-colour-mode` so may need to be cleared/deleted in order to take effect on next browser refresh.