### PR TITLE
fix(EG-466): fix create-user-invite API User's OrganizationAccess definition for new Users

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/user/create-user-invite.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/user/create-user-invite.lambda.ts
@@ -51,9 +51,11 @@ export const handler: Handler = async (
         // Attempt to add the new User record, and add the Organization-User access mapping in one transaction
         if (await platformUserService.addNewUserToOrganization({
           ...newUser,
-          [organization.OrganizationId]: {
-            Status: newOrganizationUser.Status,
-            LaboratoryAccess: {},
+          OrganizationAccess: {
+            [organization.OrganizationId]: {
+              Status: newOrganizationUser.Status,
+              LaboratoryAccess: {},
+            },
           },
         }, newOrganizationUser)) {
           // TODO: Send email


### PR DESCRIPTION
This fixes a bug in the `create-user-invite` API when defining a new User object. The OrganizationAccess metadata was incorrectly defined.