### PR TITLE
fix(eg-551): add missing import to fix reset password page render

### DIFF
--- a/packages/front-end/src/app/pages/reset-password.vue
+++ b/packages/front-end/src/app/pages/reset-password.vue
@@ -5,6 +5,7 @@
   import { checkIsTokenExpired } from '~/utils/jwt';
   import { getUrlParamValue } from '~/utils/string-utils';
   import { NonEmptyStringSchema } from '@easy-genomics/shared-lib/src/app/types/base-unified';
+  import { AutoCompleteOptionsEnum } from '~/types/forms';
 
   definePageMeta({ layout: 'password' });
 


### PR DESCRIPTION
Fixes a regression in the Reset Password Vue template which was failing to render due to a missing `AutoCompleteOptionsEnum` import.