### PR TITLE
chore(EG-358): rename data-seeding-nested-stack to data-provisioning-nested-stack

### DIFF
--- a/packages/back-end/src/infra/stacks/back-end-stack.ts
+++ b/packages/back-end/src/infra/stacks/back-end-stack.ts
@@ -2,7 +2,7 @@ import { BackEndStackProps } from '@easy-genomics/shared-lib/src/infra/types/mai
 import { Stack } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { AwsHealthOmicsNestedStack } from './aws-healthomics-nested-stack';
-import { DataSeedingNestedStack } from './data-seeding-nested-stack';
+import { DataProvisioningNestedStack } from './data-provisioning-nested-stack';
 import { EasyGenomicsNestedStack } from './easy-genomics-nested-stack';
 import { NFTowerNestedStack } from './nf-tower-nested-stack';
 import { ApiGatewayConstruct } from '../constructs/api-gateway-construct';
@@ -11,7 +11,7 @@ import { IamConstruct } from '../constructs/iam-construct';
 import {
   AwsHealthOmicsNestedStackProps,
   EasyGenomicsNestedStackProps,
-  NFTowerNestedStackProps, DataSeedingNestedStackProps,
+  NFTowerNestedStackProps, DataProvisioningNestedStackProps,
 } from '../types/back-end-stack';
 
 /**
@@ -97,12 +97,12 @@ export class BackEndStack extends Stack {
     };
     new NFTowerNestedStack(this, 'nf-tower-nested-stack', nfTowerNestedStackProps);
 
-    // DataSeedingNestedStackProps extends the BackEndStackProps
-    const dataSeedingNestedStackProps: DataSeedingNestedStackProps = {
+    // DataProvisioningNestedStackProps extends the BackEndStackProps
+    const dataSeedingNestedStackProps: DataProvisioningNestedStackProps = {
       ...this.props,
       userPool: this.cognitoIdp.userPool,
       dynamoDBTables: easyGenomicsNestedStack.dynamoDBTables,
     };
-    new DataSeedingNestedStack(this, 'data-seeding-nested-stack', dataSeedingNestedStackProps);
+    new DataProvisioningNestedStack(this, 'data-provisioning-nested-stack', dataSeedingNestedStackProps);
   };
 }

--- a/packages/back-end/src/infra/stacks/data-provisioning-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/data-provisioning-nested-stack.ts
@@ -10,12 +10,12 @@ import { Table } from 'aws-cdk-lib/aws-dynamodb';
 import { AwsCustomResource, AwsCustomResourcePolicy, PhysicalResourceId } from 'aws-cdk-lib/custom-resources';
 import { DynamoDB } from 'aws-sdk';
 import { Construct } from 'constructs';
-import { DataSeedingNestedStackProps } from '../types/back-end-stack';
+import { DataProvisioningNestedStackProps } from '../types/back-end-stack';
 
-export class DataSeedingNestedStack extends NestedStack {
-  readonly props: DataSeedingNestedStackProps;
+export class DataProvisioningNestedStack extends NestedStack {
+  readonly props: DataProvisioningNestedStackProps;
 
-  constructor(scope: Construct, id: string, props: DataSeedingNestedStackProps) {
+  constructor(scope: Construct, id: string, props: DataProvisioningNestedStackProps) {
     super(scope, id, props);
     this.props = props;
 

--- a/packages/back-end/src/infra/types/back-end-stack.d.ts
+++ b/packages/back-end/src/infra/types/back-end-stack.d.ts
@@ -20,8 +20,8 @@ export interface AwsHealthOmicsNestedStackProps extends EasyGenomicsNestedStackP
 export interface NFTowerNestedStackProps extends EasyGenomicsNestedStackProps {
 }
 
-// Defines the Data Seeding specific props
-export interface DataSeedingNestedStackProps extends BackEndStackProps, NestedStackProps {
+// Defines the Data Provisioning specific props
+export interface DataProvisioningNestedStackProps extends BackEndStackProps, NestedStackProps {
     userPool: UserPool,
     dynamoDBTables: Map<string, Table>
 }


### PR DESCRIPTION
This PR is a minor clean up that renames the `data-seeding-nested-stack` to `data-provisioning-nested-stack` as preparations for further data provisioning such as adding the System Admin and S3 buckets, along with existing data seeding.