### PR TITLE
fix(EG-653): update config to inc 'seqera-api-base-url' setting & root 'build-and-deploy' convenience script

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -169,6 +169,10 @@ root.addScripts({
   // Development convenience scripts
   ['build-back-end']: 'pnpm nx run-many --targets=build --projects=@easy-genomics/shared-lib,@easy-genomics/back-end --verbose=true',
   ['build-front-end']: 'pnpm nx run-many --targets=build --projects=@easy-genomics/shared-lib,@easy-genomics/front-end --verbose=true',
+  ['build-and-deploy']:
+    'pnpm nx run-many --targets=build --projects=@easy-genomics/shared-lib,@easy-genomics/back-end,@easy-genomics/front-end --verbose=true && ' +
+    'pnpm nx run-many --targets=deploy --projects=@easy-genomics/shared-lib,@easy-genomics/back-end --verbose=true && ' +
+    'pnpm nx run-many --targets=deploy --projects=@easy-genomics/shared-lib,@easy-genomics/front-end --verbose=true',
   // CI/CD convenience scripts
   ['cicd-build-deploy-back-end']:
     'export CI_CD=true && pnpm nx run-many --targets=build-and-deploy --projects=@easy-genomics/shared-lib,@easy-genomics/back-end --verbose=true',

--- a/README.md
+++ b/README.md
@@ -291,6 +291,16 @@ configuration details generated from the Back-End deployment.
    Finally, use the `${easy-genomics root-dir}/config/easy-genomics.yaml` file's configured`test-user-email` and
    `test-user-password` account details to log in into Easy Genomics to test the functionality.
 
+   Once you have completed an initial deployment of the Back-End and Front-End application logic, you can subsequently
+   use the `build-and-deploy` short-cut command from the `${easy-genomics root-dir}` directory to conveniently complete
+   both Back-End and Front-End deployments in one command.
+
+      ```
+      e.g.
+      [easy-genomics/packages/front-end]$ cd ../../
+      [easy-genomics]$ pnpm run build-and-deploy             # Deploys both Back-End and Front-End logic using the existing easy-genomics.yaml settings
+      ```
+
 ---
 
 ## Contributions

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ and edit the Shared and Back-End settings for your deployment environment.
             back-end:
                test-user-email: 'demouser@easygenomics.com'
                test-user-password: # Demo User Password - must be minimum 8 chars long and contain: 1 number, 1 special char, 1 uppercase letter, 1 lowercase letter
+               seqera-api-base-url: # Optional: Update for self-hosted Seqera API Base URL; if unspecified this defaults to 'https://api.cloud.seqera.io'
 
             # Front-End specific settings
                front-end:

--- a/config/easy-genomics.example.yaml
+++ b/config/easy-genomics.example.yaml
@@ -12,6 +12,7 @@ easy-genomics:
         back-end:
             test-user-email: 'demouser@easygenomics.com'
             test-user-password: # Demo User Password - must be minimum 8 chars long and contain: 1 number, 1 special char, 1 uppercase letter, 1 lowercase letter
+            seqera-api-base-url: # Optional: Update for self-hosted Seqera API Base URL; if unspecified this defaults to 'https://api.cloud.seqera.io'
 
         # Front-End specific settings
         front-end:

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "projen": "pnpm dlx projen; nx reset",
     "build-back-end": "pnpm nx run-many --targets=build --projects=@easy-genomics/shared-lib,@easy-genomics/back-end --verbose=true",
     "build-front-end": "pnpm nx run-many --targets=build --projects=@easy-genomics/shared-lib,@easy-genomics/front-end --verbose=true",
+    "build-and-deploy": "pnpm nx run-many --targets=build --projects=@easy-genomics/shared-lib,@easy-genomics/back-end,@easy-genomics/front-end --verbose=true && pnpm nx run-many --targets=deploy --projects=@easy-genomics/shared-lib,@easy-genomics/back-end --verbose=true && pnpm nx run-many --targets=deploy --projects=@easy-genomics/shared-lib,@easy-genomics/front-end --verbose=true",
     "cicd-build-deploy-back-end": "export CI_CD=true && pnpm nx run-many --targets=build-and-deploy --projects=@easy-genomics/shared-lib,@easy-genomics/back-end --verbose=true",
     "cicd-build-deploy-front-end": "export CI_CD=true && pnpm nx run-many --targets=build-and-deploy --projects=@easy-genomics/shared-lib,@easy-genomics/front-end --verbose=true",
     "prepare": "husky || true"

--- a/packages/back-end/src/main.ts
+++ b/packages/back-end/src/main.ts
@@ -155,7 +155,7 @@ if (process.env.CI_CD === 'true') {
         systemAdminPassword: systemAdminPassword,
         testUserEmail: testUserEmail,
         testUserPassword: testUserPassword,
-        seqeraApiBaseUrl: seqeraApiBaseUrl,
+        seqeraApiBaseUrl: seqeraApiBaseUrl.replace(/\/+$/, ''), // Remove trailing slashes
       });
     }
   });

--- a/packages/shared-lib/src/app/schema/configuration.ts
+++ b/packages/shared-lib/src/app/schema/configuration.ts
@@ -14,7 +14,7 @@ export const ConfigurationSettingsSchema = z.object({
     ['system-admin-password']: z.string().nullable().optional(), // Initial Cognito password
     ['test-user-email']: z.string(),
     ['test-user-password']: z.string(), // Initial Cognito password
-    ['seqera-api-base-url']: z.string().nullable().optional(), // Optional: Update for self-hosted Seqera API Base URL; defaults to 'https://api.cloud.seqera.io'
+    ['seqera-api-base-url']: z.string().nullable().optional(), // Optional: Update for self-hosted Seqera API Base URL; if unspecified this defaults to 'https://api.cloud.seqera.io'
   }),
 
   // Front-End specific settings

--- a/packages/shared-lib/src/app/types/configuration.d.ts
+++ b/packages/shared-lib/src/app/types/configuration.d.ts
@@ -12,7 +12,7 @@ export interface ConfigurationSettings {
     ['system-admin-password']?: string, // Initial Cognito password
     ['test-user-email']: string,
     ['test-user-password']: string,
-    ['seqera-api-base-url']?: string, // Optional: Update for self-hosted Seqera API Base URL; defaults to 'https://api.cloud.seqera.io'
+    ['seqera-api-base-url']?: string, // Optional: Update for self-hosted Seqera API Base URL; if unspecified this defaults to 'https://api.cloud.seqera.io'
   }
 
   // Front-End specific settings


### PR DESCRIPTION
This PR updates the `easy-genomics.example.yaml` and README.md files to inc the optional `'seqera-api-base-url' setting in case the AMD training wishes to configure Easy Genomics with a self-hosted NextFlow Tower instance.

It also adds a sanity logic to ensure that a trailing slash for `'seqera-api-base-url' setting is removed.

It also adds the root project convenience script `'build-and-deploy'` to allow both the FE and BE to be deployed in one command once the initial BE and FE have been deployed.