### PR TITLE
fix(EG-584): enhance create-file-upload-request API file validation logic

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/upload/create-file-upload-request.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/upload/create-file-upload-request.lambda.ts
@@ -79,6 +79,14 @@ export const handler: Handler = async (
     const s3Region: string = bucketLocation ? bucketLocation : 'us-east-1';
 
     const files: FileUploadInfo[] = request.Files.map((file: FileInfo) => {
+      // Sanity checks
+      if (file.Name.length === 0) {
+        throw new Error(`File name is invalid: '${file.Name}'`);
+      }
+      if (file.Size === 0) {
+        throw new Error(`File size is invalid: '${file.Name}'`);
+      }
+
       /**
        * If a file size is greater than the EASY_GENOMICS_SINGLE_FILE_TRANSFER_LIMIT then throw an error,
        * otherwise default to generating a single upload S3 URL for the respective file.


### PR DESCRIPTION
This PR enhances the `/easy-genomics/upload/create-file-upload-request` API to include a sanity check the list of files submitted for uploading that their respective File Name and Size are not 0.

The FE should prevent the user from selecting a File that has no name. But nevertheless, this BE API improvement will catch that edge-case scenario.