### PR TITLE
fix(EG-461): fix DynamoDB marshalling error when LaboratoryAccess object is undefined

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/user/add-laboratory-user.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/user/add-laboratory-user.lambda.ts
@@ -71,10 +71,10 @@ export const handler: Handler = async (
       ? organizationAccess[laboratory.OrganizationId].Status
       : 'Inactive'; // Fallback default
 
-    const laboratoryAccess: LaboratoryAccess | undefined =
-      (user.OrganizationAccess && user.OrganizationAccess[laboratory.OrganizationId])
+    const laboratoryAccess: LaboratoryAccess =
+      (user.OrganizationAccess && user.OrganizationAccess[laboratory.OrganizationId].LaboratoryAccess)
         ? user.OrganizationAccess[laboratory.OrganizationId].LaboratoryAccess
-        : undefined;
+        : {};
 
     const response: boolean = await platformUserService.addExistingUserToLaboratory({
       ...user,

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/user/edit-laboratory-user.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/user/edit-laboratory-user.lambda.ts
@@ -49,10 +49,10 @@ export const handler: Handler = async (
       ? organizationAccess[laboratory.OrganizationId].Status
       : 'Inactive'; // Fallback default
 
-    const laboratoryAccess: LaboratoryAccess | undefined =
-      (user.OrganizationAccess && user.OrganizationAccess[laboratory.OrganizationId])
+    const laboratoryAccess: LaboratoryAccess =
+      (user.OrganizationAccess && user.OrganizationAccess[laboratory.OrganizationId].LaboratoryAccess)
         ? user.OrganizationAccess[laboratory.OrganizationId].LaboratoryAccess
-        : undefined;
+        : {};
 
     const response: boolean = await platformUserService.editExistingUserAccessToLaboratory(
       {

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/user/remove-laboratory-user.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/user/remove-laboratory-user.lambda.ts
@@ -45,10 +45,10 @@ export const handler: Handler = async (
       ? organizationAccess[laboratory.OrganizationId].Status
       : 'Inactive'; // Fallback default
 
-    const laboratoryAccess: LaboratoryAccess | undefined =
-      (user.OrganizationAccess && user.OrganizationAccess[laboratory.OrganizationId])
+    const laboratoryAccess: LaboratoryAccess =
+      (user.OrganizationAccess && user.OrganizationAccess[laboratory.OrganizationId].LaboratoryAccess)
         ? user.OrganizationAccess[laboratory.OrganizationId].LaboratoryAccess
-        : undefined;
+        : {};
     (laboratoryAccess) ? delete laboratoryAccess[laboratory.LaboratoryId] : false;
 
     const response: boolean = await platformUserService.removeExistingUserFromLaboratory({

--- a/packages/back-end/src/app/controllers/easy-genomics/organization/user/edit-organization-user.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/organization/user/edit-organization-user.lambda.ts
@@ -38,10 +38,10 @@ export const handler: Handler = async (
 
     // Retrieve the User's OrganizationAccess metadata to update
     const organizationAccess: OrganizationAccess | undefined = user.OrganizationAccess;
-    const laboratoryAccess: LaboratoryAccess | undefined =
-      (organizationAccess && organizationAccess[request.OrganizationId])
+    const laboratoryAccess: LaboratoryAccess =
+      (organizationAccess && organizationAccess[request.OrganizationId].LaboratoryAccess)
         ? organizationAccess[request.OrganizationId].LaboratoryAccess
-        : undefined;
+        : {};
 
     const response: boolean = await platformUserService.editExistingUserAccessToOrganization(
       {

--- a/packages/back-end/src/app/controllers/easy-genomics/user/create-user-invite.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/user/create-user-invite.lambda.ts
@@ -51,7 +51,12 @@ export const handler: Handler = async (
         // Attempt to add the new User record, and add the Organization-User access mapping in one transaction
         if (await platformUserService.addNewUserToOrganization({
           ...newUser,
-          OrganizationAccess: { [organization.OrganizationId]: { Status: newOrganizationUser.Status } },
+          OrganizationAccess: {
+            [organization.OrganizationId]: {
+              Status: newOrganizationUser.Status,
+              LaboratoryAccess: {},
+            },
+          },
         }, newOrganizationUser)) {
           // TODO: Send email
           return buildResponse(200, JSON.stringify({ Status: 'Success' }), event);
@@ -88,7 +93,10 @@ export const handler: Handler = async (
             ...user,
             OrganizationAccess: {
               ...user.OrganizationAccess,
-              [organization.OrganizationId]: { Status: newOrganizationUser.Status },
+              [organization.OrganizationId]: {
+                Status: newOrganizationUser.Status,
+                LaboratoryAccess: {},
+              },
             },
             ModifiedAt: new Date().toISOString(),
             ModifiedBy: currentUserId,

--- a/packages/back-end/src/app/services/easy-genomics/platform-user-service.ts
+++ b/packages/back-end/src/app/services/easy-genomics/platform-user-service.ts
@@ -150,10 +150,10 @@ export class PlatformUserService extends DynamoDBService {
     console.info(logRequestMessage);
 
     // Find the current OrganizationAccess to identify the existing associated LaboratoryIds to remove
-    const laboratoryAccess: LaboratoryAccess | undefined =
-      (user.OrganizationAccess && user.OrganizationAccess[organizationUser.OrganizationId])
+    const laboratoryAccess: LaboratoryAccess =
+      (user.OrganizationAccess && user.OrganizationAccess[organizationUser.OrganizationId].LaboratoryAccess)
         ? user.OrganizationAccess[organizationUser.OrganizationId].LaboratoryAccess
-        : undefined;
+        : {};
 
     // Generate array of Delete transaction items to remove the User's associated LaboratoryUser mappings
     const laboratoryUserDeletions = (laboratoryAccess)


### PR DESCRIPTION
This PR fixes the APIs that lookup/update the User's OrganizationAccess metadata's optional LaboratoryAccess details.

It explicitly specifies the LaboratoryAccess object to be an empty JSON object `{}` to resolve an error from the DynamoDB SDK client when marshaling an object that has an undefined attribute.

