### PR TITLE
feat: add basic global list styles; disabled input styles figma align

### DIFF
--- a/packages/front-end/src/app/components/EGInput.vue
+++ b/packages/front-end/src/app/components/EGInput.vue
@@ -30,7 +30,7 @@
     :disabled="disabled"
     :ui="{
       icon: { trailing: { pointer: '' } },
-      base: 'h-13 !shadow-none border-background-stroke-dark text-body bg-white disabled:text-muted disabled:bg-background-light-grey',
+      base: 'h-13 !shadow-none border-background-stroke-dark text-body bg-white disabled:text-muted disabled:bg-background-light-grey disabled:opacity-100',
       rounded: 'rounded-md',
       placeholder: 'text-muted',
       padding: {

--- a/packages/front-end/src/app/components/EGRunPipelineFormUploadData.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineFormUploadData.vue
@@ -362,7 +362,7 @@
     <ul class="text-muted ml-6 mt-1 list-disc text-sm font-normal tracking-tight">
       <li>
         Files containing _R1_ or _R2_ with a matching prefix and suffix will be combined as paired-end data samples e.g,
-        <ul class="ml-4 list-disc text-xs font-normal tracking-tight">
+        <ul>
           <li>
             GOL2051A55857_S103_L002
             <strong>_R1_</strong>

--- a/packages/front-end/src/app/components/EGTextArea.vue
+++ b/packages/front-end/src/app/components/EGTextArea.vue
@@ -9,7 +9,7 @@
       placeholder: '',
       disabled: false,
       required: false,
-    }
+    },
   );
 </script>
 
@@ -17,7 +17,7 @@
   <UTextarea
     :disabled="disabled"
     :ui="{
-      base: 'mt-2 !shadow-none border-background-dark-grey bg-white text-body disabled:text-muted disabled:bg-background-light-grey',
+      base: 'mt-2 !shadow-none border-background-dark-grey bg-white text-body disabled:text-muted disabled:bg-background-light-grey disabled:opacity-100',
       rounded: 'rounded-md',
       placeholder: 'text-muted',
       padding: {

--- a/packages/front-end/src/app/styles/_lists.scss
+++ b/packages/front-end/src/app/styles/_lists.scss
@@ -1,0 +1,11 @@
+ul {
+  padding-bottom: 0.25rem;
+  margin-left: 1rem;
+  li {
+    list-style: disc;
+    line-height: 2;
+    & > ul > li {
+      margin-left: 0;
+    }
+  }
+}

--- a/packages/front-end/src/app/styles/main.scss
+++ b/packages/front-end/src/app/styles/main.scss
@@ -1,3 +1,4 @@
 @import './variables.scss';
 @import './helpers.scss';
 @import './fonts.scss';
+@import './lists.scss';


### PR DESCRIPTION
A couple of small style improvements:

- adds default global CSS styles for `ul` `li` formatting across the app to improve alignment/spacing
- align input disabled state styles with Figma