### PR TITLE
feat(EG-420): restrict create-organization api to the SystemAdmin's Cognito Auth session

### DIFF
--- a/packages/back-end/src/app/utils/auth-utils.ts
+++ b/packages/back-end/src/app/utils/auth-utils.ts
@@ -1,0 +1,61 @@
+import {
+  LaboratoryAccess,
+  LaboratoryAccessDetails,
+  OrganizationAccess,
+  OrganizationAccessDetails,
+} from '@easy-genomics/shared-lib/src/app/types/easy-genomics/user';
+import { APIGatewayProxyWithCognitoAuthorizerEvent } from 'aws-lambda';
+import { APIGatewayProxyEvent } from 'aws-lambda/trigger/api-gateway-proxy';
+
+/**
+ * Helper function to check if the current User's Cognito session belongs to
+ * System Admin user in order to allow access to restricted APIs.
+ * @param event
+ */
+export function validateSystemAdminAccess(event: APIGatewayProxyWithCognitoAuthorizerEvent): Boolean {
+  const cognitoGroup: string = event.requestContext.authorizer.claims['cognito:groups'];
+  return cognitoGroup === 'SystemAdmin';
+}
+
+/**
+ * Helper function to check if an authenticated User's JWT OrganizationAccess
+ * metadata allows access to the requested Organization / Laboratory.
+ * @param event
+ * @param organizationId
+ * @param laboratoryId
+ */
+export function validateOrganizationAccess(
+  event: APIGatewayProxyEvent,
+  organizationId: string,
+  laboratoryId?: string,
+): Boolean {
+  try {
+    const orgAccessMetadata: string | undefined = event.requestContext.authorizer?.claims.OrganizationAccess;
+    if (!orgAccessMetadata) {
+      return false;
+    }
+
+    const organizationAccess: OrganizationAccess = JSON.parse(orgAccessMetadata);
+    const organizationAccessDetails: OrganizationAccessDetails | undefined = organizationAccess[organizationId];
+    if (!organizationAccessDetails || (organizationAccessDetails && organizationAccessDetails.Status !== 'Active')) {
+      return false;
+    }
+
+    if (laboratoryId) {
+      const laboratoryAccess: LaboratoryAccess | undefined = organizationAccessDetails.LaboratoryAccess;
+      if (!laboratoryAccess) {
+        return false;
+      }
+
+      const laboratoryAccessDetails: LaboratoryAccessDetails | undefined = laboratoryAccess[laboratoryId];
+      if (!laboratoryAccessDetails || (laboratoryAccessDetails && laboratoryAccessDetails.Status !== 'Active')) {
+        return false;
+      }
+    }
+
+    return true;
+  } catch (error) {
+    console.error(error);
+    return false;
+  }
+}

--- a/packages/back-end/src/app/utils/rest-api-utils.ts
+++ b/packages/back-end/src/app/utils/rest-api-utils.ts
@@ -1,9 +1,3 @@
-import {
-  LaboratoryAccess,
-  LaboratoryAccessDetails,
-  OrganizationAccess,
-  OrganizationAccessDetails,
-} from '@easy-genomics/shared-lib/src/app/types/easy-genomics/user';
 import { APIGatewayProxyEvent } from 'aws-lambda/trigger/api-gateway-proxy';
 
 export const enum REST_API_METHOD {
@@ -80,47 +74,4 @@ export function getApiParameters(event: APIGatewayProxyEvent): URLSearchParams {
   }
 
   return parameters;
-}
-
-/**
- * Helper function to check if an authenticated User's JWT OrganizationAccess
- * metadata allows access to the requested Organization / Laboratory.
- * @param event
- * @param organizationId
- * @param laboratoryId
- */
-export function validateOrganizationAccess(
-  event: APIGatewayProxyEvent,
-  organizationId: string,
-  laboratoryId?: string,
-): Boolean {
-  try {
-    const orgAccessMetadata: string | undefined = event.requestContext.authorizer?.claims.OrganizationAccess;
-    if (!orgAccessMetadata) {
-      return false;
-    }
-
-    const organizationAccess: OrganizationAccess = JSON.parse(orgAccessMetadata);
-    const organizationAccessDetails: OrganizationAccessDetails | undefined = organizationAccess[organizationId];
-    if (!organizationAccessDetails || (organizationAccessDetails && organizationAccessDetails.Status !== 'Active')) {
-      return false;
-    }
-
-    if (laboratoryId) {
-      const laboratoryAccess: LaboratoryAccess | undefined = organizationAccessDetails.LaboratoryAccess;
-      if (!laboratoryAccess) {
-        return false;
-      }
-
-      const laboratoryAccessDetails: LaboratoryAccessDetails | undefined = laboratoryAccess[laboratoryId];
-      if (!laboratoryAccessDetails || (laboratoryAccessDetails && laboratoryAccessDetails.Status !== 'Active')) {
-        return false;
-      }
-    }
-
-    return true;
-  } catch (error) {
-    console.error(error);
-    return false;
-  }
 }


### PR DESCRIPTION
This PR enhances the POST `/easy-genomics/organization/create-organization` API to restrict it to only the SystemAdmin User's Cognito Auth Session.

The auth utility functions in `src/app/utils/rest-api-utils.ts` are now moved to a separate `src/app/utils/auth-utils.ts` definition for better clarity.