### PR TITLE
fix(EG-620): remove pipeline skeleton to improve time to interaction

### DIFF
--- a/packages/front-end/src/app/components/EGRunPipelineStepper.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineStepper.vue
@@ -5,7 +5,6 @@
   const props = defineProps<{
     schema: object;
     params: object;
-    isLoading: boolean;
   }>();
 
   const router = useRouter();
@@ -172,9 +171,7 @@
       </template>
 
       <template #item="{ item, index }">
-        <div class="bg-skeleton-container flex h-[473px] items-center rounded-2xl p-4" v-if="isLoading" />
-
-        <div v-else-if="!hasLaunched">
+        <div v-if="!hasLaunched">
           <!-- Run Details -->
           <template v-if="items[selectedIndex].key === 'details'">
             <EGRunPipelineFormRunDetails

--- a/packages/front-end/src/app/pages/labs/[labId]/[pipelineId]/run-pipeline.vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/[pipelineId]/run-pipeline.vue
@@ -14,11 +14,9 @@
   const nextRoute = ref(null);
   const schema = ref({});
   const resetStepperKey = ref(0);
-  const isLoading = ref(true);
 
   onBeforeMount(async () => {
     await initializePipelineData();
-    isLoading.value = false;
   });
 
   /**
@@ -95,7 +93,6 @@
     :params="usePipelineRunStore().params"
     @reset-run-pipeline="resetRunPipeline()"
     :key="resetStepperKey"
-    :is-loading="isLoading"
   />
   <EGDialog
     action-label="Cancel Pipeline Run"


### PR DESCRIPTION
Removes the Step 1 skeleton loader to improve the users's time to interaction with the Run Pipeline stepper.

The skeleton loader was overkill in the end, whose initial purpose was to waiting for an API response for data required in Step 3. With this change a user can now interact with the stepper immediately.