### PR TITLE
fix: remove redundant route/tab query param

### DIFF
--- a/packages/front-end/src/app/pages/labs/[labId]/index.vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/index.vue
@@ -166,7 +166,6 @@
           usePipelineRunStore().setPipelineDescription(pipelineDescription);
           router.push({
             path: `/labs/${labId}/${pipelineId}/run-pipeline`,
-            query: { tab: 'Run Details' },
           });
         },
       },


### PR DESCRIPTION
Removes a redundant tab query param that was appended during navigation to `/run-pipeline`