### PR TITLE
fix(EG-554): improve nf-tower APIs retrieval of AccessToken from SSM & fix import statements

### DIFF
--- a/packages/back-end/src/app/controllers/nf-tower/pipeline/list-pipelines.lambda.ts
+++ b/packages/back-end/src/app/controllers/nf-tower/pipeline/list-pipelines.lambda.ts
@@ -1,5 +1,6 @@
-import { ListPipelinesResponse } from '@easy-genomics/shared-lib/lib/app/types/nf-tower/nextflow-tower-api';
-import { buildResponse } from '@easy-genomics/shared-lib/lib/app/utils/common';
+import { GetParameterCommandOutput, ParameterNotFound } from '@aws-sdk/client-ssm';
+import { ListPipelinesResponse } from '@easy-genomics/shared-lib/src/app/types/nf-tower/nextflow-tower-api';
+import { buildResponse } from '@easy-genomics/shared-lib/src/app/utils/common';
 import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
 import { LaboratoryService } from '../../../services/easy-genomics/laboratory-service';
 import { SsmService } from '../../../services/ssm-service';
@@ -38,12 +39,14 @@ export const handler: Handler = async (
     }
 
     // Retrieve Seqera Cloud / NextFlow Tower AccessToken from SSM
-    const accessToken: string | undefined = (
-      await ssmService.getParameter({
+    const accessToken: string | undefined = await ssmService
+      .getParameter({
         Name: `/easy-genomics/organization/${laboratory.OrganizationId}/laboratory/${laboratory.LaboratoryId}/nf-access-token`,
         WithDecryption: true,
       })
-    ).Parameter?.Value;
+      .then(async (value: GetParameterCommandOutput) => {
+        return value.Parameter?.Value;
+      });
     if (!accessToken) {
       throw new Error('Laboratory Access Token unavailable');
     }
@@ -59,6 +62,15 @@ export const handler: Handler = async (
     return buildResponse(200, JSON.stringify(response), event);
   } catch (err: any) {
     console.error(err);
-    return buildResponse(400, JSON.stringify({ Error: err.message }), event);
+    return buildResponse(400, JSON.stringify({ Error: getErrorMessage(err) }), event);
   }
 };
+
+// Used for customising error messages by exception types
+function getErrorMessage(err: any) {
+  if (err instanceof ParameterNotFound) {
+    return 'Laboratory Access Token unavailable';
+  } else {
+    return err.message;
+  }
+}

--- a/packages/back-end/src/app/controllers/nf-tower/workflow/list-workflows.lambda.ts
+++ b/packages/back-end/src/app/controllers/nf-tower/workflow/list-workflows.lambda.ts
@@ -1,5 +1,6 @@
-import { ListWorkflowsResponse } from '@easy-genomics/shared-lib/lib/app/types/nf-tower/nextflow-tower-api';
-import { buildResponse } from '@easy-genomics/shared-lib/lib/app/utils/common';
+import { GetParameterCommandOutput, ParameterNotFound } from '@aws-sdk/client-ssm';
+import { ListWorkflowsResponse } from '@easy-genomics/shared-lib/src/app/types/nf-tower/nextflow-tower-api';
+import { buildResponse } from '@easy-genomics/shared-lib/src/app/utils/common';
 import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
 import { LaboratoryService } from '../../../services/easy-genomics/laboratory-service';
 import { SsmService } from '../../../services/ssm-service';
@@ -38,12 +39,14 @@ export const handler: Handler = async (
     }
 
     // Retrieve Seqera Cloud / NextFlow Tower AccessToken from SSM
-    const accessToken: string | undefined = (
-      await ssmService.getParameter({
+    const accessToken: string | undefined = await ssmService
+      .getParameter({
         Name: `/easy-genomics/organization/${laboratory.OrganizationId}/laboratory/${laboratory.LaboratoryId}/nf-access-token`,
         WithDecryption: true,
       })
-    ).Parameter?.Value;
+      .then(async (value: GetParameterCommandOutput) => {
+        return value.Parameter?.Value;
+      });
     if (!accessToken) {
       throw new Error('Laboratory Access Token unavailable');
     }
@@ -59,6 +62,15 @@ export const handler: Handler = async (
     return buildResponse(200, JSON.stringify(response), event);
   } catch (err: any) {
     console.error(err);
-    return buildResponse(400, JSON.stringify({ Error: err.message }), event);
+    return buildResponse(400, JSON.stringify({ Error: getErrorMessage(err) }), event);
   }
 };
+
+// Used for customising error messages by exception types
+function getErrorMessage(err: any) {
+  if (err instanceof ParameterNotFound) {
+    return 'Laboratory Access Token unavailable';
+  } else {
+    return err.message;
+  }
+}

--- a/packages/back-end/src/app/controllers/nf-tower/workflow/read-workflow.lambda.ts
+++ b/packages/back-end/src/app/controllers/nf-tower/workflow/read-workflow.lambda.ts
@@ -1,5 +1,6 @@
-import { DescribeWorkflowResponse } from '@easy-genomics/shared-lib/lib/app/types/nf-tower/nextflow-tower-api';
-import { buildResponse } from '@easy-genomics/shared-lib/lib/app/utils/common';
+import { GetParameterCommandOutput, ParameterNotFound } from '@aws-sdk/client-ssm';
+import { DescribeWorkflowResponse } from '@easy-genomics/shared-lib/src/app/types/nf-tower/nextflow-tower-api';
+import { buildResponse } from '@easy-genomics/shared-lib/src/app/utils/common';
 import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
 import { LaboratoryService } from '../../../services/easy-genomics/laboratory-service';
 import { SsmService } from '../../../services/ssm-service';
@@ -41,12 +42,14 @@ export const handler: Handler = async (
     }
 
     // Retrieve Seqera Cloud / NextFlow Tower AccessToken from SSM
-    const accessToken: string | undefined = (
-      await ssmService.getParameter({
+    const accessToken: string | undefined = await ssmService
+      .getParameter({
         Name: `/easy-genomics/organization/${laboratory.OrganizationId}/laboratory/${laboratory.LaboratoryId}/nf-access-token`,
         WithDecryption: true,
       })
-    ).Parameter?.Value;
+      .then(async (value: GetParameterCommandOutput) => {
+        return value.Parameter?.Value;
+      });
     if (!accessToken) {
       throw new Error('Laboratory Access Token unavailable');
     }
@@ -62,6 +65,15 @@ export const handler: Handler = async (
     return buildResponse(200, JSON.stringify(response), event);
   } catch (err: any) {
     console.error(err);
-    return buildResponse(400, JSON.stringify({ Error: err.message }), event);
+    return buildResponse(400, JSON.stringify({ Error: getErrorMessage(err) }), event);
   }
 };
+
+// Used for customising error messages by exception types
+function getErrorMessage(err: any) {
+  if (err instanceof ParameterNotFound) {
+    return 'Laboratory Access Token unavailable';
+  } else {
+    return err.message;
+  }
+}


### PR DESCRIPTION
This PR fixes the `/nf-token/...` APIs' retrieval of the Laboratory AccessToken from SSM:

 - improve retrieval of AccessToken value from SSM GetParameter request
 - detect for SSM ParameterNotFound error to return 'Laboratory Access Token unavailable'
 - fix imports
