### PR TITLE
feat(EG-472): update list-laboratory-users-details API to replace UserDisplayName with Name details

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/user/list-laboratory-users-details.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/user/list-laboratory-users-details.lambda.ts
@@ -31,23 +31,18 @@ export const handler: Handler = async (
     const response: LaboratoryUserDetails[] = laboratoryUsers.map(labUser => {
       const user: User | undefined = users.filter(u => u.UserId === labUser.UserId).shift();
       if (user) {
-        return <LaboratoryUserDetails> {
+        return <LaboratoryUserDetails>{
           UserId: labUser.UserId,
           LaboratoryId: labUser.LaboratoryId,
           LabManager: labUser.LabManager,
           LabTechnician: labUser.LabTechnician,
-          UserDisplayName: `${user.PreferredName ? user.PreferredName : user.FirstName} ${user.LastName}`.trim(),
+          PreferredName: user.PreferredName,
+          FirstName: user.FirstName,
+          LastName: user.LastName,
           UserEmail: user.Email,
         };
-      } else {
-        return <LaboratoryUserDetails> {
-          UserId: labUser.UserId,
-          LaboratoryId: labUser.LaboratoryId,
-          LabManager: labUser.LabManager,
-          LabTechnician: labUser.LabTechnician,
-        };
       }
-    });
+    }).flat();
 
     return buildResponse(200, JSON.stringify(response), event);
   } catch (err: any) {

--- a/packages/shared-lib/src/app/types/easy-genomics/laboratory-user-details.d.ts
+++ b/packages/shared-lib/src/app/types/easy-genomics/laboratory-user-details.d.ts
@@ -8,8 +8,10 @@
  *   LaboratoryId: <string>,
  *   LabManager: <boolean>,
  *   LabTechnician: <boolean>,
- *   UserDisplayName?: <string>,
- *   UserEmail?: <string>
+ *   PreferredName?: <string>,
+ *   FirstName?: <string>,
+ *   LastName?: <string>,
+ *   UserEmail: <string>
  * }
  */
 
@@ -18,6 +20,8 @@ export interface LaboratoryUserDetails {
   LaboratoryId: string;
   LabManager: boolean;
   LabTechnician: boolean;
-  UserDisplayName?: string;
-  UserEmail?: string;
+  PreferredName?: string;
+  FirstName?: string;
+  LastName?: string;
+  UserEmail: string;
 }


### PR DESCRIPTION
This PR brings the `list-laboratory-users-details` API response in line with the `list-organization-users-details` API by replacing the `UserDisplayName` with separate Name attributes.