### PR TITLE
fix(eg-484): race condition causing stale user data

### DIFF
--- a/packages/front-end/src/app/pages/orgs/edit-user/index.vue
+++ b/packages/front-end/src/app/pages/orgs/edit-user/index.vue
@@ -23,12 +23,10 @@
     },
   ];
 
-  onMounted(async () => {
-    await updateSelectedUser();
-    await fetchOrgLabs();
-    await fetchLabsUserData();
-    isLoading.value = false;
-  });
+  await updateSelectedUser();
+  await fetchOrgLabs();
+  await fetchLabsUserData();
+  isLoading.value = false;
 
   function updateSearchOutput(newVal: string) {
     searchOutput.value = newVal;
@@ -154,7 +152,6 @@
     <EGUserOrgAdminToggle
       :is-loading="isLoading"
       :user="useOrgsStore().selectedUser"
-      :display-name="useOrgsStore().getSelectedUserDisplayName"
       @update-user="updateSelectedUser($event)"
     />
   </div>

--- a/packages/front-end/src/app/pages/orgs/view/[id].vue
+++ b/packages/front-end/src/app/pages/orgs/view/[id].vue
@@ -96,13 +96,13 @@
     isOpen.value = false;
     isRemovingUser.value = true;
 
-    const userToRemove = orgUsersDetailsData.value.find(user => user.UserId === selectedUserId.value);
+    const userToRemove = orgUsersDetailsData.value.find((user) => user.UserId === selectedUserId.value);
     const displayName = useUser().displayName({
       preferredName: userToRemove?.PreferredName,
       firstName: userToRemove?.FirstName,
       lastName: userToRemove?.LastName,
       email: userToRemove?.UserEmail,
-    })
+    });
 
     try {
       if (!selectedUserId.value) {


### PR DESCRIPTION
Edit User org admin panel was showing stale user data caused by component rendering before the API had refreshed the selected user data. 

To solve this, the initial API calls in `/orgs/edit-user/` have been moved out of `onBeforeMount` and now sit top level inside the page `setup` function. This has also improved page rendering performance as the component now receives the data quicker. 

`EGUserOrgAdminToggle` was also refactored to compute the user display name inside internally rather than handled via a prop.