### PR TITLE
feat(EG-704): update list-organization API for SysAdmin/User filtering

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/organization/list-organizations.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/organization/list-organizations.lambda.ts
@@ -26,9 +26,6 @@ export const handler: Handler = async (
       return buildResponse(200, JSON.stringify(response), event);
     } else {
       const organizationIds = getOrganizationAccessOrganizationIds(event);
-      if (organizationIds.length === 0) {
-        throw new Error('Unauthorized access');
-      }
 
       const response: Organization[] = await organizationService.list();
       const userOrganizations: Organization[] = response.filter((org: Organization) =>

--- a/packages/back-end/src/app/controllers/easy-genomics/organization/list-organizations.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/organization/list-organizations.lambda.ts
@@ -2,16 +2,41 @@ import { Organization } from '@easy-genomics/shared-lib/src/app/types/easy-genom
 import { buildResponse } from '@easy-genomics/shared-lib/src/app/utils/common';
 import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
 import { OrganizationService } from '@BE/services/easy-genomics/organization-service';
+import { getOrganizationAccessOrganizationIds, validateSystemAdminAccess } from '@BE/utils/auth-utils';
 
 const organizationService = new OrganizationService();
 
+/**
+ * This API is returns a list of Organizations depending on the User's Cognito
+ * Session.
+ *
+ * If the User is the SystemAdmin, then it will return all Organizations in the
+ * platform. Otherwise if it is a normal User, then it will return only the
+ * Organizations the User has been invited to.
+ *
+ * @param event
+ */
 export const handler: Handler = async (
   event: APIGatewayProxyWithCognitoAuthorizerEvent,
 ): Promise<APIGatewayProxyResult> => {
   console.log('EVENT: \n' + JSON.stringify(event, null, 2));
   try {
-    const response: Organization[] = await organizationService.list();
-    return buildResponse(200, JSON.stringify(response), event);
+    if (validateSystemAdminAccess(event)) {
+      const response: Organization[] = await organizationService.list();
+      return buildResponse(200, JSON.stringify(response), event);
+    } else {
+      const organizationIds = getOrganizationAccessOrganizationIds(event);
+      if (organizationIds.length === 0) {
+        throw new Error('Unauthorized access');
+      }
+
+      const response: Organization[] = await organizationService.list();
+      const userOrganizations: Organization[] = response.filter((org: Organization) =>
+        organizationIds.includes(org.OrganizationId),
+      );
+
+      return buildResponse(200, JSON.stringify(userOrganizations), event);
+    }
   } catch (err: any) {
     console.error(err);
     return buildResponse(400, JSON.stringify({ Error: getErrorMessage(err) }), event);

--- a/packages/back-end/src/app/utils/auth-utils.ts
+++ b/packages/back-end/src/app/utils/auth-utils.ts
@@ -18,6 +18,20 @@ export function validateSystemAdminAccess(event: APIGatewayProxyWithCognitoAutho
 }
 
 /**
+ * Helper function to return the User's OrganizationAccess OrganizationIds.
+ * @param event
+ */
+export function getOrganizationAccessOrganizationIds(event: APIGatewayProxyEvent): string[] {
+  const orgAccessMetadata: string | undefined = event.requestContext.authorizer?.claims.OrganizationAccess;
+  if (!orgAccessMetadata) {
+    return [];
+  }
+
+  const organizationAccess: OrganizationAccess = JSON.parse(orgAccessMetadata);
+  return Object.keys(organizationAccess);
+}
+
+/**
  * Helper function to check if an authenticated User's JWT OrganizationAccess
  * metadata allows access to the requested Organization / Laboratory.
  * @param event


### PR DESCRIPTION
This PR modifies the `/easy-genomics/organization/list-organizations` API to return a list of Organizations depending on the Cognito User Session.

If the User is the SystemAdmin it will return all existing Organizations in the Platform.

If the User is a normal User then it will only return a filtered list of Organizations that the User has been invited to.