### PR TITLE
feat(EG-378): avatar colours; invite users toggle button

### DIFF
--- a/packages/front-end/src/app/components/EGUserAvatar.vue
+++ b/packages/front-end/src/app/components/EGUserAvatar.vue
@@ -21,11 +21,7 @@
     if (!props.name && props.email) {
       return 'bg-primary-muted text-primary-dark';
     } else {
-      return props.labManager
-        ? 'bg-alert-danger-dark text-white'
-        : props.labTechnician
-          ? 'bg-primary-500 text-white'
-          : 'text-primary bg-primary-muted';
+      return 'bg-primary-dark text-white';
     }
   });
 </script>

--- a/packages/front-end/src/app/pages/orgs/view/[id].vue
+++ b/packages/front-end/src/app/pages/orgs/view/[id].vue
@@ -151,7 +151,7 @@
         <EGText tag="p" class="text-muted">{{ orgDescription }}</EGText>
       </div>
       <div class="relative flex flex-col items-end">
-        <EGButton label="Invite users" @click="() => (showInviteModule = true)" />
+        <EGButton label="Invite users" @click="() => (showInviteModule = !showInviteModule)" />
         <div class="absolute top-[60px] w-[500px]" v-if="showInviteModule">
           <EGInviteModule @invite-clicked="invite($event)" />
         </div>


### PR DESCRIPTION
UX/UI tweaks requested by Brent after the feature was merged:

- avatar colours: remove the Lab Manager/Techinican colours and change the fallback colour to the dark primary purple.
- "Invite users" button action should be a toggle instead of a one-time click.