### PR TITLE
feat(EG-467): fix edit-organization-user API for editing but prevent reverting Status to 'Invited'

### DIFF
--- a/packages/shared-lib/src/app/schema/easy-genomics/organization-user.ts
+++ b/packages/shared-lib/src/app/schema/easy-genomics/organization-user.ts
@@ -21,7 +21,7 @@ export const AddOrganizationUserSchema = z.object({
 export const EditOrganizationUserSchema = z.object({
   OrganizationId: z.string().uuid(),
   UserId: z.string().uuid(),
-  Status: z.enum(['Active', 'Inactive']),
+  Status: z.enum(['Active', 'Inactive', 'Invited']),
   OrganizationAdmin: z.boolean(),
 }).strict();
 


### PR DESCRIPTION
This PR fixes a bug when attempting to Edit an Organization User's `IsAdmin` toggle setting.

I had previously removed the `Invited` Status from the `EditOrganizationUserSchema` definition to prevent the Status from being modified back to `Invited`.

However, this caused the edit request to fail when just trying to update the User's `IsAdmin` toggle setting.

This fix adds the `Invited` status back to the `EditOrganizationUserSchema`, and add an extra logic check within the `edit-organization-user` API to prevent the Status from being changed back to `Invited` if it is already `Active` or `Inactive`.