### PR TITLE
feat(eg-448): user lab count per org

### DIFF
--- a/packages/front-end/src/app/composables/useUser.ts
+++ b/packages/front-end/src/app/composables/useUser.ts
@@ -11,6 +11,9 @@ type UserNameOptions = {
   email: string | undefined;
 };
 
+/**
+ * Composables for any User related functions
+ */
 export default function useUser() {
   const { $api } = useNuxtApp();
 
@@ -65,9 +68,19 @@ export default function useUser() {
     await handleInvite(reqBody, 'send');
   }
 
+  /**
+   * Count the number of labs a user has access to; default to 0 if no access
+   * @param user
+   */
+  function labsCount(user: OrganizationUserDetails) {
+    const labsAccess = Object.values(user?.OrganizationAccess || {}).flatMap(orgAccess => Object.values(orgAccess?.LaboratoryAccess || {}));
+    return labsAccess.filter(labAccess => labAccess.Status === "Active").length;
+  }
+
   return {
     displayName,
-    resendInvite,
+    labsCount,
     invite,
+    resendInvite
   };
 }

--- a/packages/front-end/src/app/pages/orgs/view/[id].vue
+++ b/packages/front-end/src/app/pages/orgs/view/[id].vue
@@ -21,7 +21,7 @@
   const orgUsersDetailsData = ref<OrganizationUserDetails[]>([]);
   const showInviteModule = ref(false);
   const { $api } = useNuxtApp();
-  const { resendInvite } = useUser();
+  const { resendInvite, labsCount } = useUser();
 
   // Dynamic remove user dialog values
   const isOpen = ref(false);
@@ -231,14 +231,7 @@
     searchOutput.value = newVal;
   }
 
-  /**
-   * Count the number of labs a user has access to; default to 0 if no access
-   * @param user
-   */
-  function labsCount(user: OrganizationUserDetails) {
-    const labsAccess = Object.values(user?.OrganizationAccess || {}).flatMap(orgAccess => Object.values(orgAccess?.LaboratoryAccess || {}));
-    return labsAccess.filter(labAccess => labAccess.Status === "Active").length;
-  }
+
 </script>
 
 <template>


### PR DESCRIPTION
Returns a total count for a user's lab access per organization by querying the `OrganizationUserDetails` response. This is used to populate the "All Users" tab in the Organization page.