### PR TITLE
fix(EG-571): pipeline name 

### DIFF
--- a/packages/front-end/src/app/pages/labs/[labId]/[workflowId]/index.vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/[workflowId]/index.vue
@@ -56,7 +56,7 @@
 </script>
 
 <template>
-  <EGPageHeader :title="workflow.runName" :description="workflow.manifest.name" />
+  <EGPageHeader :title="workflow.runName" :description="workflow.projectName" />
   <UTabs
     :ui="EGTabsStyles"
     :model-value="tabIndex"

--- a/packages/front-end/src/app/pages/labs/[labId]/index.vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/index.vue
@@ -347,7 +347,7 @@
 
 <template>
   <EGPageHeader
-    :title="labName"
+    :title="labName || ''"
     description="View your Lab users, details and pipelines"
     :back-action="() => $router.push('/labs')"
   >


### PR DESCRIPTION
Fixes an issue with the pipeline name (e.g. `nf-core/rnaseq`) breaking when viewing cancelled runs. This is due to the `manifest` property value not existing in the cancelled run data. This same value exists in `workflow.projectName` so the prop value references this value now instead.

Also fixes a console warning for the `labName` null value before the page data is retrieved.