### PR TITLE
fix: pipelines table empty message

### DIFF
--- a/packages/front-end/src/app/pages/labs/[id]/index.vue
+++ b/packages/front-end/src/app/pages/labs/[id]/index.vue
@@ -283,7 +283,7 @@
 
           <template #empty-state>
             <div class="text-muted flex h-24 items-center justify-center font-normal">
-              There are no users in your Lab
+              There are no Pipelines assigned to this Lab
             </div>
           </template>
         </EGTable>


### PR DESCRIPTION
Adds the Pipelines table empty-state message, missed in the previous PR.