### PR TITLE
feat(EG-517): update cognito-idp-construct to disable Cognito AdvancedSecurity Auditing Mode

### DIFF
--- a/packages/back-end/src/infra/constructs/cognito-idp-construct.ts
+++ b/packages/back-end/src/infra/constructs/cognito-idp-construct.ts
@@ -50,7 +50,7 @@ export class CognitoIdpConstruct extends Construct {
       },
       customSenderKmsKey: props.customSenderKmsKey,
       removalPolicy: removalPolicy,
-      advancedSecurityMode: AdvancedSecurityMode.AUDIT,
+      advancedSecurityMode: AdvancedSecurityMode.OFF,
     });
 
     this.userPoolClient = this.userPool.addClient('client', {


### PR DESCRIPTION
This PR disables the Cognito Advanced Security Auditing Mode. It is not necessary anymore, and this should be disabled to avoid the higher running costs for Cognito.