### PR TITLE
feat(EG-713): added timeout in editlab test

### DIFF
--- a/packages/front-end/tests/e2e/EditLab.spec.e2e.ts
+++ b/packages/front-end/tests/e2e/EditLab.spec.e2e.ts
@@ -48,6 +48,7 @@ test('Update a Laboratory Successfully', async ({ page, baseURL }) => {
       .fill('eyJ0aWQiOiA5NjY5fS5jNTYxOGNmNmVmNzY4ZWU4M2JhZWUzMTQ0MGMxNjRjNTYwYWZlZmRm');
 
     await page.getByRole('button', { name: 'Save Changes' }).click();
+    await page.waitForTimeout(2000);
 
     // confirm update
     await expect(page.getByText('Automation Lab successfully updated').nth(0)).toBeVisible();


### PR DESCRIPTION
Fixes #
- added a timeout code after editing Lab changes to give enough time to save the changes and the toast messages to appear