### PR TITLE
feat: restrict laboratories by organizational access

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/list-laboratories.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/list-laboratories.lambda.ts
@@ -1,8 +1,18 @@
 import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
 import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/src/app/utils/common';
-import { NoLabratoriesFoundError, RequiredIdNotFoundError } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
+import {
+  NoLabratoriesFoundError,
+  RequiredIdNotFoundError,
+  UnauthorizedAccessError,
+} from '@easy-genomics/shared-lib/src/app/utils/HttpError';
 import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
+import {
+  getLaboratoryAccessLaboratoryIds,
+  validateOrganizationAccess,
+  validateOrganizationAdminAccess,
+  validateSystemAdminAccess,
+} from '@BE/utils/auth-utils';
 
 const laboratoryService = new LaboratoryService();
 
@@ -15,7 +25,18 @@ export const handler: Handler = async (
     const organizationId: string | undefined = event.queryStringParameters?.organizationId;
     if (!organizationId) throw new RequiredIdNotFoundError();
 
-    const response: Laboratory[] = await laboratoryService.queryByOrganizationId(organizationId);
+    if (!validateSystemAdminAccess(event) && !validateOrganizationAccess(event, organizationId)) {
+      throw new UnauthorizedAccessError();
+    }
+
+    var response: Laboratory[] = await laboratoryService.queryByOrganizationId(organizationId);
+
+    if (validateSystemAdminAccess(event) || validateOrganizationAdminAccess(event, organizationId)) {
+      // System Admins and Organization admins see all laboratories for their organization
+    } else {
+      const laboratoryIds = getLaboratoryAccessLaboratoryIds(event, organizationId);
+      response = response.filter((lab: Laboratory) => laboratoryIds.includes(lab.LaboratoryId));
+    }
 
     if (response) {
       return buildResponse(200, JSON.stringify(response), event);

--- a/packages/back-end/src/app/utils/auth-utils.ts
+++ b/packages/back-end/src/app/utils/auth-utils.ts
@@ -32,6 +32,31 @@ export function getOrganizationAccessOrganizationIds(event: APIGatewayProxyEvent
 }
 
 /**
+ * Helper function to return the User's LaboratoryAccess LaboratoryIds.
+ * @param event
+ */
+export function getLaboratoryAccessLaboratoryIds(event: APIGatewayProxyEvent, organizationId: string): string[] {
+  const orgAccessMetadata: string | undefined = event.requestContext.authorizer?.claims?.OrganizationAccess;
+  if (!orgAccessMetadata) {
+    return [];
+  }
+
+  const organizationAccess: OrganizationAccess = JSON.parse(orgAccessMetadata);
+  const organizationAccessDetails: OrganizationAccessDetails | undefined = organizationAccess[organizationId];
+  if (
+    !organizationAccessDetails ||
+    organizationAccessDetails.Status != 'Active' ||
+    !organizationAccessDetails.LaboratoryAccess
+  ) {
+    return [];
+  }
+
+  const laboratoryAccess = organizationAccessDetails.LaboratoryAccess;
+
+  return Object.keys(laboratoryAccess).filter((key) => laboratoryAccess[key].Status == 'Active');
+}
+
+/**
  * Helper function to check if an authenticated User's JWT OrganizationAccess
  * metadata allows access to administrate the requested Organization
  * @param event

--- a/packages/back-end/test/app/utils/auth-utils.test.ts
+++ b/packages/back-end/test/app/utils/auth-utils.test.ts
@@ -1,0 +1,256 @@
+import { OrganizationAccess } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/user';
+import { APIGatewayProxyEvent } from 'aws-lambda/trigger/api-gateway-proxy';
+import { getLaboratoryAccessLaboratoryIds } from '../../../src/app/utils/auth-utils';
+
+describe('get laboratory access ids from authorizer claims', () => {
+  let mockEvent: APIGatewayProxyEvent = {
+    body: '',
+    headers: {},
+    multiValueHeaders: {},
+    httpMethod: 'GET',
+    path: '/test/',
+    isBase64Encoded: false,
+    pathParameters: {},
+    queryStringParameters: {},
+    multiValueQueryStringParameters: {},
+    stageVariables: {},
+    resource: '',
+    requestContext: {
+      accountId: '',
+      authorizer: {},
+      protocol: '',
+      httpMethod: '',
+      identity: {
+        accessKey: '',
+        accountId: '',
+        apiKey: '',
+        apiKeyId: '',
+        caller: '',
+        clientCert: {
+          serialNumber: '',
+          clientCertPem: '',
+          subjectDN: '',
+          issuerDN: '',
+          validity: {
+            notAfter: '',
+            notBefore: '',
+          },
+        },
+        cognitoAuthenticationProvider: '',
+        cognitoAuthenticationType: '',
+        cognitoIdentityId: '',
+        cognitoIdentityPoolId: '',
+        principalOrgId: '',
+        sourceIp: '',
+        user: '',
+        userAgent: '',
+        userArn: '',
+      },
+      path: '',
+      stage: '',
+      apiId: '',
+      requestId: '',
+      requestTimeEpoch: 0,
+      resourceId: '',
+      resourcePath: '',
+    },
+  };
+
+  it('No claims, should be empty', () => {
+    const organizationId = 'b237c754-19d0-41bc-a2ca-b1736fc51413';
+    mockEvent.requestContext.authorizer = {};
+    expect(getLaboratoryAccessLaboratoryIds(mockEvent, organizationId)).toEqual([]);
+  });
+
+  it('Empty claims, should be empty', () => {
+    const organizationId = 'b237c754-19d0-41bc-a2ca-b1736fc51413';
+    mockEvent.requestContext.authorizer = {
+      claims: {},
+    };
+    expect(getLaboratoryAccessLaboratoryIds(mockEvent, organizationId)).toEqual([]);
+  });
+
+  it('Empty Org Access, should be empty', () => {
+    const organizationId = 'b237c754-19d0-41bc-a2ca-b1736fc51413';
+    const organizationAccess: OrganizationAccess = {};
+    mockEvent.requestContext.authorizer = {
+      claims: {
+        OrganizationAccess: JSON.stringify(organizationAccess),
+      },
+    };
+    expect(getLaboratoryAccessLaboratoryIds(mockEvent, organizationId)).toEqual([]);
+  });
+
+  it('Org Access but not for request organizationId, should be empty', () => {
+    const organizationId = 'b237c754-19d0-41bc-a2ca-b1736fc51413';
+    const organizationAccess: OrganizationAccess = {
+      'da47e581-834b-4eb4-9c8d-23e83767522d': {
+        Status: 'Active',
+      },
+    };
+    mockEvent.requestContext.authorizer = {
+      claims: {
+        OrganizationAccess: JSON.stringify(organizationAccess),
+      },
+    };
+    expect(getLaboratoryAccessLaboratoryIds(mockEvent, organizationId)).toEqual([]);
+  });
+
+  it('Org Access but no laboratories, should be empty', () => {
+    const organizationId = 'b237c754-19d0-41bc-a2ca-b1736fc51413';
+    const organizationAccess: OrganizationAccess = {
+      'b237c754-19d0-41bc-a2ca-b1736fc51413': {
+        Status: 'Active',
+        LaboratoryAccess: {},
+      },
+    };
+    mockEvent.requestContext.authorizer = {
+      claims: {
+        OrganizationAccess: JSON.stringify(organizationAccess),
+      },
+    };
+    expect(getLaboratoryAccessLaboratoryIds(mockEvent, organizationId)).toEqual([]);
+  });
+
+  it('Org Access with one laboratory, return one laboratoryId', () => {
+    const organizationId = 'b237c754-19d0-41bc-a2ca-b1736fc51413';
+    const organizationAccess: OrganizationAccess = {
+      'b237c754-19d0-41bc-a2ca-b1736fc51413': {
+        Status: 'Active',
+        LaboratoryAccess: {
+          '21072469-c909-43b9-9471-42b78b054ca2': {
+            Status: 'Active',
+          },
+        },
+      },
+    };
+    mockEvent.requestContext.authorizer = {
+      claims: {
+        OrganizationAccess: JSON.stringify(organizationAccess),
+      },
+    };
+    expect(getLaboratoryAccessLaboratoryIds(mockEvent, organizationId)).toEqual([
+      '21072469-c909-43b9-9471-42b78b054ca2',
+    ]);
+  });
+
+  it('Ignore Org Access with Inactive Status', () => {
+    const organizationId = 'b237c754-19d0-41bc-a2ca-b1736fc51413';
+    const organizationAccess: OrganizationAccess = {
+      'b237c754-19d0-41bc-a2ca-b1736fc51413': {
+        Status: 'Inactive',
+        LaboratoryAccess: {
+          '21072469-c909-43b9-9471-42b78b054ca2': {
+            Status: 'Active',
+          },
+        },
+      },
+    };
+    mockEvent.requestContext.authorizer = {
+      claims: {
+        OrganizationAccess: JSON.stringify(organizationAccess),
+      },
+    };
+    expect(getLaboratoryAccessLaboratoryIds(mockEvent, organizationId)).toEqual([]);
+  });
+
+  it('Ignore Org Access with Invited Status', () => {
+    const organizationId = 'b237c754-19d0-41bc-a2ca-b1736fc51413';
+    const organizationAccess: OrganizationAccess = {
+      'b237c754-19d0-41bc-a2ca-b1736fc51413': {
+        Status: 'Invited',
+        LaboratoryAccess: {
+          '21072469-c909-43b9-9471-42b78b054ca2': {
+            Status: 'Active',
+          },
+        },
+      },
+    };
+    mockEvent.requestContext.authorizer = {
+      claims: {
+        OrganizationAccess: JSON.stringify(organizationAccess),
+      },
+    };
+    expect(getLaboratoryAccessLaboratoryIds(mockEvent, organizationId)).toEqual([]);
+  });
+
+  it('Org Access with multiple laboratories, return multiple laboratoryId', () => {
+    const organizationId = 'b237c754-19d0-41bc-a2ca-b1736fc51413';
+    const organizationAccess: OrganizationAccess = {
+      'b237c754-19d0-41bc-a2ca-b1736fc51413': {
+        Status: 'Active',
+        LaboratoryAccess: {
+          '21072469-c909-43b9-9471-42b78b054ca2': {
+            Status: 'Active',
+          },
+          '41002720-9dc0-4c95-b06e-432d9c9cf757': {
+            Status: 'Active',
+          },
+          '322eec6c-1b92-47c1-b79f-dea510ddf2dc': {
+            Status: 'Active',
+          },
+        },
+      },
+    };
+    mockEvent.requestContext.authorizer = {
+      claims: {
+        OrganizationAccess: JSON.stringify(organizationAccess),
+      },
+    };
+    expect(getLaboratoryAccessLaboratoryIds(mockEvent, organizationId).sort()).toEqual(
+      [
+        '21072469-c909-43b9-9471-42b78b054ca2',
+        '322eec6c-1b92-47c1-b79f-dea510ddf2dc',
+        '41002720-9dc0-4c95-b06e-432d9c9cf757',
+      ].sort(),
+    );
+  });
+
+  it('Ignore laboratories from other organizations, should be empty', () => {
+    const organizationId = 'b237c754-19d0-41bc-a2ca-b1736fc51413';
+    const organizationAccess: OrganizationAccess = {
+      'da47e581-834b-4eb4-9c8d-23e83767522d': {
+        Status: 'Active',
+        LaboratoryAccess: {
+          '11072469-c909-43b9-9471-42b78b054ca2': {
+            Status: 'Active',
+          },
+        },
+      },
+    };
+    mockEvent.requestContext.authorizer = {
+      claims: {
+        OrganizationAccess: JSON.stringify(organizationAccess),
+      },
+    };
+    expect(getLaboratoryAccessLaboratoryIds(mockEvent, organizationId)).toEqual([]);
+  });
+
+  it('Ignore LaboratoryAccess with Inactive Status', () => {
+    const organizationId = 'b237c754-19d0-41bc-a2ca-b1736fc51413';
+    const organizationAccess: OrganizationAccess = {
+      'b237c754-19d0-41bc-a2ca-b1736fc51413': {
+        Status: 'Active',
+        LaboratoryAccess: {
+          '21072469-c909-43b9-9471-42b78b054ca2': {
+            Status: 'Active',
+          },
+          '41002720-9dc0-4c95-b06e-432d9c9cf757': {
+            Status: 'Inactive',
+          },
+          '322eec6c-1b92-47c1-b79f-dea510ddf2dc': {
+            Status: 'Active',
+          },
+        },
+      },
+    };
+    mockEvent.requestContext.authorizer = {
+      claims: {
+        OrganizationAccess: JSON.stringify(organizationAccess),
+      },
+    };
+    expect(getLaboratoryAccessLaboratoryIds(mockEvent, organizationId).sort()).toEqual(
+      ['21072469-c909-43b9-9471-42b78b054ca2', '322eec6c-1b92-47c1-b79f-dea510ddf2dc'].sort(),
+    );
+  });
+});


### PR DESCRIPTION
Super Admins and Organizational Admins can get a list of all laboratories.

For all other users, they will need Laboratory Access to see the laboratories via the list-laboratories endpoint.