### PR TITLE
fix(EG-590): add 'path' format type to construct params ui

### DIFF
--- a/packages/front-end/src/app/components/EGRunPipelineParameterInputs.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineParameterInputs.vue
@@ -10,6 +10,7 @@
 
   function propertyType(property) {
     if (property.type === 'string' && property.format === undefined) return 'EGParametersStringField';
+    if (property.type === 'string' && property.format === 'path') return 'EGParametersStringField';
     if (property.type === 'string' && property.format === 'file-path') return 'EGParametersStringField';
     if (property.type === 'string' && property.format === 'directory-path') return 'EGParametersStringField';
     if (property.type === 'boolean') return 'EGParametersBooleanField';


### PR DESCRIPTION
Added a check for the `path` format in the params schema so that these fields appears in the UI.