### PR TITLE
fix(EG-566): change statuses to accurately reflect seqera api

### DIFF
--- a/packages/front-end/src/app/components/EGStatusChip.vue
+++ b/packages/front-end/src/app/components/EGStatusChip.vue
@@ -25,11 +25,11 @@
   const label = computed(() => {
     switch (props.status) {
       case StatusEnum.enum.CANCELLED:
-        return 'Failed';
+        return 'Cancelled';
       case StatusEnum.enum.FAILED:
         return 'Failed';
       case StatusEnum.enum.SUCCEEDED:
-        return 'Completed';
+        return 'Succeeded';
       case StatusEnum.enum.RUNNING:
         return 'Running';
       case StatusEnum.enum.SUBMITTED:


### PR DESCRIPTION
Correctly reflects Seqera's "Cancelled" and "Succeeded" statuses in the UI.