### PR TITLE
fix(EG-697): fix local FE build process to ensure shared-lib is included to run nuxt-dev

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -444,7 +444,7 @@ frontEndApp.addScripts({
   ['deploy']: 'pnpm cdk bootstrap && pnpm dlx projen deploy',
   ['build-and-deploy']:
     'pnpm -w run build-front-end && pnpm cdk bootstrap && pnpm dlx projen deploy --require-approval any-change', // Run root build-front-end script to inc shared-lib
-  ['nuxt-dev']: 'pnpm run build && pnpm kill-port 3000 && nuxt dev',
+  ['nuxt-dev']: 'pnpm -w run build-front-end && pnpm kill-port 3000 && nuxt dev',
   ['nuxt-load-settings']: 'npx esrun nuxt-load-configuration-settings.ts',
   ['nuxt-generate']: 'nuxt generate',
   ['nuxt-prepare']: 'nuxt prepare', // Required to create front-end/.nuxt/tsconfig.json

--- a/packages/front-end/package.json
+++ b/packages/front-end/package.json
@@ -21,7 +21,7 @@
     "watch": "pnpm dlx projen watch",
     "projen": "pnpm dlx projen",
     "build-and-deploy": "pnpm -w run build-front-end && pnpm cdk bootstrap && pnpm dlx projen deploy --require-approval any-change",
-    "nuxt-dev": "pnpm run build && pnpm kill-port 3000 && nuxt dev",
+    "nuxt-dev": "pnpm -w run build-front-end && pnpm kill-port 3000 && nuxt dev",
     "nuxt-load-settings": "npx esrun nuxt-load-configuration-settings.ts",
     "nuxt-generate": "nuxt generate",
     "nuxt-prepare": "nuxt prepare",


### PR DESCRIPTION
This PR fixes the FE `pnpm run nuxt-dev` command to ensure it runs the `build-front-end` script which will include the shared-lib as part of the build process.

This will allow a clean checkout of this Easy Genomics repo, and run the FE locally using `pnpm run nuxt-dev` with the following sequence of commands:

```
git clone https://github.com/twobulls/easy-genomics.git
cd easy-genomics
pnpm install

// Configure the easy-genomics.yaml file and deploy the BE if not already deployed to AWS
...

cd packages/front-end
pnpm run nuxt-dev
```