### PR TITLE
fix(EG-751): update test.user@easygenomics.org OrganizationAccess to inc OrganizationAdmin flag

### DIFF
--- a/packages/shared-lib/src/app/types/easy-genomics/sample-data.ts
+++ b/packages/shared-lib/src/app/types/easy-genomics/sample-data.ts
@@ -37,6 +37,7 @@ export const user: User = {
   OrganizationAccess: {
     [organizationId]: {
       Status: 'Active',
+      OrganizationAdmin: true,
       LaboratoryAccess: {
         [laboratoryId]: {
           Status: 'Active',


### PR DESCRIPTION
This PR adds the missing `OrganizationAdmin: true` property to the seeded test user account.