### PR TITLE
feat(EG-575): disable remove org option from org page

### DIFF
--- a/packages/front-end/src/app/pages/orgs/index.vue
+++ b/packages/front-end/src/app/pages/orgs/index.vue
@@ -36,13 +36,14 @@
         click: async () => viewOrg(row),
       },
     ],
-    [
-      {
-        label: 'Remove',
-        class: 'text-alert-danger-dark',
-        click: () => {},
-      },
-    ],
+    // TODO: temporarily disabled; see: https://dept-au.atlassian.net/browse/EG-575
+    // [
+    //   {
+    //     label: 'Remove',
+    //     class: 'text-alert-danger-dark',
+    //     click: () => {},
+    //   },
+    // ],
   ];
 
   function viewOrg(org: Organization) {


### PR DESCRIPTION
Removes option to delete an Organisation. This is temporary measure so as to prevent deleting the only single instance org currently being used.