### PR TITLE
fix(EG-478): rename NextFlowTowerApiToken to NextFlowTowerAccessToken for consistency

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/create-laboratory.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/create-laboratory.lambda.ts
@@ -46,7 +46,7 @@ export const handler: Handler = async (
 
     const response: Laboratory = await laboratoryService.add({
       ...request,
-      NextFlowTowerApiToken: await encrypt(request.NextFlowTowerApiToken),
+      NextFlowTowerAccessToken: await encrypt(request.NextFlowTowerAccessToken),
       LaboratoryId: uuidv4(),
       AwsHealthOmicsEnabled: request.AwsHealthOmicsEnabled || organization.AwsHealthOmicsEnabled || false,
       NextFlowTowerEnabled: request.NextFlowTowerEnabled || organization.NextFlowTowerEnabled || false,

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/update-laboratory.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/update-laboratory.lambda.ts
@@ -50,7 +50,7 @@ export const handler: Handler = async (
     const updated: Laboratory = await laboratoryService.update({
       ...existing,
       ...request,
-      NextFlowTowerApiToken: await encrypt(request.NextFlowTowerApiToken),
+      NextFlowTowerAccessToken: await encrypt(request.NextFlowTowerAccessToken),
       ModifiedAt: new Date().toISOString(),
       ModifiedBy: userId,
     }, existing);

--- a/packages/shared-lib/src/app/schema/easy-genomics/laboratory.ts
+++ b/packages/shared-lib/src/app/schema/easy-genomics/laboratory.ts
@@ -9,7 +9,7 @@ export const LaboratorySchema = z.object({
   Status: z.enum(['Active', 'Inactive']),
   AwsHealthOmicsEnabled: z.boolean().optional(),
   NextFlowTowerEnabled: z.boolean().optional(),
-  NextFlowTowerApiToken: z.string().optional(), // Encrypted
+  NextFlowTowerAccessToken: z.string().optional(), // Encrypted
   NextFlowTowerWorkspaceId: z.string().optional(),
   CreatedAt: z.string().optional(),
   CreatedBy: z.string().optional(),
@@ -24,8 +24,8 @@ export const CreateLaboratorySchema = z.object({
   Status: z.enum(['Active', 'Inactive']),
   AwsHealthOmicsEnabled: z.boolean().optional(),
   NextFlowTowerEnabled: z.boolean().optional(),
-  NextFlowTowerApiToken: z.string().optional(),
-  NextFlowTowerWorkspaceId: z.string().optional(), // Encrypted
+  NextFlowTowerAccessToken: z.string().optional(), // Encrypted
+  NextFlowTowerWorkspaceId: z.string().optional(),
 }).strict();
 
 export const RequestLaboratorySchema = z.object({
@@ -40,6 +40,6 @@ export const UpdateLaboratorySchema = z.object({
   Status: z.enum(['Active', 'Inactive']),
   AwsHealthOmicsEnabled: z.boolean().optional(),
   NextFlowTowerEnabled: z.boolean().optional(),
-  NextFlowTowerApiToken: z.string().optional(),
-  NextFlowTowerWorkspaceId: z.string().optional(), // Encrypted
+  NextFlowTowerAccessToken: z.string().optional(), // Encrypted
+  NextFlowTowerWorkspaceId: z.string().optional(),
 }).strict();

--- a/packages/shared-lib/src/app/types/easy-genomics/laboratory.d.ts
+++ b/packages/shared-lib/src/app/types/easy-genomics/laboratory.d.ts
@@ -18,7 +18,7 @@
  *   S3Bucket?: <string>,
  *   AwsHealthOmicsEnabled?: <boolean>,
  *   NextFlowTowerEnabled?: <boolean>,
- *   NextFlowTowerApiToken?: <string>, // Encrypted
+ *   NextFlowTowerAccessToken?: <string>, // Encrypted
  *   NextFlowTowerWorkspaceId?: <string>,
  *   CreatedAt?: <string>,
  *   CreatedBy?: <string>,
@@ -39,7 +39,7 @@ export interface Laboratory extends BaseAttributes {
   S3Bucket?: string;
   AwsHealthOmicsEnabled?: boolean;
   NextFlowTowerEnabled?: boolean;
-  NextFlowTowerApiToken?: string; // Encrypted
+  NextFlowTowerAccessToken?: string; // Encrypted
   NextFlowTowerWorkspaceId?: string;
 }
 


### PR DESCRIPTION
This PR renames the `Laboratory` object property `NextFlowTowerApiToken` to `NextFlowTowerAccessToken` to use the same terminology as NextFlow Tower for consistency and improve understandability.