### PR TITLE
feat(EG-758): add request-file-download API

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/files/request-file-download.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/files/request-file-download.lambda.ts
@@ -1,0 +1,75 @@
+import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/lib/app/utils/common';
+import {
+  InvalidRequestError,
+  LaboratoryBucketNotFoundError,
+  UnauthorizedAccessError,
+} from '@easy-genomics/shared-lib/lib/app/utils/HttpError';
+import { RequestFileDownloadSchema } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/files/request-file-download';
+import {
+  FileDownloadResponse,
+  RequestFileDownload,
+} from '@easy-genomics/shared-lib/src/app/types/easy-genomics/files/request-file-download';
+import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
+import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
+import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
+import { S3Service } from '@BE/services/s3-service';
+import {
+  validateLaboratoryManagerAccess,
+  validateLaboratoryTechnicianAccess,
+  validateOrganizationAdminAccess,
+} from '@BE/utils/auth-utils';
+
+const laboratoryService = new LaboratoryService();
+const s3Service = new S3Service();
+
+/**
+ * @param event
+ */
+export const handler: Handler = async (
+  event: APIGatewayProxyWithCognitoAuthorizerEvent,
+): Promise<APIGatewayProxyResult> => {
+  console.log('EVENT: \n' + JSON.stringify(event, null, 2));
+  try {
+    // Post Request Body
+    const request: RequestFileDownload = event.isBase64Encoded
+      ? JSON.parse(atob(event.body!))
+      : JSON.parse(event.body!);
+    // Data validation safety check
+    const requestParseResult = RequestFileDownloadSchema.safeParse(request);
+    if (!requestParseResult.success) {
+      throw new InvalidRequestError();
+    }
+
+    const laboratoryId: string = request.LaboratoryId;
+    const laboratory: Laboratory = await laboratoryService.queryByLaboratoryId(laboratoryId);
+
+    // Only Organisation Admins and Laboratory Members are allowed to edit laboratories
+    if (
+      !validateOrganizationAdminAccess(event, laboratory.OrganizationId) ||
+      !validateLaboratoryManagerAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId) ||
+      !validateLaboratoryTechnicianAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId)
+    ) {
+      throw new UnauthorizedAccessError();
+    }
+
+    const s3Key: string = request.Path;
+    const s3Bucket: string | undefined = laboratory.S3Bucket;
+    if (!s3Bucket) {
+      throw new LaboratoryBucketNotFoundError(laboratoryId);
+    }
+
+    const preSignedS3DownloadUrl: string = await s3Service.getPreSignedDownloadUrl({
+      Bucket: s3Bucket,
+      Key: s3Key,
+    });
+
+    const response: FileDownloadResponse = {
+      DownloadUrl: preSignedS3DownloadUrl,
+    };
+
+    return buildResponse(200, JSON.stringify(response), event);
+  } catch (err: any) {
+    console.error(err);
+    return buildErrorResponse(err, event);
+  }
+};

