### PR TITLE
feat(deploy): ignore easy-genomics.yaml and replace with example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,25 +59,8 @@ The following steps provide a quick start local development guide:
    Default region name [us-east-1]:
    Default output format [None]:
    ```
-6. Copy `.env.example` as `.env.local` and edit its settings for your AWS environment:
-
-   ```
-   AWS_ACCOUNT_ID=<AWS Account ID>                   # AWS Account to deploy to.
-   AWS_REGION=<AWS Region>                           # Must be an AWS Region that supports AWS HealthOmics
-
-   # The following ENV_TYPE, SUB_DOMAIN, and DOMAIN_NAME settings will be used to generate the Site Application URL.
-   # The Site Application URL generated will be:
-   # - prod: https://{SUB_DOMAIN}.{DOMAIN_NAME}
-   # - dev / pre-prod: https://{SUB_DOMAIN}.{ENV_TYPE}.{DOMAIN_NAME}
-   ENV_TYPE=prod                                     # e.g. dev, pre-prod, prod
-   SUB_DOMAIN=                                       # e.g. easy-genomics
-   DOMAIN_NAME=<Your desired domain name>            # e.g. myinstitution.org
-
-   # The following HOSTED_ZONE_ID, HOSTED_ZONE_NAME AND CERTIFICATE_ARN will need to be preconfigured in AWS.
-   HOSTED_ZONE_ID=<AWS Route53 Hosted Zone ID>
-   HOSTED_ZONE_NAME=<AWS Route53 Hosted Zone Name>   # Should be the same as the Site Application URL
-   CERTIFICATE_ARN=<AWS Certificate ARN>             # AWS ACM Certificate ARN for the Site Application URL
-   ```
+6. Copy `/config/easy-genomics.example.yaml` as `config/easy-genomics.yaml` and edit its settings for your deployment
+   environment. To add new environments add configuration following the example template.
 
 7. Run `pnpm bootstrap-all` to bootstrap CDK for configured AWS Account ID & Region:
    ```

--- a/config/easy-genomics.example.yaml
+++ b/config/easy-genomics.example.yaml
@@ -1,0 +1,24 @@
+easy-genomics:
+  configurations:
+    - dev:
+        aws-account-id:
+        aws-region:
+        env-type:
+        application-url:
+
+        # Back-End specific settings
+        back-end:
+            system-admin-email:
+
+        # Front-End specific settings
+        front-end:
+            # The following Front-End Infrastructure settings will need to be pre-configured in AWS.
+            aws-hosted-zone-id:
+            aws-hosted-zone-name:
+            aws-certificate-arn:
+
+            # The following Front-End Web UI / Nuxt Config settings will need to be sourced from the Back-End deployment.
+            aws-cognito-user-pool-id:
+            aws-cognito-client-id:
+            base-api-url: # TODO: Replace with application-url once APIGateway uses custom domains
+            mock-org-id: # TODO: Remove once custom User Authorization logic retrieves OrgIds

--- a/packages/front-end/package.json
+++ b/packages/front-end/package.json
@@ -62,7 +62,6 @@
     "constructs": "^10.0.5",
     "dotenv": "^16.4.5",
     "nuxt": "^3.10.1",
-    "ofetch": "^1.3.3",
     "prettier-plugin-tailwindcss": "^0.5.12",
     "sass": "^1.72.0",
     "tailwindcss": "^3.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -94,7 +94,7 @@ importers:
         version: 0.80.14(constructs@10.3.0)
       ts-jest:
         specifier: ^29.1.2
-        version: 29.1.2(@babel/core@7.24.3)(esbuild@0.20.0)(jest@29.7.0)(typescript@5.3.3)
+        version: 29.1.2(@babel/core@7.23.9)(jest@29.7.0)(typescript@5.4.3)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@18.19.26)(typescript@5.4.3)
@@ -228,9 +228,6 @@ importers:
       nuxt:
         specifier: ^3.10.1
         version: 3.10.1(@types/node@18.19.26)(eslint@8.56.0)(sass@1.72.0)(typescript@5.4.3)(vite@5.2.6)
-      ofetch:
-        specifier: ^1.3.3
-        version: 1.3.3
       prettier-plugin-tailwindcss:
         specifier: ^0.5.12
         version: 0.5.12(prettier@3.2.5)
@@ -379,7 +376,7 @@ importers:
         version: 0.79.27(constructs@10.3.0)
       ts-jest:
         specifier: ^29.1.2
-        version: 29.1.2(@babel/core@7.24.3)(esbuild@0.20.2)(jest@29.7.0)(typescript@5.4.3)
+        version: 29.1.2(@babel/core@7.24.3)(esbuild@0.20.0)(jest@29.7.0)(typescript@5.3.3)
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
@@ -12464,7 +12461,7 @@ packages:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.57.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.20.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
@@ -12498,7 +12495,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.20.0(eslint@8.56.0)(typescript@5.4.3)
+      '@typescript-eslint/parser': 6.20.0(eslint@8.56.0)(typescript@5.3.3)
       debug: 3.2.7
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
@@ -12547,7 +12544,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.20.0(eslint@8.56.0)(typescript@5.4.3)
+      '@typescript-eslint/parser': 6.20.0(eslint@8.56.0)(typescript@5.3.3)
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
@@ -19233,6 +19230,40 @@ packages:
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: false
+
+  /ts-jest@29.1.2(@babel/core@7.23.9)(jest@29.7.0)(typescript@5.4.3):
+    resolution: {integrity: sha512-br6GJoH/WUX4pu7FbZXuWGKGNDuU7b8Uj77g/Sp7puZV6EXzuByl6JrECvm0MzVzSTkSHWTihsXt+5XYER5b+g==}
+    engines: {node: ^16.10.0 || ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@jest/types': ^29.0.0
+      babel-jest: ^29.0.0
+      esbuild: '*'
+      jest: ^29.0.0
+      typescript: '>=4.3 <6'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@jest/types':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+    dependencies:
+      '@babel/core': 7.23.9
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.7.0(@types/node@18.19.26)(ts-node@10.9.2)
+      jest-util: 29.7.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.5.4
+      typescript: 5.4.3
+      yargs-parser: 21.1.1
+    dev: true
 
   /ts-jest@29.1.2(@babel/core@7.24.3)(esbuild@0.20.0)(jest@29.7.0)(typescript@5.3.3):
     resolution: {integrity: sha512-br6GJoH/WUX4pu7FbZXuWGKGNDuU7b8Uj77g/Sp7puZV6EXzuByl6JrECvm0MzVzSTkSHWTihsXt+5XYER5b+g==}


### PR DESCRIPTION
Replaces `easy-genomics.yaml` with `easy-genomics.example.yaml` and instructions in order to `gitignore` local changes to `easy-genomics.yaml`