### PR TITLE
fix(EG-461): fix DynamoDB marshalling error when LaboratoryAccess object is undefined

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/user/add-laboratory-user.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/user/add-laboratory-user.lambda.ts
@@ -83,7 +83,7 @@ export const handler: Handler = async (
         [laboratory.OrganizationId]: <OrganizationAccessDetails>{
           Status: organizationStatus,
           LaboratoryAccess: <LaboratoryAccessDetails>{
-            ...laboratoryAccess,
+            ...(laboratoryAccess) ? laboratoryAccess : {},
             [laboratory.LaboratoryId]: { Status: status },
           },
         },

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/user/edit-laboratory-user.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/user/edit-laboratory-user.lambda.ts
@@ -62,7 +62,7 @@ export const handler: Handler = async (
           [laboratory.OrganizationId]: <OrganizationAccessDetails>{
             Status: organizationStatus,
             LaboratoryAccess: <LaboratoryAccessDetails>{
-              ...laboratoryAccess,
+              ...(laboratoryAccess) ? laboratoryAccess : {},
               [laboratory.LaboratoryId]: {
                 Status: status,
               },

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/user/remove-laboratory-user.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/user/remove-laboratory-user.lambda.ts
@@ -3,6 +3,7 @@ import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomic
 import { LaboratoryUser } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory-user';
 import {
   LaboratoryAccess,
+  LaboratoryAccessDetails,
   OrganizationAccess,
   OrganizationAccessDetails,
   User,
@@ -57,7 +58,9 @@ export const handler: Handler = async (
         ...organizationAccess,
         [laboratory.OrganizationId]: <OrganizationAccessDetails>{
           Status: organizationStatus,
-          LaboratoryAccess: laboratoryAccess,
+          LaboratoryAccess: <LaboratoryAccessDetails>{
+            ...(laboratoryAccess) ? laboratoryAccess : {},
+          },
         },
       },
       ModifiedAt: new Date().toISOString(),

--- a/packages/back-end/src/app/controllers/easy-genomics/organization/user/edit-organization-user.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/organization/user/edit-organization-user.lambda.ts
@@ -3,6 +3,7 @@ import { Status } from '@easy-genomics/shared-lib/src/app/types/base-entity';
 import { OrganizationUser } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/organization-user';
 import {
   LaboratoryAccess,
+  LaboratoryAccessDetails,
   OrganizationAccess,
   OrganizationAccessDetails,
   User,
@@ -50,7 +51,9 @@ export const handler: Handler = async (
           ...organizationAccess,
           [request.OrganizationId]: <OrganizationAccessDetails>{
             Status: status,
-            LaboratoryAccess: laboratoryAccess,
+            LaboratoryAccess: <LaboratoryAccessDetails>{
+              ...(laboratoryAccess) ? laboratoryAccess : {},
+            },
           },
         },
         ModifiedAt: new Date().toISOString(),

--- a/packages/back-end/src/app/controllers/easy-genomics/user/create-user-invite.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/user/create-user-invite.lambda.ts
@@ -51,7 +51,10 @@ export const handler: Handler = async (
         // Attempt to add the new User record, and add the Organization-User access mapping in one transaction
         if (await platformUserService.addNewUserToOrganization({
           ...newUser,
-          OrganizationAccess: { [organization.OrganizationId]: { Status: newOrganizationUser.Status } },
+          [organization.OrganizationId]: {
+            Status: newOrganizationUser.Status,
+            LaboratoryAccess: {},
+          },
         }, newOrganizationUser)) {
           // TODO: Send email
           return buildResponse(200, JSON.stringify({ Status: 'Success' }), event);
@@ -88,7 +91,10 @@ export const handler: Handler = async (
             ...user,
             OrganizationAccess: {
               ...user.OrganizationAccess,
-              [organization.OrganizationId]: { Status: newOrganizationUser.Status },
+              [organization.OrganizationId]: {
+                Status: newOrganizationUser.Status,
+                LaboratoryAccess: {},
+              },
             },
             ModifiedAt: new Date().toISOString(),
             ModifiedBy: currentUserId,


### PR DESCRIPTION
This PR fixes a DynamoDB SDK marshaling error when the LaboratoryAccess metadata was undefined.

It checks if the read `laboratoryAccess` metadata exists, and if it doesn't it defaults to an empty JSON object `{}`.