### PR TITLE
fix(EG-668): lint package folders separately to fix context issue

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -197,8 +197,6 @@ root.addScripts({
     'pnpm nx run-many --targets=build --projects=@easy-genomics/shared-lib,@easy-genomics/back-end,@easy-genomics/front-end --verbose=true && ' +
     'pnpm nx run-many --targets=deploy --projects=@easy-genomics/shared-lib,@easy-genomics/back-end --verbose=true && ' +
     'pnpm nx run-many --targets=deploy --projects=@easy-genomics/shared-lib,@easy-genomics/front-end --verbose=true',
-  ['lint-all']:
-    'pnpm --prefix packages/front-end run lint && pnpm --prefix packages/back-end run lint && pnpm --prefix packages/shared-lib run lint',
   ['prettier']: "prettier --write '{**/*,*}.{js,ts,vue,scss,json,md,html,mdx}'",
   // CI/CD convenience scripts
   ['cicd-build-deploy-back-end']:
@@ -212,8 +210,10 @@ root.addScripts({
 
 root.addFields({
   'lint-staged': {
-    'packages/**/*.{js,ts}': ['pnpm lint-all'],
     '{**/*,*}.{js,ts,vue,scss,json,md,html,mdx}': ['prettier --write'],
+    'packages/front-end/src/**/*.{js,ts}': ['pnpm --prefix packages/front-end run lint'],
+    'packages/back-end/src/**/*.{js,ts}': ['pnpm --prefix packages/back-end run lint'],
+    'packages/shared-lib/src/**/*.{js,ts}': ['pnpm --prefix packages/shared-lib run lint'],
   },
 });
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "build-back-end": "pnpm nx run-many --targets=build --projects=@easy-genomics/shared-lib,@easy-genomics/back-end --verbose=true",
     "build-front-end": "nx reset && pnpm nx run-many --targets=build --projects=@easy-genomics/shared-lib,@easy-genomics/front-end --verbose=true",
     "build-and-deploy": "pnpm nx run-many --targets=build --projects=@easy-genomics/shared-lib,@easy-genomics/back-end,@easy-genomics/front-end --verbose=true && pnpm nx run-many --targets=deploy --projects=@easy-genomics/shared-lib,@easy-genomics/back-end --verbose=true && pnpm nx run-many --targets=deploy --projects=@easy-genomics/shared-lib,@easy-genomics/front-end --verbose=true",
-    "lint-all": "pnpm --prefix packages/front-end run lint && pnpm --prefix packages/back-end run lint && pnpm --prefix packages/shared-lib run lint",
     "prettier": "prettier --write '{**/*,*}.{js,ts,vue,scss,json,md,html,mdx}'",
     "cicd-build-deploy-back-end": "export CI_CD=true && pnpm nx run-many --targets=build-and-deploy --projects=@easy-genomics/shared-lib,@easy-genomics/back-end --verbose=true",
     "cicd-build-deploy-front-end": "export CI_CD=true && pnpm nx run-many --targets=build-and-deploy --projects=@easy-genomics/shared-lib,@easy-genomics/front-end --verbose=true",
@@ -116,11 +115,17 @@
   },
   "types": "lib/index.d.ts",
   "lint-staged": {
-    "packages/**/*.{js,ts}": [
-      "pnpm lint-all"
-    ],
     "{**/*,*}.{js,ts,vue,scss,json,md,html,mdx}": [
       "prettier --write"
+    ],
+    "packages/front-end/src/**/*.{js,ts}": [
+      "pnpm --prefix packages/front-end run lint"
+    ],
+    "packages/back-end/src/**/*.{js,ts}": [
+      "pnpm --prefix packages/back-end run lint"
+    ],
+    "packages/shared-lib/src/**/*.{js,ts}": [
+      "pnpm --prefix packages/shared-lib run lint"
     ]
   },
   "packageManager": "pnpm@9.6.0",


### PR DESCRIPTION
Running `lint-all` from root was causing an issue between ESLint/tsconfig establishing the right folder path/context, throwing an error and preventing the ability to commit. 

The simplest solution was to separate the lint tasks out separately and run sequentially as part of the existing `lint-staged` script. The Prettier step has been moved to run before ESLint also as best practice.