### PR TITLE
fix(EG-582): add missing FE lib dep '@aws-sdk/util-format-url' and fix s3-upload-utils

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -319,6 +319,7 @@ const frontEndApp = new awscdk.AwsCdkTypeScriptApp({
   deps: [
     '@aws-amplify/ui-vue@3.1.30',
     '@aws-sdk/s3-request-presigner',
+    '@aws-sdk/util-format-url',
     '@easy-genomics/shared-lib@workspace:*',
     '@nuxt/ui',
     '@pinia-plugin-persistedstate/nuxt',

--- a/packages/front-end/.projen/deps.json
+++ b/packages/front-end/.projen/deps.json
@@ -120,6 +120,10 @@
       "type": "runtime"
     },
     {
+      "name": "@aws-sdk/util-format-url",
+      "type": "runtime"
+    },
+    {
       "name": "@easy-genomics/shared-lib",
       "version": "workspace:*",
       "type": "runtime"

--- a/packages/front-end/.projen/tasks.json
+++ b/packages/front-end/.projen/tasks.json
@@ -165,13 +165,13 @@
       },
       "steps": [
         {
-          "exec": "pnpm dlx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev,peer,prod,optional --filter=@aws-sdk/types,@nuxt/types,@nuxtjs/eslint-config-typescript,@types/jest,@types/uuid,esbuild,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,eslint-plugin-vue,jest,kill-port,lint-staged,prettier,projen,ts-jest,ts-node,typed-openapi,typescript,vue-eslint-parser,@aws-sdk/s3-request-presigner,@nuxt/ui,@pinia-plugin-persistedstate/nuxt,@pinia/nuxt,@smithy/types,@smithy/url-parser,class-variance-authority,date-fns,dotenv,jwt-decode,nuxt,pinia,prettier-plugin-tailwindcss,sass,tailwindcss,unplugin-icons,unplugin-vue-components,uuid,zod"
+          "exec": "pnpm dlx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev,peer,prod,optional --filter=@aws-sdk/types,@nuxt/types,@nuxtjs/eslint-config-typescript,@types/jest,@types/uuid,esbuild,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,eslint-plugin-vue,jest,kill-port,lint-staged,prettier,projen,ts-jest,ts-node,typed-openapi,typescript,vue-eslint-parser,@aws-sdk/s3-request-presigner,@aws-sdk/util-format-url,@nuxt/ui,@pinia-plugin-persistedstate/nuxt,@pinia/nuxt,@smithy/types,@smithy/url-parser,class-variance-authority,date-fns,dotenv,jwt-decode,nuxt,pinia,prettier-plugin-tailwindcss,sass,tailwindcss,unplugin-icons,unplugin-vue-components,uuid,zod"
         },
         {
           "exec": "pnpm i --no-frozen-lockfile"
         },
         {
-          "exec": "pnpm update @aws-sdk/types @nuxt/types @nuxtjs/eslint-config-typescript @types/jest @types/node @types/uuid @typescript-eslint/eslint-plugin @typescript-eslint/parser aws-cdk esbuild eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint-plugin-vue eslint jest jest-junit kill-port lint-staged prettier projen ts-jest ts-node typed-openapi typescript vue-eslint-parser @aws-amplify/ui-vue @aws-sdk/s3-request-presigner @easy-genomics/shared-lib @nuxt/ui @pinia-plugin-persistedstate/nuxt @pinia/nuxt @smithy/types @smithy/url-parser aws-amplify aws-cdk-lib class-variance-authority constructs date-fns dotenv jwt-decode nuxt pinia prettier-plugin-tailwindcss sass tailwindcss unplugin-icons unplugin-vue-components uuid zod"
+          "exec": "pnpm update @aws-sdk/types @nuxt/types @nuxtjs/eslint-config-typescript @types/jest @types/node @types/uuid @typescript-eslint/eslint-plugin @typescript-eslint/parser aws-cdk esbuild eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint-plugin-vue eslint jest jest-junit kill-port lint-staged prettier projen ts-jest ts-node typed-openapi typescript vue-eslint-parser @aws-amplify/ui-vue @aws-sdk/s3-request-presigner @aws-sdk/util-format-url @easy-genomics/shared-lib @nuxt/ui @pinia-plugin-persistedstate/nuxt @pinia/nuxt @smithy/types @smithy/url-parser aws-amplify aws-cdk-lib class-variance-authority constructs date-fns dotenv jwt-decode nuxt pinia prettier-plugin-tailwindcss sass tailwindcss unplugin-icons unplugin-vue-components uuid zod"
         },
         {
           "exec": "pnpm dlx projen"

--- a/packages/front-end/package.json
+++ b/packages/front-end/package.json
@@ -68,6 +68,7 @@
   "dependencies": {
     "@aws-amplify/ui-vue": "3.1.30",
     "@aws-sdk/s3-request-presigner": "^3.620.0",
+    "@aws-sdk/util-format-url": "^3.609.0",
     "@easy-genomics/shared-lib": "workspace:*",
     "@nuxt/ui": "^2.15.0",
     "@pinia-plugin-persistedstate/nuxt": "^1.2.0",

--- a/packages/front-end/src/app/utils/s3-upload-utils.ts
+++ b/packages/front-end/src/app/utils/s3-upload-utils.ts
@@ -1,5 +1,6 @@
 import { Hash } from 'crypto';
 import { S3RequestPresigner } from '@aws-sdk/s3-request-presigner';
+import { formatUrl } from '@aws-sdk/util-format-url';
 import { FileUploadInfo } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/upload/s3-file-upload-manifest';
 import { AwsCredentialIdentity } from '@smithy/types/dist-types/identity/awsCredentialIdentity';
 import { parseUrl } from '@smithy/url-parser';
@@ -13,7 +14,10 @@ import { parseUrl } from '@smithy/url-parser';
  * @param credentials
  * @param fileUploadInfo
  */
-export function getFileUploadSignedS3Url(credentials: AwsCredentialIdentity, fileUploadInfo: FileUploadInfo): string {
+export async function getFileUploadSignedS3Url(
+  credentials: AwsCredentialIdentity,
+  fileUploadInfo: FileUploadInfo,
+): Promise<string> {
   const bucket: string = fileUploadInfo.Bucket;
   const key: string = fileUploadInfo.Key;
   const region: string = fileUploadInfo.Region;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,6 +243,9 @@ importers:
       '@aws-sdk/s3-request-presigner':
         specifier: ^3.620.0
         version: 3.620.0
+      '@aws-sdk/util-format-url':
+        specifier: ^3.609.0
+        version: 3.609.0
       '@easy-genomics/shared-lib':
         specifier: workspace:*
         version: link:../shared-lib
@@ -16605,7 +16608,7 @@ snapshots:
   camel-case@4.1.2:
     dependencies:
       pascal-case: 3.1.2
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   camelcase-css@2.0.1: {}
 
@@ -16631,7 +16634,7 @@ snapshots:
   capital-case@1.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.6.3
       upper-case-first: 2.0.2
 
   chalk@2.4.2:
@@ -16660,7 +16663,7 @@ snapshots:
       path-case: 3.0.4
       sentence-case: 3.0.4
       snake-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   char-regex@1.0.2: {}
 
@@ -16885,7 +16888,7 @@ snapshots:
   constant-case@3.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.6.3
       upper-case: 2.0.2
 
   constructs@10.3.0: {}
@@ -17270,7 +17273,7 @@ snapshots:
   dot-case@3.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   dot-prop@5.3.0:
     dependencies:
@@ -18312,7 +18315,7 @@ snapshots:
   header-case@2.0.4:
     dependencies:
       capital-case: 1.0.4
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   hermes-estree@0.19.1: {}
 
@@ -19438,7 +19441,7 @@ snapshots:
 
   lower-case@2.0.2:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   lru-cache@10.4.3: {}
 
@@ -19920,7 +19923,7 @@ snapshots:
   no-case@3.0.4:
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   nocache@3.0.4: {}
 
@@ -20339,7 +20342,7 @@ snapshots:
   param-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   parent-module@1.0.1:
     dependencies:
@@ -20377,7 +20380,7 @@ snapshots:
   pascal-case@3.1.2:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   pastable@2.2.1(react@18.2.0)(xstate@4.38.3):
     dependencies:
@@ -20393,7 +20396,7 @@ snapshots:
   path-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   path-exists@3.0.0: {}
 
@@ -21176,7 +21179,7 @@ snapshots:
   sentence-case@3.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.6.3
       upper-case-first: 2.0.2
 
   serialize-error@2.1.0: {}
@@ -21303,7 +21306,7 @@ snapshots:
   snake-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   source-map-js@1.2.0: {}
 
@@ -22047,11 +22050,11 @@ snapshots:
 
   upper-case-first@2.0.2:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   upper-case@2.0.2:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   uqr@0.1.2: {}
 


### PR DESCRIPTION
This PR updates the FE projen lib to include a missing `@aws-sdk/util-format-url` dependency used by the `utils/s3-upload-utils.ts` implementation.

It also corrects the `getFileUploadSignedS3Url()` definition to be `async` and return a `Promise<string>` since the `s3RequestPresigner.presign()` function call is asynchronous.