### PR TITLE
fix(EG-625): fix CI/CD template to inc env JWT_SECRET_KEY to fix confirm-user-invitation-request api

### DIFF
--- a/.github/workflows/cicd-release-quality.yml
+++ b/.github/workflows/cicd-release-quality.yml
@@ -21,6 +21,7 @@ jobs:
       ENV_NAME: ${{ vars.ENV_NAME }}
       APP_DOMAIN_NAME: ${{ vars.APP_DOMAIN_NAME }}
       AWS_HOSTED_ZONE_ID: ${{ secrets.AWS_HOSTED_ZONE_ID }}
+      JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
       SYSTEM_ADMIN_EMAIL: ${{ vars.SYSTEM_ADMIN_EMAIL }}
       SYSTEM_ADMIN_PASSWORD: ${{ secrets.SYSTEM_ADMIN_PASSWORD }}
       TEST_USER_EMAIL: ${{ vars.TEST_USER_EMAIL }}
@@ -74,6 +75,7 @@ jobs:
       ENV_NAME: ${{ vars.ENV_NAME }}
       APP_DOMAIN_NAME: ${{ vars.APP_DOMAIN_NAME }}
       AWS_HOSTED_ZONE_ID: ${{ secrets.AWS_HOSTED_ZONE_ID }}
+      JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
       SYSTEM_ADMIN_EMAIL: ${{ vars.SYSTEM_ADMIN_EMAIL }}
       SYSTEM_ADMIN_PASSWORD: ${{ secrets.SYSTEM_ADMIN_PASSWORD }}
       TEST_USER_EMAIL: ${{ vars.TEST_USER_EMAIL }}
@@ -137,6 +139,7 @@ jobs:
       ENV_NAME: ${{ vars.ENV_NAME }}
       APP_DOMAIN_NAME: ${{ vars.APP_DOMAIN_NAME }}
       AWS_HOSTED_ZONE_ID: ${{ secrets.AWS_HOSTED_ZONE_ID }}
+      JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
       SYSTEM_ADMIN_EMAIL: ${{ vars.SYSTEM_ADMIN_EMAIL }}
       SYSTEM_ADMIN_PASSWORD: ${{ secrets.SYSTEM_ADMIN_PASSWORD }}
       TEST_USER_EMAIL: ${{ vars.TEST_USER_EMAIL }}

--- a/.github/workflows/cicd-release-sandbox.yml
+++ b/.github/workflows/cicd-release-sandbox.yml
@@ -21,6 +21,7 @@ jobs:
       ENV_NAME: ${{ vars.ENV_NAME }}
       APP_DOMAIN_NAME: ${{ vars.APP_DOMAIN_NAME }}
       AWS_HOSTED_ZONE_ID: ${{ secrets.AWS_HOSTED_ZONE_ID }}
+      JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
       SYSTEM_ADMIN_EMAIL: ${{ vars.SYSTEM_ADMIN_EMAIL }}
       SYSTEM_ADMIN_PASSWORD: ${{ secrets.SYSTEM_ADMIN_PASSWORD }}
       TEST_USER_EMAIL: ${{ vars.TEST_USER_EMAIL }}
@@ -74,6 +75,7 @@ jobs:
       ENV_NAME: ${{ vars.ENV_NAME }}
       APP_DOMAIN_NAME: ${{ vars.APP_DOMAIN_NAME }}
       AWS_HOSTED_ZONE_ID: ${{ secrets.AWS_HOSTED_ZONE_ID }}
+      JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
       SYSTEM_ADMIN_EMAIL: ${{ vars.SYSTEM_ADMIN_EMAIL }}
       SYSTEM_ADMIN_PASSWORD: ${{ secrets.SYSTEM_ADMIN_PASSWORD }}
       TEST_USER_EMAIL: ${{ vars.TEST_USER_EMAIL }}
@@ -137,6 +139,7 @@ jobs:
       ENV_NAME: ${{ vars.ENV_NAME }}
       APP_DOMAIN_NAME: ${{ vars.APP_DOMAIN_NAME }}
       AWS_HOSTED_ZONE_ID: ${{ secrets.AWS_HOSTED_ZONE_ID }}
+      JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
       SYSTEM_ADMIN_EMAIL: ${{ vars.SYSTEM_ADMIN_EMAIL }}
       SYSTEM_ADMIN_PASSWORD: ${{ secrets.SYSTEM_ADMIN_PASSWORD }}
       TEST_USER_EMAIL: ${{ vars.TEST_USER_EMAIL }}

--- a/projenrc/github-actions-cicd-release.ts
+++ b/projenrc/github-actions-cicd-release.ts
@@ -125,6 +125,7 @@ export class GithubActionsCICDRelease extends Component {
       'APP_DOMAIN_NAME': '${{ vars.APP_DOMAIN_NAME }}',
       'AWS_HOSTED_ZONE_ID': '${{ secrets.AWS_HOSTED_ZONE_ID }}', // Not required when env-type: 'dev', but must exist for the same app-domain-name if configured
       // Back-End specific settings
+      'JWT_SECRET_KEY': '${{ secrets.JWT_SECRET_KEY }}',
       'SYSTEM_ADMIN_EMAIL': '${{ vars.SYSTEM_ADMIN_EMAIL }}',
       'SYSTEM_ADMIN_PASSWORD': '${{ secrets.SYSTEM_ADMIN_PASSWORD }}',
       'TEST_USER_EMAIL': '${{ vars.TEST_USER_EMAIL }}',


### PR DESCRIPTION
This PR updates the `projenrc/github-actions-cicd-release.ts` template to inc the optional `JWT_SECRET_KEY` setting for the respective CI/CD release pipelines.

Our CI/CD release pipelines in Github have been updated to specify the `JWT_SECRET_KEY` env secret to ensure the JWT signature is signed and verified properly.

This was a regression caused by EG-606 which initially removed the `JWT_SECRET_KEY` and then readded it back in as an optional setting, and missed updating the `projenrc/github-actions-cicd-release.ts` template.