### PR TITLE
feat(EG-638): remove transactionId variable from stepper 2 and add to lab/[labId]/index.vue page usePipelineRunStore()

### DIFF
--- a/packages/front-end/src/app/components/EGRunPipelineFormUploadData.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineFormUploadData.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
   import axios from 'axios';
-  import { v4 as uuidv4 } from 'uuid';
   import { ButtonSizeEnum } from '@FE/types/buttons';
   import {
     FileInfo,
@@ -41,9 +40,6 @@
   const emit = defineEmits(['next-step', 'previous-step', 'step-validated']);
 
   const labId = $route.params.labId as string;
-
-  // TODO: Move transactionId to store and generate at step 01
-  const transactionId = uuidv4();
 
   const chooseFilesButton = ref<HTMLButtonElement | null>(null);
 
@@ -327,7 +323,7 @@
   async function getSampleSheetCsv(uploadedFilePairs: UploadedFilePairInfo[]): Promise<SampleSheetResponse> {
     const request: SampleSheetRequest = {
       LaboratoryId: labId,
-      TransactionId: transactionId,
+      TransactionId: usePipelineRunStore().transactionId,
       UploadedFilePairs: uploadedFilePairs,
     };
     const response = await $api.uploads.getSampleSheetCsv(request);
@@ -347,7 +343,7 @@
 
     const request: FileUploadRequest = {
       LaboratoryId: labId,
-      TransactionId: transactionId,
+      TransactionId: usePipelineRunStore().transactionId,
       Files: files,
     };
 

--- a/packages/front-end/src/app/pages/labs/[labId]/index.vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/index.vue
@@ -15,6 +15,7 @@
   import { getDate, getTime } from '@FE/utils/date-time';
   import EGModal from '@FE/components/EGModal';
   import { caseInsensitiveSortFn } from '@FE/utils/sort-utils';
+  import { v4 as uuidv4 } from 'uuid';
 
   const { $api } = useNuxtApp();
   const $route = useRoute();
@@ -326,9 +327,10 @@
     usePipelineRunStore().setPipelineId(pipelineId);
     usePipelineRunStore().setPipelineName(pipelineName);
     usePipelineRunStore().setPipelineDescription(pipelineDescription);
-    $router.push({
-      path: `/labs/${labId}/${pipelineId}/run-pipeline`,
-    });
+    usePipelineRunStore().setTransactionId(uuidv4()),
+      $router.push({
+        path: `/labs/${labId}/${pipelineId}/run-pipeline`,
+      });
   }
 
   function viewRunDetails(row) {

--- a/packages/front-end/src/app/stores/pipeline-run.ts
+++ b/packages/front-end/src/app/stores/pipeline-run.ts
@@ -7,6 +7,7 @@ export const pipelineRunStateSchema = z.object({
   pipelineId: z.number(),
   pipelineName: z.string(),
   pipelineDescription: z.string(),
+  transactionId: z.string(),
   userPipelineRunName: z.string(),
   params: z.object({}),
   sampleSheetCsv: z.string(),
@@ -28,6 +29,7 @@ const initialState = (): PipeLineRunState => ({
   pipelineId: 0,
   pipelineName: '',
   pipelineDescription: '',
+  transactionId: '',
   userPipelineRunName: '',
   params: {},
   sampleSheetCsv: '',
@@ -56,6 +58,10 @@ const usePipelineRunStore = defineStore('pipelineRunStore', {
 
     setPipelineDescription(pipelineDescription: string) {
       this.pipelineDescription = pipelineDescription;
+    },
+
+    setTransactionId(transactionId: string) {
+      this.transactionId = transactionId;
     },
 
     setUserPipelineRunName(userPipelineRunName: string) {


### PR DESCRIPTION
This PR removes the `transactionId` variable declaration from the 2nd Stepper `EGRunPipelineFormUploadData.vue` and adds it to the initial `lab/[labId]/index.vue page` and stores the transactionId value within the `usePipelineRunStore()` so it can be easily accessed by any Stepper.

This will allow files to be uploaded consistently to the same S3 Bucket Path for the current Launch Run session.