### PR TITLE
feat: extends fe factory for /nftower/* endpoints

### DIFF
--- a/packages/front-end/src/app/repository/factory.ts
+++ b/packages/front-end/src/app/repository/factory.ts
@@ -2,7 +2,23 @@ import { useRuntimeConfig } from 'nuxt/app';
 const { getToken } = useAuth();
 
 class HttpFactory {
-  private baseRequestUrl = `${useRuntimeConfig().public.BASE_API_URL}/easy-genomics`;
+  private baseApiUrl = useRuntimeConfig().public.BASE_API_URL;
+  private defaultApiUrl = `${this.baseApiUrl}/easy-genomics`;
+  private nfTowerApiUrl = `${this.baseApiUrl}/nf-tower`;
+
+  /**
+   * @description Default API request handler
+   */
+  call<T>(method = 'GET', url: string, data: unknown = ''): Promise<T | undefined> {
+    return this.performRequest<T>(method, this.defaultApiUrl + url, data);
+  }
+
+  /**
+   * @description NF Tower API request handler
+   */
+  callNfTower<T>(method = 'GET', url: string, data: unknown = ''): Promise<T | undefined> {
+    return this.performRequest<T>(method, this.nfTowerApiUrl + url, data);
+  }
 
   /**
    * @description Call API with token and handle response errors
@@ -11,8 +27,7 @@ class HttpFactory {
    * @param data
    * @returns Promise<T | undefined>
    */
-  async call<T>(method = 'GET', url: string, data: unknown = ''): Promise<T | undefined> {
-    const requestUrl = `${this.baseRequestUrl}${url}`;
+  private async performRequest<T>(method: string, url: string, data: unknown = ''): Promise<T | undefined> {
     try {
       const headers: HeadersInit = new Headers();
       headers.append('Content-Type', 'application/json');
@@ -30,11 +45,9 @@ class HttpFactory {
       } catch (tokenError) {
         console.warn(`Failed to get token; reason: ${tokenError}; continuing without Bearer or X-API header`);
       }
-
       if (token) {
         headers.append('Authorization', token);
       }
-
       const settings: RequestInit = {
         method,
         headers,
@@ -42,10 +55,11 @@ class HttpFactory {
       if (data) {
         settings.body = JSON.stringify(data);
       }
-      const response = await fetch(requestUrl, settings);
+      const response = await fetch(url, settings);
       if (!response.ok) {
         await this.handleResponseError(response);
       }
+
       return await ((await response.json()) as Promise<T>);
     } catch (error: any) {
       throw new Error(`Request error: ${error.message}`);


### PR DESCRIPTION
Extends `factory.ts` to allow calls to `/nftower/*` endpoints. 

Essentially this is a new wrapper for the existing API handler that has the NF Tower API base host preconfigured. 