### PR TITLE
fix(EG-618): list lab pipelines and runs for org admin

### DIFF
--- a/packages/back-end/src/app/controllers/nf-tower/pipeline/list-pipelines.lambda.ts
+++ b/packages/back-end/src/app/controllers/nf-tower/pipeline/list-pipelines.lambda.ts
@@ -38,7 +38,14 @@ export const handler: Handler = async (
     if (laboratoryId === '') throw new Error('Required laboratoryId is missing');
 
     const laboratory: Laboratory = await laboratoryService.queryByLaboratoryId(laboratoryId);
-    if (!validateOrganizationAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId)) {
+
+    // 2024-08-12: EG-618
+    // No longer passing LaboratoryId to validateOrganizationAccess.
+    // This enables an Org Admin to setup a Lab and verify the Next Flow Tower
+    // Workspace ID and Personal Access Token are working correctly by viewing
+    // the Pipelines and Runs views of the Lab.
+    // This logic will be revisited when the User Access epic is implemented.
+    if (!validateOrganizationAccess(event, laboratory.OrganizationId)) {
       throw new Error('Unauthorized');
     }
     if (!laboratory.NextFlowTowerWorkspaceId) {

--- a/packages/back-end/src/app/controllers/nf-tower/workflow/list-workflows.lambda.ts
+++ b/packages/back-end/src/app/controllers/nf-tower/workflow/list-workflows.lambda.ts
@@ -38,7 +38,14 @@ export const handler: Handler = async (
     if (laboratoryId === '') throw new Error('Required laboratoryId is missing');
 
     const laboratory: Laboratory = await laboratoryService.queryByLaboratoryId(laboratoryId);
-    if (!validateOrganizationAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId)) {
+
+    // 2024-08-12: EG-618
+    // No longer passing LaboratoryId to validateOrganizationAccess.
+    // This enables an Org Admin to setup a Lab and verify the Next Flow Tower
+    // Workspace ID and Personal Access Token are working correctly by viewing
+    // the Pipelines and Runs views of the Lab.
+    // This logic will be revisited when the User Access epic is implemented.
+    if (!validateOrganizationAccess(event, laboratory.OrganizationId)) {
       throw new Error('Unauthorized');
     }
     if (!laboratory.NextFlowTowerWorkspaceId) {


### PR DESCRIPTION
Addresses issue where as an Org Admin you had to add yourself to a lab, logout, and log back in before you could to view the pipelines and runs - even when the Lab has a valid Workspace ID and Personal Access Token.

The **User Access** epic will implement stricter access controls requiring standard Org Users be assigned to a Lab before they can view the labs Pipeline or Runs tabs - while maintaining full viewing functionality for Org Admins.