### PR TITLE
fix: clean null properties from nf tower api response

### DIFF
--- a/packages/front-end/src/app/repository/modules/pipelines.ts
+++ b/packages/front-end/src/app/repository/modules/pipelines.ts
@@ -1,14 +1,14 @@
 import { ListPipelinesResponse } from '@easy-genomics/shared-lib/src/app/types/nf-tower/nextflow-tower-api';
-// import { ListPipelinesResponse as ListPipelinesResponseSchema } from '@easy-genomics/shared-lib/src/app/types/nf-tower/nextflow-tower-zod-schemas.client';
+import { ListPipelinesResponse as ListPipelinesResponseSchema } from '@easy-genomics/shared-lib/src/app/types/nf-tower/nextflow-tower-zod-schemas.client';
 import { useRuntimeConfig } from 'nuxt/app';
 import HttpFactory from '../factory';
-// import { validateApiResponse } from '~/utils/api-utils';
+import { validateApiResponse, stripNullProperties } from '~/utils/api-utils';
 
 class PipelinesModule extends HttpFactory {
   $config = useRuntimeConfig();
 
-  async list(labId: string): Promise<ListPipelinesResponse[]> {
-    const res = await this.callNextflowTower<ListPipelinesResponse[]>(
+  async list(labId: string): Promise<ListPipelinesResponse> {
+    const res = await this.callNextflowTower<ListPipelinesResponse>(
       'GET',
       `/pipeline/list-pipelines?laboratoryId=${labId}`,
     );
@@ -18,11 +18,10 @@ class PipelinesModule extends HttpFactory {
       throw new Error('Failed to retrieve pipelines');
     }
 
-    // 2024-07-19: Need to get the quality environment up and running again.
-    // Commented out because this validation is failing. Not failing because
-    // of the contents of the response, but because of the validation
-    // function/schema itself.
-    // validateApiResponse(ListPipelinesResponseSchema, res);
+    const cleanedPipelines = stripNullProperties(res?.pipelines || []);
+    const cleanedRes = { ...res, pipelines: cleanedPipelines };
+
+    validateApiResponse(ListPipelinesResponseSchema, cleanedRes);
     return res;
   }
 }

--- a/packages/front-end/src/app/utils/api-utils.ts
+++ b/packages/front-end/src/app/utils/api-utils.ts
@@ -3,9 +3,18 @@ import { ZodSchema } from 'zod';
 export function validateApiResponse<T>(schema: ZodSchema<T>, data: any) {
   const validation = schema.safeParse(data);
 
-  if (validation.success) {
-  } else {
-    console.error('Error validating response:', validation.error);
-    throw new Error('Failed to validate API response');
+  if (!validation.success) {
+    throw new Error('Failed to validate API response: ', validation.error);
   }
+}
+
+/**
+ * Strip null properties from an array of objects - example usage might be to remove null properties from
+ * a Nextflow Tower API response to allow the Zod schema to validate the response
+ * @param val
+ */
+export function stripNullProperties(val: Array<any>): Array<any> {
+  return val.map((val) => {
+    return Object.fromEntries(Object.entries(val).filter(([, value]) => value !== null));
+  });
 }


### PR DESCRIPTION
**Issue:**
The pipeline list request ( `GET /pipeline/list-pipelines?laboratoryId=${labId}`) was throwing a Zod validation error on the frontend due to non-nullable types in the `PipelineDbDto` object. 

**Resolution:**
This particular Zod schema is for the Seqera API and is autogenerated. The solution was to add an additional helper function to strip out `null` properties from the `pipelines` object before parsing the Zod validation schema. The alternative but less favourable option was to manually add `.nullable()` to the generated Zod schema, but this would have introduced deviation from the Seqera source schema.

