### PR TITLE
chore(EG-636): remove Lab & Org Summary menu option placeholder

### DIFF
--- a/packages/front-end/src/app/pages/labs/index.vue
+++ b/packages/front-end/src/app/pages/labs/index.vue
@@ -28,12 +28,6 @@
   const actionItems = (lab: Laboratory) => [
     [
       {
-        label: 'Summary',
-        click: () => {},
-      },
-    ],
-    [
-      {
         label: 'View / Edit',
         click: () => viewLab(lab.LaboratoryId, lab.Name),
       },

--- a/packages/front-end/src/app/pages/orgs/index.vue
+++ b/packages/front-end/src/app/pages/orgs/index.vue
@@ -27,12 +27,6 @@
   const actionItems = (row: Organization) => [
     [
       {
-        label: 'Summary',
-        click: () => {},
-      },
-    ],
-    [
-      {
         label: 'View / Edit',
         click: async () => viewOrg(row),
       },


### PR DESCRIPTION
This PR removes the Lab and Org `Summary` menu placeholder that is currently unused.