### PR TITLE
fix(EG-664): update lab role in UI  on change

### DIFF
--- a/packages/front-end/src/app/pages/labs/[labId]/index.vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/index.vue
@@ -431,7 +431,7 @@
             <div class="flex items-center">
               <EGUserRoleDropdownNew
                 :show-remove-from-lab="true"
-                :key="labUser?.UserId"
+                :key="labUser?.LabManager"
                 :disabled="useUiStore().isRequestPending"
                 :user="labUser"
                 @assign-lab-role="handleAssignLabRole($event)"


### PR DESCRIPTION
Fixes the lab role not updating in the UI when changed between "Lab Manager" and "Lab Technician". 