### PR TITLE
fix: apply apache license with correct copyright name and year

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 !/.projen/files.json
 !/.github/workflows/pull-request-lint.yml
 !/package.json
-!/LICENSE
 !/.npmignore
 logs
 *.log
@@ -49,6 +48,7 @@ jspm_packages/
 !/.husky/pre-commit
 !/.github/workflows/cicd-release-quality.yml
 !/.github/workflows/cicd-release-sandbox.yml
+!/LICENSE
 !/packages/back-end/src/app/README.md
 !/packages/back-end/src/app/controllers/README.md
 !/packages/back-end/src/app/controllers/easy-genomics/README.md

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,4 +1,4 @@
-import { awscdk, javascript, typescript } from 'projen';
+import { awscdk, javascript, typescript, LicenseOptions } from 'projen';
 import {
   ArrowParens,
   HTMLWhitespaceSensitivity,
@@ -13,6 +13,7 @@ import {
 import { pathsToModuleNameMapper } from 'ts-jest';
 import { setupProjectFolders } from './projenrc/easy-genomics-project-setup';
 import { GithubActionsCICDRelease } from './projenrc/github-actions-cicd-release';
+import { ApacheLicense } from './projenrc/apache-license';
 import { Husky } from './projenrc/husky';
 import { Nx } from './projenrc/nx';
 import { PnpmWorkspace } from './projenrc/pnpm';
@@ -117,11 +118,15 @@ const jestOptions: JestOptions = {
   extraCliOptions: ['--detectOpenHandles'],
 };
 
+const licenseOptions: LicenseOptions = {
+  spdx: 'Apache-2.0',
+  copyrightOwner: copyrightOwner,
+  copyrightPeriod: copyrightPeriod,
+};
+
 const root = new typescript.TypeScriptProject({
   authorName: authorName,
   authorOrganization: true,
-  copyrightOwner: copyrightOwner,
-  copyrightPeriod: copyrightPeriod,
   defaultReleaseBranch: defaultReleaseBranch,
   description:
     'Easy Genomics web application to help simplify genomic analysis of sequenced genetic data for bioinformaticians utilizing AWS HealthOmics & NextFlow Tower',
@@ -137,8 +142,7 @@ const root = new typescript.TypeScriptProject({
     },
   },
   homepage: 'https://github.com/twobulls/easy-genomics',
-  license: 'Apache-2.0',
-  licensed: true,
+  licensed: false, // we apply the Apache 2.0 license later
   minNodeVersion: nodeVersion,
   name: '@easy-genomics/root',
   packageManager: javascript.NodePackageManager.PNPM,
@@ -227,11 +231,7 @@ const sharedLib = new typescript.TypeScriptProject({
   sampleCode: false,
   authorName: authorName,
   authorOrganization: true,
-  // Copyright & Licensing
-  copyrightOwner: copyrightOwner,
-  copyrightPeriod: copyrightPeriod,
-  license: 'Apache-2.0',
-  licensed: true,
+  licensed: false, // we apply the Apache 2.0 license later
   // Use same settings from root project
   packageManager: root.package.packageManager,
   projenCommand: root.projenCommand,
@@ -271,10 +271,7 @@ const backEndApp = new awscdk.AwsCdkTypeScriptApp({
   sampleCode: false,
   authorName: authorName,
   authorOrganization: true,
-  copyrightOwner: copyrightOwner,
-  copyrightPeriod: copyrightPeriod,
-  license: 'Apache-2.0',
-  licensed: true,
+  licensed: false, // we apply the Apache 2.0 license later
   packageManager: root.package.packageManager,
   projenCommand: root.projenCommand,
   minNodeVersion: root.minNodeVersion,
@@ -346,10 +343,7 @@ const frontEndApp = new awscdk.AwsCdkTypeScriptApp({
   // Copyright & Licensing
   authorName: authorName,
   authorOrganization: true,
-  copyrightOwner: copyrightOwner,
-  copyrightPeriod: copyrightPeriod,
-  license: 'Apache-2.0',
-  licensed: true,
+  licensed: false, // we apply the Apache 2.0 license later
   // Use same settings from root project
   packageManager: root.package.packageManager,
   projenCommand: root.projenCommand,
@@ -446,6 +440,10 @@ new Nx(root);
 new Husky(root);
 new GithubActionsCICDRelease(root, { environment: 'quality', pnpmVersion: pnpmVersion });
 new GithubActionsCICDRelease(root, { environment: 'sandbox', pnpmVersion: pnpmVersion, onPushBranch: 'infra/*' });
+new ApacheLicense(root, licenseOptions);
+new ApacheLicense(backEndApp, licenseOptions);
+new ApacheLicense(frontEndApp, licenseOptions);
+new ApacheLicense(sharedLib, licenseOptions);
 
 // Provision templated project folders structure with README.md descriptions.
 setupProjectFolders(root);

--- a/packages/back-end/.gitignore
+++ b/packages/back-end/.gitignore
@@ -4,7 +4,6 @@
 !/.projen/deps.json
 !/.projen/files.json
 !/package.json
-!/LICENSE
 !/.npmignore
 logs
 *.log
@@ -45,3 +44,4 @@ junit.xml
 /cdk.out/
 .cdk.staging/
 .parcel-cache/
+!/LICENSE

--- a/packages/back-end/LICENSE
+++ b/packages/back-end/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2024 DEPT Agency
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/packages/front-end/.gitignore
+++ b/packages/front-end/.gitignore
@@ -4,7 +4,6 @@
 !/.projen/deps.json
 !/.projen/files.json
 !/package.json
-!/LICENSE
 !/.npmignore
 logs
 *.log
@@ -45,3 +44,4 @@ junit.xml
 /cdk.out/
 .cdk.staging/
 .parcel-cache/
+!/LICENSE

--- a/packages/front-end/LICENSE
+++ b/packages/front-end/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2024 DEPT Agency
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/packages/shared-lib/.gitignore
+++ b/packages/shared-lib/.gitignore
@@ -4,7 +4,6 @@
 !/.projen/deps.json
 !/.projen/files.json
 !/package.json
-!/LICENSE
 !/.npmignore
 logs
 *.log
@@ -40,3 +39,4 @@ junit.xml
 /lib
 /dist/
 !/.eslintrc.json
+!/LICENSE

--- a/packages/shared-lib/LICENSE
+++ b/packages/shared-lib/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2024 DEPT Agency
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/projenrc/apache-license.ts
+++ b/projenrc/apache-license.ts
@@ -1,0 +1,37 @@
+import { Project, LicenseOptions, License, IResolver } from 'projen';
+import { TypeScriptProject } from 'projen/lib/typescript';
+import { AwsCdkTypeScriptApp } from 'projen/lib/awscdk';
+import * as fs from 'fs';
+
+/**
+ * Apply the Apache 2.0 license with the correct copyright date and name
+ */
+export class ApacheLicense extends License {
+  apacheText: string;
+  constructor(project: Project, options: LicenseOptions) {
+    super(project, options);
+    const spdx = 'Apache-2.0';
+
+    if (project instanceof TypeScriptProject || project instanceof AwsCdkTypeScriptApp) {
+      // apply the license type to the project
+      project.addFields({ license: spdx });
+    }
+
+    const textFile = `projenrc/license-text/${spdx}.txt`;
+    if (!fs.existsSync(textFile)) {
+      throw new Error(`could not find license ${spdx}`);
+    }
+    const years = options.copyrightPeriod ?? new Date().getFullYear().toString();
+    const owner = options.copyrightOwner;
+    let text = fs.readFileSync(textFile, 'utf-8');
+    text = text.replace('[yyyy]', years);
+    if (owner) {
+      text = text.replace('[name of copyright owner]', owner);
+    }
+
+    this.apacheText = text;
+  }
+  synthesizeContent(_: IResolver) {
+    return this.apacheText;
+  }
+}

--- a/projenrc/license-text/Apache-2.0.txt
+++ b/projenrc/license-text/Apache-2.0.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2024 DEPT Agency
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Extends the Projen License class to apply the Apache-2.0 and override the year and owner placeholders.