### PR TITLE
fix(EG-633): ensure the S3 Bucket Name length is less than 63 characters

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/create-laboratory.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/create-laboratory.lambda.ts
@@ -36,16 +36,10 @@ export const handler: Handler = async (
       throw new Error(`Laboratory creation error, OrganizationId '${request.OrganizationId}' not found`);
     }
 
-    // Automatically create an S3 Bucket for this Lab based on the Lab name and Lab ID
+    // Automatically create an S3 Bucket for this Lab based on the LaboratoryId, and must be less than 63
     const laboratoryId: string = crypto.randomUUID().toLowerCase();
-    const bucketName = `${process.env.ACCOUNT_ID}-${process.env.NAME_PREFIX}-lab-${laboratoryId}`;
-
-    // S3 bucket names must between 3 - 63 characters long, and globally unique
-    if (bucketName.length < 3 || bucketName.length > 63) {
-      throw new Error(
-        `Laboratory creation error, unable to create Laboratory S3 Bucket due to invalid length of bucket name; bucketName: ${bucketName} (${bucketName.length}-chars) exceeds the length allowed 3 to 63 characters`,
-      );
-    }
+    const s3BucketId = laboratoryId.replace(/-+/g, '');
+    const bucketName = `${process.env.ACCOUNT_ID}-${process.env.NAME_PREFIX}-lab-${s3BucketId}`.substring(0, 63);
 
     // Create S3 Bucket for Laboratory
     const createS3BucketResult = await s3Service.createBucket({ Bucket: bucketName });

--- a/packages/back-end/src/infra/stacks/data-provisioning-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/data-provisioning-nested-stack.ts
@@ -61,8 +61,9 @@ export class DataProvisioningNestedStack extends NestedStack {
         Type: 'organization-name',
       });
 
-      // S3 Bucket Names must be globally unique
-      const s3BucketFullName = `${this.props.env.account!}-${this.props.namePrefix}-lab-${laboratory.LaboratoryId}`;
+      // S3 Bucket Names must be globally unique and less than 63 in length
+      const s3BucketId = laboratory.LaboratoryId.toLowerCase().replace(/-+/g, '');
+      const s3BucketFullName = `${this.props.env.account!}-${this.props.namePrefix}-lab-${s3BucketId}`.substring(0, 63);
       this.addDynamoDBSeedData<Laboratory>(`${this.props.namePrefix}-laboratory-table`, {
         ...laboratory,
         S3Bucket: s3BucketFullName, // Save the S3 Bucket's Full Name in Laboratory DynamoDB record


### PR DESCRIPTION
This PR is a follow up fix for the S3 Bucket Name generated for each Lab.

It still follows the naming convention: `{aws-account-id}-{name-prefix}-lab-{laboratory-id}`

But it strips the hyphens from the LaboratoryId to shorten the length whilst maintaining the same level of entropy/randomness, and explicitly shortens the length to 63 characters if it still exceeds it.

The prefix fix ran into an error for the quality deployment because the generated full name was too long due to the extra length of the name-prefix: `dev-quality`.

i.e. `{account-id}-dev-quality-lab-{laboratory-id}`