### PR TITLE
chore(EG-497): lower invitation JWT expiry to 1hr to support JWT expiry testing

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/user/create-user-invitation-request.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/user/create-user-invitation-request.lambda.ts
@@ -202,7 +202,7 @@ function generateUserInvitationJwt(email: string, userId: string, organizationId
     Email: email,
     CreatedAt: createdAt,
   };
-  return generateJwt(userInvitationJwt, process.env.JWT_SECRET_KEY, '7 days');
+  return generateJwt(userInvitationJwt, process.env.JWT_SECRET_KEY, '1 h');
 }
 
 // Used for customising error messages by exception types


### PR DESCRIPTION
This PR lowers the JWT expiry limit to 1 hour to assist with testing the JWT expiry behaviour.

The invitation JWT expiry limit will need to be changed back to 7 days once the JWT expiry testing is completed.