### PR TITLE
feat(EG-524): update create-user-forgot-password-request API to return false positive response

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/user/create-user-forgot-password-request.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/user/create-user-forgot-password-request.lambda.ts
@@ -30,34 +30,29 @@ export const handler: Handler = async (
     const user: User | undefined = (await userService.queryByEmail(request.Email)).shift();
 
     if (!user) {
-      throw new Error('Bad request');
+      throw new Error(`User ${request.Email} not found`);
     }
 
     if (user.Status === 'Inactive') {
-      throw new Error('Bad request');
+      throw new Error(`User ${request.Email} Status 'Inactive'`);
     }
 
     // Retrieve Cognito User Account and initiate Cognito's forgot password workflow
     const cognitoUser: AdminGetUserCommandOutput = await cognitoService.adminGetUser(process.env.COGNITO_USER_POOL_ID, request.Email);
 
     if (!cognitoUser.Enabled) {
-      throw new Error('Bad request');
+      throw new Error(`User ${request.Email} Cognito Account disabled`);
     }
 
-    const response = await cognitoService.forgotPassword(process.env.COGNITO_USER_POOL_CLIENT_ID, request.Email);
-    return buildResponse(200, JSON.stringify(response), event);
+    await cognitoService.forgotPassword(process.env.COGNITO_USER_POOL_CLIENT_ID, request.Email);
+    return buildResponse(200, JSON.stringify({ Status: 'success' }), event);
   } catch (err: any) {
     console.error(err);
     return {
       statusCode: 400,
       body: JSON.stringify({
-        Error: getErrorMessage(err),
+        Status: 'success', // Return false positive to prevent snooping
       }),
     };
   }
-};
-
-// Used for customising error messages by exception types
-function getErrorMessage(err: any) {
-  return err.message;
 };


### PR DESCRIPTION
This PR updates the `/easy-genomics/user/create-user-forgot-password-request` API to return a false positive response to prevent leaking information if an email / user account exists or not.