### PR TITLE
fix: remove clickable rows for users

### DIFF
--- a/packages/front-end/src/app/pages/orgs/[orgId]/index.vue
+++ b/packages/front-end/src/app/pages/orgs/[orgId]/index.vue
@@ -331,7 +331,6 @@
         />
 
         <EGTable
-          :row-click-action="onRowClicked"
           :table-data="filteredTableData"
           :columns="tableColumns"
           :is-loading="isLoading"


### PR DESCRIPTION
I couldn't avoid side effects of disabling the click through action, so just removing the clickable row until we can address this properly.