### PR TITLE
fix(EG-444): improve add-laboratory-user API to check LaboratoryUser record doesn't already exist

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/user/add-laboratory-user.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/user/add-laboratory-user.lambda.ts
@@ -13,11 +13,13 @@ import {
 import { buildResponse } from '@easy-genomics/shared-lib/src/app/utils/common';
 import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
 import { LaboratoryService } from '../../../../services/easy-genomics/laboratory-service';
+import { LaboratoryUserService } from '../../../../services/easy-genomics/laboratory-user-service';
 import { OrganizationUserService } from '../../../../services/easy-genomics/organization-user-service';
 import { PlatformUserService } from '../../../../services/easy-genomics/platform-user-service';
 import { UserService } from '../../../../services/easy-genomics/user-service';
 
 const laboratoryService = new LaboratoryService();
+const laboratoryUserService = new LaboratoryUserService();
 const organizationUserService = new OrganizationUserService();
 const platformUserService = new PlatformUserService();
 const userService = new UserService();
@@ -37,20 +39,31 @@ export const handler: Handler = async (
 
     const status: Status = (request.Status === 'Inactive') ? 'Inactive' : 'Active';
 
-    // Lookup by LaboratoryId & UserId to confirm existence before adding
+    // Verify User does not have an existing LaboratoryUser access mapping
+    const laboratoryUser: LaboratoryUser | void = await laboratoryUserService.get(request.LaboratoryId, request.UserId).catch((error: unknown) => {
+      if (error.message.endsWith('Resource not found')) {
+        // Do nothing - allow new Laboratory-User access mapping to proceed.
+      } else {
+        throw error;
+      }
+    });
+
+    if (laboratoryUser) {
+      throw new Error('Laboratory User already exists');
+    }
+
+    // Retrieve existing Laboratory and User record details
     const laboratory: Laboratory = await laboratoryService.queryByLaboratoryId(request.LaboratoryId);
     const user: User = await userService.get(request.UserId);
 
     // Verify User has access to the Organization - throws error if not found
-    try {
-      await organizationUserService.get(laboratory.OrganizationId, user.UserId);
-    } catch (error: unknown) {
+    await organizationUserService.get(laboratory.OrganizationId, user.UserId).catch((error: unknown) => {
       if (error.message.endsWith('Resource not found')) {
         throw new Error('User not permitted access to the Laboratory without first granted access to the Organization');
       } else {
         throw error;
       }
-    }
+    });
 
     // Retrieve the User's OrganizationAccess metadata to update
     const organizationAccess: OrganizationAccess | undefined = user.OrganizationAccess;

--- a/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
@@ -338,6 +338,11 @@ export class EasyGenomicsNestedStack extends NestedStack {
       '/easy-genomics/laboratory/user/add-laboratory-user',
       [
         new PolicyStatement({
+          resources: [`arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-user-table`],
+          actions: ['dynamodb:GetItem'],
+          effect: Effect.ALLOW,
+        }),
+        new PolicyStatement({
           resources: [
             `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table`,
             `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table/index/*`,


### PR DESCRIPTION
This PR improves the `add-laboratory-user` API to check that the request to add a LaboratoryUser access mapping does not already exist.

This enhancement explicitly returns an API error message: `"Laboratory User already exists"`.