### PR TITLE
fix(EG-500): update UsersModule invite() to call the 'create-user-invitation-request' API endpoint

### DIFF
--- a/packages/front-end/src/app/repository/modules/users.ts
+++ b/packages/front-end/src/app/repository/modules/users.ts
@@ -10,7 +10,7 @@ class UsersModule extends HttpFactory {
   }
 
   async invite(orgId: string, email: string): Promise<User | undefined> {
-    return this.call<User>('POST', '/user/create-user-invite', {
+    return this.call<User>('POST', '/user/create-user-invitation-request', {
       Email: email,
       OrganizationId: orgId,
     });


### PR DESCRIPTION
This PR fixes the FE UserModule invite() to call the renamed API endpoint `/easy-genomics/user/create-user-invitation-request`.