### PR TITLE
feat(EG-641): change default labs tab to Runs

### DIFF
--- a/packages/front-end/src/app/pages/labs/[labId]/index.vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/index.vue
@@ -23,13 +23,13 @@
 
   const tabItems = [
     {
+      key: 'runs',
+      label: 'Runs',
+    },
+    {
       key: 'pipelines',
 
       label: 'Pipelines',
-    },
-    {
-      key: 'runs',
-      label: 'Runs',
     },
     {
       key: 'users',


### PR DESCRIPTION
 Changes Pipelines tab to Runs tab as the first/default tab when viewing the Lab.