### PR TITLE
fix(EG-587): show toggle password visibility button in password fields

### DIFF
--- a/packages/front-end/src/app/components/EGLabDetailsForm.vue
+++ b/packages/front-end/src/app/components/EGLabDetailsForm.vue
@@ -325,6 +325,7 @@
           v-model="state.NextFlowTowerAccessToken"
           :select-on-focus="true"
           :password="true"
+          placeholder="Add or update the Next Flow Tower personal access token. Note: A previously set token will never be shown."
           :show-toggle-password-button="isEditingNextFlowTowerAccessToken"
           :autocomplete="AutoCompleteOptionsEnum.enum.Off"
           eager-validation

--- a/packages/front-end/src/app/components/EGPasswordInput.vue
+++ b/packages/front-end/src/app/components/EGPasswordInput.vue
@@ -26,7 +26,7 @@
       disabled: false,
       showTogglePasswordButton: true,
       selectOnFocus: false,
-    }
+    },
   );
 
   const inputType = props.password ? ref('password') : ref('text');
@@ -56,10 +56,11 @@
   >
     <template v-if="showTogglePasswordButton" #trailing>
       <UButton
+        class="text-alert-danger"
         color="black"
         variant="link"
         :padded="false"
-        :icon="inputType === 'password' ? 'i-heroicons-eye-slash text-red' : 'i-heroicons-eye'"
+        :icon="inputType === 'password' ? 'i-heroicons-eye-slash' : 'i-heroicons-eye'"
         @click="switchVisibility"
       />
     </template>


### PR DESCRIPTION
Fixes the regression I introduced where the toggle password visibility button was not displaying correctly.

Updated the Lab Details form placeholder text to inform/be consistent with the new way we handle the Personal Access Token in the Lab. Now we never display an existing value to the user. They can only toggle the visibility of the token they are currently entering.