### PR TITLE
feat: update create workflow execution lambda with new request type

### DIFF
--- a/packages/shared-lib/src/app/types/nf-tower/nextflow-tower-api.ts
+++ b/packages/shared-lib/src/app/types/nf-tower/nextflow-tower-api.ts
@@ -21,6 +21,11 @@ export type CreateWorkflowLaunchQuery = operations['CreateWorkflowLaunch']['para
 export type CreateWorkflowLaunchRequest = components['schemas']['SubmitWorkflowLaunchRequest'];
 export type CreateWorkflowLaunchResponse = components['schemas']['SubmitWorkflowLaunchResponse'];
 
+export type CreatePipelineRunRequest = {
+  userRunName: string;
+  pipelineLaunchDetails: CreateWorkflowLaunchRequest;
+};
+
 /** POST /workflow/{workflowId}/cancel **/
 export type CancelWorkflowQuery = operations['CancelWorkflow']['parameters']['query'];
 export type CancelWorkflowResponse = string;


### PR DESCRIPTION
Adds new type to support frontend create pipeline run request

Note: currently ignoring the `userRunName` property in the request. Follow-on PR will add a new table and store the `userRunName` along with other details.