--- a/packages/back-end/src/app/services/s3-service.ts
+++ b/packages/back-end/src/app/services/s3-service.ts
@@ -19,6 +19,9 @@ import {
   GetBucketLocationCommand,
   GetBucketLocationCommandInput,
   GetBucketLocationCommandOutput,
+  GetObjectCommand,
+  GetObjectCommandInput,
+  GetObjectCommandOutput,
   HeadObjectCommand,
   HeadObjectCommandInput,
   HeadObjectCommandOutput,
@@ -64,6 +67,7 @@ export enum S3Command {
   DELETE_BUCKET_OBJECT = 'delete-bucket-object',
   LIST_BUCKET_OBJECTS = 'list-bucket-objects',
   HEAD_OBJECT = 'head-object',
+  GET_OBJECT = 'get-object',
   PUT_OBJECT = 'put-object',
   // Multi-Part S3 Uploads
   CREATE_MULTI_PART_UPLOAD = 'create-multi-part-upload',
@@ -165,6 +169,10 @@ export class S3Service {
     }
   };
 
+  public getObject = async (getObjectInput: GetObjectCommandInput): Promise<GetObjectCommandOutput> => {
+    return this.s3Request<GetObjectCommandInput, GetObjectCommandOutput>(S3Command.GET_OBJECT, getObjectInput);
+  };
+
   public putObject = async (putObjectInput: PutObjectCommandInput): Promise<PutObjectCommandOutput> => {
     return this.s3Request<PutObjectCommandInput, PutObjectCommandOutput>(S3Command.PUT_OBJECT, putObjectInput);
   };
@@ -236,6 +244,8 @@ export class S3Service {
         return new ListObjectsV2Command(data as ListObjectsV2CommandInput);
       case S3Command.HEAD_OBJECT:
         return new HeadObjectCommand(data as HeadObjectCommandInput);
+      case S3Command.GET_OBJECT:
+        return new GetObjectCommand(data as GetObjectCommandInput);
       case S3Command.PUT_OBJECT:
         return new PutObjectCommand(data as PutObjectCommandInput);
       // Multi-Part S3 Upload Commands

--- a/packages/back-end/src/app/services/s3-service.ts
+++ b/packages/back-end/src/app/services/s3-service.ts
@@ -157,7 +157,7 @@ export class S3Service {
   };
 
   public getPreSignedDownloadUrl = async (getObjectInput: GetObjectCommandInput): Promise<string> => {
-    return getSignedUrl(this.s3Client, this.getS3Command(S3Command.GET_OBJECT, getObjectInput), { expiresIn: 3600 });
+    return getSignedUrl(this.s3Client, this.getS3Command(S3Command.GET_OBJECT, getObjectInput), { expiresIn: 60 });
   };
 
   public doesObjectExist = async (headObjectInput: HeadObjectCommandInput): Promise<boolean> => {

--- a/packages/back-end/src/app/services/s3-service.ts
+++ b/packages/back-end/src/app/services/s3-service.ts
@@ -153,8 +153,7 @@ export class S3Service {
   };
 
   public getPreSignedUploadUrl = async (putObjectInput: PutObjectCommandInput): Promise<string> => {
-    const putObjectCommand: PutObjectCommand = new PutObjectCommand(putObjectInput);
-    return getSignedUrl(this.s3Client, putObjectCommand, { expiresIn: 3600 });
+    return getSignedUrl(this.s3Client, this.getS3Command(S3Command.PUT_OBJECT, putObjectInput), { expiresIn: 3600 });
   };
 
   public doesObjectExist = async (headObjectInput: HeadObjectCommandInput): Promise<boolean> => {

--- a/packages/back-end/src/app/services/s3-service.ts
+++ b/packages/back-end/src/app/services/s3-service.ts
@@ -156,6 +156,10 @@ export class S3Service {
     return getSignedUrl(this.s3Client, this.getS3Command(S3Command.PUT_OBJECT, putObjectInput), { expiresIn: 3600 });
   };
 
+  public getPreSignedDownloadUrl = async (getObjectInput: GetObjectCommandInput): Promise<string> => {
+    return getSignedUrl(this.s3Client, this.getS3Command(S3Command.GET_OBJECT, getObjectInput), { expiresIn: 3600 });
+  };
+
   public doesObjectExist = async (headObjectInput: HeadObjectCommandInput): Promise<boolean> => {
     try {
       const response = await this.s3Request<HeadObjectCommandInput, HeadObjectCommandOutput>(

--- a/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
@@ -692,6 +692,22 @@ export class EasyGenomicsNestedStack extends NestedStack {
       }),
     ]);
 
+    // /easy-genomics/files/request-file-download
+    this.iam.addPolicyStatements('/easy-genomics/files/request-file-download', [
+      new PolicyStatement({
+        resources: [
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table`,
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table/index/*`,
+        ],
+        actions: ['dynamodb:Query'],
+      }),
+      new PolicyStatement({
+        resources: ['arn:aws:s3:::*/*'],
+        actions: ['s3:GetObject'], // Required to generate pre-signed S3 Urls for uploading with GetObject request
+        effect: Effect.ALLOW,
+      }),
+    ]);
+
     // /easy-genomics/upload/create-file-upload-request
     this.iam.addPolicyStatements('/easy-genomics/upload/create-file-upload-request', [
       new PolicyStatement({

--- a/packages/shared-lib/src/app/schema/easy-genomics/files/request-file-download.ts
+++ b/packages/shared-lib/src/app/schema/easy-genomics/files/request-file-download.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+// request-file-download API request validation schemas
+
+export const RequestFileDownloadSchema = z
+  .object({
+    LaboratoryId: z.string(),
+    Path: z.string(),
+    FileName: z.string().optional(),
+    MimeType: z.string().optional(),
+    Size: z.number().optional(),
+  })
+  .strict();

--- a/packages/shared-lib/src/app/types/easy-genomics/files/request-file-download.d.ts
+++ b/packages/shared-lib/src/app/types/easy-genomics/files/request-file-download.d.ts
@@ -1,0 +1,12 @@
+// request-file-download API type definition
+export type RequestFileDownload = {
+  LaboratoryId: string;
+  Path: string;
+  FileName?: string;
+  MimeType?: string;
+  Size?: number;
+};
+
+export type FileDownloadResponse = {
+  DownloadUrl: string;
+}

--- a/packages/shared-lib/src/app/utils/HttpError.ts
+++ b/packages/shared-lib/src/app/utils/HttpError.ts
@@ -239,6 +239,17 @@ export class LaboratoryUserNotFoundError extends HttpError {
   }
 }
 
+/**
+ * Laboratory Bucket not found
+ *
+ * @param laboratoryId
+ */
+export class LaboratoryBucketNotFoundError extends HttpError {
+  constructor(laboratoryId: string) {
+    super(`Laboratory '${laboratoryId}' S3 Bucket could not be found`, 404, 'EG-314');
+  }
+}
+
 // User Errors
 
 /**


### PR DESCRIPTION
This PR adds the POST `/easy-genomics/files/request-file-download` API and it requires the JSON payload:

```
{
    "LaboratoryId": "<< Laboratory ID >>",
    "Path": "<< File Path / S3 Key >>"
}
```

It returns:
```
{
    "DownloadUrl": "<< Pre-Signed S3 URL >>"
}
```

The `DownloadUrl` is set to expire after 60 seconds.

The LaboratoryId is used to:
1. Verify if the User calling the API has access to the Laboratory
2. Retrieve the S3 Bucket for the Laboratory to generate the Pre-signed S3 URL to obtain the file

---

The existing `/easy-genomics/upload/...` APIs should be refactored to sit in the `/easy-genomics/files/...` path for logical grouping. This will need to be done in a separate ticket / PR.

Additionally, the `validateLaboratoryManagerAccess()` and `validateLaboratoryTechnicianAccess()` validation helper functions can be refactored and simplified to something:

```
export function validateLaboratoryUserAccess(event: APIGatewayProxyEvent, organizationId: string, laboratoryId: string, isLabManager?: boolean, isLabTechnician?: boolean) {
  ...
}
```

Again this can be done in a separate ticket / PR.