### PR TITLE
fix(EG-501): correct confirm-user-invitation-request API to use x-api-key

### DIFF
--- a/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
@@ -47,6 +47,10 @@ export class EasyGenomicsNestedStack extends NestedStack {
             COGNITO_USER_POOL_ID: this.props.userPool!.userPoolId,
             JWT_SECRET_KEY: this.props.secretKey,
           },
+          methodOptions: {
+            apiKeyRequired: true,
+            authorizer: undefined, // Explicitly remove authorizer
+          },
         },
         '/easy-genomics/user/create-user-forgot-password-request': {
           environment: {


### PR DESCRIPTION
This PR fixes the `/easy-genomics/user/confirm-user-invitation-request` API endpoint to be protected by the `x-api-key` instead of the Cognito session.

This is to allow User's to properly access this API endpoint and complete the User invitation / sign-up workflow since they haven't got a Cognito session yet.