### PR TITLE
feat(EG-700): make s3 url editable input

### DIFF
--- a/packages/front-end/src/app/components/EGRunPipelineFormUploadData.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineFormUploadData.vue
@@ -529,11 +529,17 @@
     </UTable>
     <div class="flex justify-end pt-4">
       <EGButton
+        v-if="uploadStatus === 'success'"
+        variant="secondary"
+        class="mr-2"
+        label="Download sample sheet"
+        @click="usePipeline().downloadSampleSheet()"
+      />
+      <EGButton
         @click="startUploadProcess"
         :disabled="isUploadButtonDisabled"
         :loading="uploadStatus === 'uploading'"
         label="Upload Files"
-        size="md"
       />
     </div>
   </EGCard>

--- a/packages/front-end/src/app/components/EGRunPipelineParameterInputs.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineParameterInputs.vue
@@ -38,38 +38,13 @@
       propValues[propName] = props.params[propName];
     }
   });
-
-  function downloadSampleSheet() {
-    const csvString = usePipelineRunStore().sampleSheetCsv;
-    const blob = new Blob([csvString], { type: 'text/csv;charset=utf-8;' });
-    const link = document.createElement('a');
-    const url = URL.createObjectURL(blob);
-
-    link.setAttribute('href', url);
-    link.setAttribute(
-      'download',
-      `samplesheet-${usePipelineRunStore().pipelineName}--${usePipelineRunStore().userPipelineRunName}.csv`,
-    );
-    link.style.visibility = 'hidden';
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-  }
 </script>
 
 <template>
   <div>
     <div v-for="(propertyDetail, propertyName) in section.properties" :key="propertyName" class="mb-6">
       <template v-if="!propertyDetail?.hidden && propertyDetail.format === 'file-path' && propertyName === 'input'">
-        <component
-          :is="components[propertyType(propertyDetail)]"
-          name="input"
-          :disabled="true"
-          :details="propertyDetail"
-          v-model="usePipelineRunStore().S3Url"
-          :hide-description="true"
-        />
-        <EGButton label="Download sample sheet" class="mt-2" @click="downloadSampleSheet()" />
+        <EGInput name="input" v-model="usePipelineRunStore().S3Url" />
       </template>
       <!-- ignore Seqera "file upload" input types  -->
       <template v-if="!propertyDetail?.hidden && propertyDetail.format !== 'file-path'">

--- a/packages/front-end/src/app/composables/usePipeline.ts
+++ b/packages/front-end/src/app/composables/usePipeline.ts
@@ -1,0 +1,30 @@
+export default function usePipeline() {
+  /**
+   * Downloads the sample sheet as a CSV file.
+   */
+  function downloadSampleSheet() {
+    const csvString = usePipelineRunStore().sampleSheetCsv;
+    const blob = new Blob([csvString], { type: 'text/csv;charset=utf-8;' });
+    const link = document.createElement('a');
+    const url = URL.createObjectURL(blob);
+
+    link.setAttribute('href', url);
+    link.setAttribute(
+      'download',
+      `samplesheet-${usePipelineRunStore().pipelineName}--${usePipelineRunStore().userPipelineRunName}.csv`,
+    );
+    link.style.visibility = 'hidden';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  }
+
+  const doesFileUrlExist = computed(() => {
+    return !!(usePipelineRunStore().S3Url || usePipelineRunStore().params?.input);
+  });
+
+  return {
+    doesFileUrlExist,
+    downloadSampleSheet,
+  };
+}


### PR DESCRIPTION
This PR makes the `input` field editable in the Edit Parameters step, providing flexibility to input an existing s3 bucket URL.

The "Download sample sheet" button has also been moved from Step 3 to Step 2, and will display once the file pairs have been successfully uploaded.