### PR TITLE
fix(EG-680): minor updates to support NF integration

### DIFF
--- a/packages/front-end/src/app/components/EGRunPipelineFormEditParameters.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineFormEditParameters.vue
@@ -11,13 +11,15 @@
   const emit = defineEmits(['next-step', 'previous-step', 'step-validated']);
 
   const activeSection = ref<string | null>(null);
+  const pipelineRunStore = usePipelineRunStore();
 
   const localProps = reactive({
     schema: props.schema,
-    params: { ...props.params },
+    params: {
+      ...props.params,
+      input: pipelineRunStore.S3Url,
+    },
   });
-
-  const pipelineRunStore = usePipelineRunStore();
 
   onMounted(() => {
     // set first section in side panel of UI to active

--- a/packages/front-end/src/app/components/EGRunPipelineFormReviewPipeline.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineFormReviewPipeline.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
   import { ButtonSizeEnum } from '@FE/types/buttons';
+  import { usePipelineRunStore, useToastStore } from '@FE/stores';
 
   const props = defineProps<{
     canLaunch?: boolean;
     labId: string;
     labName: string;
+    schema: object;
     params: object;
     pipelineName: string;
     userPipelineRunName: string;
@@ -14,6 +16,10 @@
   const isLaunchingWorkflow = ref(false);
   const emit = defineEmits(['launch-workflow', 'has-launched', 'previous-tab']);
 
+  const paramsText = JSON.stringify(props.params);
+  const schema = JSON.parse(JSON.stringify(props.schema));
+  const params = JSON.parse(paramsText);
+
   async function launchWorkflow() {
     try {
       isLaunchingWorkflow.value = true;
@@ -22,7 +28,7 @@
         props.labId,
       );
       if (launchDetails.launch) {
-        launchDetails.launch.paramsText = JSON.stringify(props.params);
+        launchDetails.launch.paramsText = paramsText;
         launchDetails.launch.runName = props.userPipelineRunName;
       }
       await $api.workflows.createPipelineRun(props.labId, launchDetails);
@@ -57,6 +63,20 @@
         </div>
       </dl>
     </section>
+    <div v-for="(section, sectionName) in schema.definitions" :key="`section-${sectionName}`">
+      <EGText tag="h4" class="mb-0">{{ section.title }}</EGText>
+      <UDivider class="py-4" />
+      <section class="stroke-light flex flex-col bg-white">
+        <dl>
+          <div v-for="(property, propertyKey) in section.properties" :key="`property-${propertyKey}`">
+            <div class="flex border-b px-4 py-4 text-sm">
+              <dt class="w-[200px] font-medium text-black">{{ propertyKey }}</dt>
+              <dd class="text-muted text-left">{{ params[propertyKey] }}</dd>
+            </div>
+          </div>
+        </dl>
+      </section>
+    </div>
   </EGCard>
 
   <div class="mt-6 flex justify-between">

--- a/packages/front-end/src/app/components/EGRunPipelineFormRunDetails.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineFormRunDetails.vue
@@ -39,7 +39,7 @@
     .max(maxRunNameLength.value, `Pipeline run name must be ${maxRunNameLength.value} characters or less`);
 
   const formStateSchema = z.object({
-    pipelineDescription: z.string().default(''), // Seqera API spec doesn't define a max length for pipeline description
+    pipelineDescription: z.string(), // Seqera API spec doesn't define a max length for pipeline description
     pipelineName: z.string(), // Seqera API spec doesn't define a max length for pipeline name a.k.a action name e.g. nf-core-viralrecon
     runName: runNameSchema,
   });
@@ -66,6 +66,7 @@
    */
   onBeforeMount(async () => {
     formState.runName = usePipelineRunStore().userPipelineRunName;
+    formState.pipelineDescription = usePipelineRunStore().pipelineDescription;
     validate(formState);
   });
 

--- a/packages/front-end/src/app/components/EGRunPipelineFormUploadData.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineFormUploadData.vue
@@ -279,23 +279,18 @@
     canProceed.value = true;
   }
 
-  function removeQueryStringFromS3Url(s3Url: string): string {
-    return s3Url.split('?')[0];
-  }
-
   function getUploadedFilePairs(uploadManifest: FileUploadManifest): UploadedFilePairInfo[] {
     const uploadedFilePairs: UploadedFilePairInfo[] = [];
 
     uploadManifest.Files.forEach((file: FileUploadInfo) => {
-      const { Bucket, Key, Name, Region, S3Url } = file;
-      const url = removeQueryStringFromS3Url(S3Url);
-      console.debug('Uploaded file:', Name, url);
+      const { Bucket, Key, Name, Region } = file;
+      const s3Uri = `s3://${Bucket}/${Key}`;
 
       const uploadFileInfo: UploadedFileInfo = {
         Bucket,
         Key,
         Region,
-        S3Url: url,
+        S3Url: s3Uri,
       };
       const sampleId = getSampleIdFromFileName(Name);
       const existingFilePair = uploadedFilePairs.find((filePair) => filePair.SampleId === sampleId);

--- a/packages/front-end/src/app/components/EGRunPipelineParameterInputs.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineParameterInputs.vue
@@ -2,6 +2,7 @@
   import StringField from './EGParametersStringField.vue';
   import NumberField from './EGParametersNumberField.vue';
   import BooleanField from './EGParametersBooleanField.vue';
+  import { usePipelineRunStore } from '@FE/stores';
 
   const props = defineProps<{
     section: Record<string, any>;

--- a/packages/front-end/src/app/components/EGRunPipelineStepper.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineStepper.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
   import { usePipelineRunStore } from '@FE/stores';
-  import { ButtonSizeEnum } from '@FE/types/buttons';
 
   const props = defineProps<{
     schema: object;
@@ -209,6 +208,7 @@
               :can-launch="true"
               :lab-id="labId"
               :lab-name="labName"
+              :schema="props.schema"
               :params="usePipelineRunStore().params"
               :pipeline-name="usePipelineRunStore().pipelineName"
               :userPipelineRunName="usePipelineRunStore().userPipelineRunName"

--- a/packages/front-end/src/app/pages/labs/[labId]/[pipelineId]/run-pipeline.vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/[pipelineId]/run-pipeline.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { usePipelineRunStore } from '@FE/stores';
+  import { usePipelineRunStore, useUiStore } from '@FE/stores';
   import { ButtonVariantEnum } from '@FE/types/buttons';
 
   const { $api } = useNuxtApp();
@@ -39,7 +39,10 @@
   async function initializePipelineData() {
     const res = await $api.pipelines.readPipelineSchema($route.params.pipelineId, $route.params.labId);
     schema.value = JSON.parse(res.schema);
-    usePipelineRunStore().setParams(JSON.parse(<string>res.params));
+    usePipelineRunStore().setPipelineDescription(schema.value.description);
+    if (res.params) {
+      usePipelineRunStore().setParams(JSON.parse(res.params));
+    }
   }
 
   function handleDialogAction() {
@@ -62,6 +65,7 @@
    */
   function resetRunPipeline() {
     usePipelineRunStore().setUserPipelineRunName('');
+    usePipelineRunStore().setPipelineDescription('');
     usePipelineRunStore().setParams({});
     initializePipelineData();
     resetStepperKey.value++;

--- a/packages/front-end/src/app/pages/labs/[labId]/index.vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/index.vue
@@ -352,7 +352,7 @@
     usePipelineRunStore().setLabName(labName);
     usePipelineRunStore().setPipelineId(pipelineId);
     usePipelineRunStore().setPipelineName(pipelineName);
-    usePipelineRunStore().setPipelineDescription(pipelineDescription);
+    usePipelineRunStore().setPipelineDescription(pipelineDescription || '');
     usePipelineRunStore().setTransactionId(uuidv4());
     $router.push({
       path: `/labs/${labId}/${pipelineId}/run-pipeline`,


### PR DESCRIPTION
This PR fixes:

* S3Urls in the samplesheet for the uploaded files
* Sets the samplesheet S3Url for the `input` property
* Adds some missing imports for FE pages
* Renders the edited settings in Step 3. in the Step 4. summary page (to update to Nick's Figma designs still)
* Filters the Pipeline's sections for any that contain all hidden settings since it is not to be edited/visible in Step 3 and Step 4.

NOTE: There is still a bug with the manual editing of the input samplesheet text field in Step 3. This only gets updated and displayed properly in Step 4 after going back to Step 3, and then Step 4 again. It seems to be a storage update issue.