### PR TITLE
fix(EG-750): setup shared s3 bucket with cors settings for deployment

### DIFF
--- a/packages/back-end/src/infra/stacks/data-provisioning-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/data-provisioning-nested-stack.ts
@@ -62,17 +62,19 @@ export class DataProvisioningNestedStack extends NestedStack {
       });
 
       // S3 Bucket Names must be globally unique and less than 63 in length
-      const s3BucketId = laboratory.LaboratoryId.toLowerCase().replace(/-+/g, '');
-      const s3BucketFullName = `${this.props.env.account!}-${this.props.namePrefix}-lab-${s3BucketId}`.substring(0, 63);
+      const s3BucketFullName = `${this.props.env.account!}-${this.props.namePrefix}-lab-bucket`;
+      if (s3BucketFullName.length > 63) {
+        throw new Error(`S3 Bucket Name: "${s3BucketFullName}" is too long`);
+      }
       this.addDynamoDBSeedData<Laboratory>(`${this.props.namePrefix}-laboratory-table`, {
         ...laboratory,
-        S3Bucket: s3BucketFullName, // Save the S3 Bucket's Full Name in Laboratory DynamoDB record
+        S3Bucket: s3BucketFullName, // Save the shared S3 Bucket's Full Name in Laboratory DynamoDB record
       });
       uniqueReferences.push({
         Value: laboratory.Name.toLowerCase(),
         Type: `organization-${laboratory.OrganizationId}-laboratory-name`,
       });
-      // Add corresponding S3 Bucket for seeded 'Test Laboratory'
+      // Add shared S3 Bucket for seeded 'Test Laboratory'
       this.s3Construct.createBucket(s3BucketFullName, this.props.devEnv);
 
       if (this.props.testUserEmail && this.props.testUserPassword) {

--- a/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
@@ -292,15 +292,6 @@ export class EasyGenomicsNestedStack extends NestedStack {
         actions: ['dynamodb:PutItem'],
         effect: Effect.ALLOW,
       }),
-      // IMPORTANT
-      // This IAM policy prevents creation of Lab S3 buckets where the bucket name
-      // doesn't begin with the name component of the  'resources' prefix.
-      // e.g. 123456789012-dev-build2-lab-*
-      new PolicyStatement({
-        resources: [`arn:aws:s3:::${this.props.env.account!}-${this.props.namePrefix}-lab-*`],
-        actions: ['s3:CreateBucket', 's3:*'], // TODO: Lock down S3 permissions for PutBucketLifecycleConfiguration
-        effect: Effect.ALLOW,
-      }),
       new PolicyStatement({
         resources: [
           `arn:aws:ssm:${this.props.env.region!}:${this.props.env.account!}:parameter/easy-genomics/organization/*/laboratory/*/nf-access-token`,


### PR DESCRIPTION
This PR updates the `data-provisioning-nested-stack.ts` to create a single shared S3 Bucket named `${this.props.env.account!}-${this.props.namePrefix}-lab-bucket` to simulate an existing S3 Bucket for a Lab to select and use.

e.g. `{AWS ACCOUNT ID}-dev-quality-lab-bucket`

It also removes an unnecessary `s3:CreateBucket` IAM policy for the `create-laboratory` API since we are no longer provisioning new S3 Buckets at Lab creation.