### PR TITLE
fix(EG-701): pipeline param inputs not updating in store

### DIFF
--- a/packages/front-end/src/app/components/EGRunPipelineParameterInputs.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineParameterInputs.vue
@@ -8,7 +8,7 @@
     params: Record<string, any>;
   }>();
 
-  const store = usePipelineRunStore();
+  const pipelineRunStore = usePipelineRunStore();
 
   function propertyType(property) {
     if (property.type === 'string' && property.format === undefined) return 'EGParametersStringField';
@@ -43,7 +43,7 @@
 
   watchEffect(() => {
     for (const key in propValues) {
-      store.params[key] = propValues[key];
+      pipelineRunStore.params[key] = propValues[key];
     }
   });
 </script>
@@ -52,7 +52,7 @@
   <div>
     <div v-for="(propertyDetail, propertyName) in section.properties" :key="propertyName" class="mb-6">
       <template v-if="!propertyDetail?.hidden && propertyDetail.format === 'file-path' && propertyName === 'input'">
-        <EGInput name="input" v-model="usePipelineRunStore().S3Url" />
+        <EGInput name="input" v-model="pipelineRunStore.S3Url" />
       </template>
       <!-- ignore Seqera "file upload" input types  -->
       <template v-if="!propertyDetail?.hidden && propertyDetail.format !== 'file-path'">

--- a/packages/front-end/src/app/components/EGRunPipelineParameterInputs.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineParameterInputs.vue
@@ -4,9 +4,11 @@
   import BooleanField from './EGParametersBooleanField.vue';
 
   const props = defineProps<{
-    section: object;
-    params: object;
+    section: Record<string, any>;
+    params: Record<string, any>;
   }>();
+
+  const store = usePipelineRunStore();
 
   function propertyType(property) {
     if (property.type === 'string' && property.format === undefined) return 'EGParametersStringField';
@@ -19,9 +21,9 @@
   }
 
   const components = {
-    'EGParametersStringField': StringField,
-    'EGParametersNumberField': NumberField,
-    'EGParametersBooleanField': BooleanField,
+    EGParametersStringField: StringField,
+    EGParametersNumberField: NumberField,
+    EGParametersBooleanField: BooleanField,
   };
 
   const propValues = reactive({});
@@ -36,6 +38,12 @@
       }
     } else {
       propValues[propName] = props.params[propName];
+    }
+  });
+
+  watchEffect(() => {
+    for (const key in propValues) {
+      store.params[key] = propValues[key];
     }
   });
 </script>


### PR DESCRIPTION
- Adds `watchEffect` on props values to fix the `params` store object not updating. 
- Cache the store as a local const for perf improvement.