### PR TITLE
chore: fields can not be empty

### DIFF
--- a/packages/shared-lib/src/app/schema/nf-tower/connection-test.ts
+++ b/packages/shared-lib/src/app/schema/nf-tower/connection-test.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 export const RequestNFConnectionTestSchema = z
   .object({
-    WorkspaceId: z.string(),
-    AccessToken: z.string(),
+    WorkspaceId: z.string().min(1),
+    AccessToken: z.string().min(1),
   })
   .strict();


### PR DESCRIPTION
Prevents the fields from being empty