### PR TITLE
fix(EG-571): add manifest name underneath run name

### DIFF
--- a/packages/front-end/src/app/pages/labs/[labId]/[workflowId]/index.vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/[workflowId]/index.vue
@@ -56,7 +56,7 @@
 </script>
 
 <template>
-  <EGPageHeader :title="workflow.runName" description="View your Lab users, details and pipelines" />
+  <EGPageHeader :title="workflow.runName" :description="workflow.manifest.name" />
   <UTabs
     :ui="EGTabsStyles"
     :model-value="tabIndex"


### PR DESCRIPTION
Small fix to add manifest name underneath run name in the Labs workflow page