### PR TITLE
fix: incorrect operator was used for user access

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/files/request-file-download.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/files/request-file-download.lambda.ts
@@ -45,9 +45,11 @@ export const handler: Handler = async (
 
     // Only Organisation Admins and Laboratory Members are allowed to edit laboratories
     if (
-      !validateOrganizationAdminAccess(event, laboratory.OrganizationId) ||
-      !validateLaboratoryManagerAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId) ||
-      !validateLaboratoryTechnicianAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId)
+      !(
+        validateOrganizationAdminAccess(event, laboratory.OrganizationId) ||
+        validateLaboratoryManagerAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId) ||
+        validateLaboratoryTechnicianAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId)
+      )
     ) {
       throw new UnauthorizedAccessError();
     }

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/list-laboratories.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/list-laboratories.lambda.ts
@@ -25,7 +25,7 @@ export const handler: Handler = async (
     const organizationId: string | undefined = event.queryStringParameters?.organizationId;
     if (!organizationId) throw new RequiredIdNotFoundError();
 
-    if (!validateSystemAdminAccess(event) && !validateOrganizationAccess(event, organizationId)) {
+    if (!(validateSystemAdminAccess(event) || validateOrganizationAccess(event, organizationId))) {
       throw new UnauthorizedAccessError();
     }
 

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/read-laboratory.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/read-laboratory.lambda.ts
@@ -25,8 +25,10 @@ export const handler: Handler = async (
 
     // Users with access to the Laboratory can view the organization
     if (
-      !validateOrganizationAdminAccess(event, existing.OrganizationId) &&
-      !validateOrganizationAccess(event, existing.OrganizationId, existing.LaboratoryId)
+      !(
+        validateOrganizationAdminAccess(event, existing.OrganizationId) ||
+        validateOrganizationAccess(event, existing.OrganizationId, existing.LaboratoryId)
+      )
     ) {
       throw new UnauthorizedAccessError();
     }

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/update-laboratory.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/update-laboratory.lambda.ts
@@ -44,7 +44,7 @@ export const handler: Handler = async (
 
     // Only Organisation Admins and Laboratory Managers are allowed to edit laboratories
     if (
-      !validateOrganizationAdminAccess(event, existing.OrganizationId) ||
+      !validateOrganizationAdminAccess(event, existing.OrganizationId) &&
       !validateLaboratoryManagerAccess(event, existing.OrganizationId, existing.LaboratoryId)
     ) {
       throw new UnauthorizedAccessError();

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/update-laboratory.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/update-laboratory.lambda.ts
@@ -44,8 +44,10 @@ export const handler: Handler = async (
 
     // Only Organisation Admins and Laboratory Managers are allowed to edit laboratories
     if (
-      !validateOrganizationAdminAccess(event, existing.OrganizationId) &&
-      !validateLaboratoryManagerAccess(event, existing.OrganizationId, existing.LaboratoryId)
+      !(
+        validateOrganizationAdminAccess(event, existing.OrganizationId) ||
+        validateLaboratoryManagerAccess(event, existing.OrganizationId, existing.LaboratoryId)
+      )
     ) {
       throw new UnauthorizedAccessError();
     }

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/update-laboratory.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/update-laboratory.lambda.ts
@@ -16,7 +16,7 @@ import {
 import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
 import { SsmService } from '@BE/services/ssm-service';
-import { validateOrganizationAdminAccess, validateLaboratoryManagerAccess } from '@BE/utils/auth-utils';
+import { validateOrganizationAdminAccess } from '@BE/utils/auth-utils';
 import { httpRequest, REST_API_METHOD } from '@BE/utils/rest-api-utils';
 
 const laboratoryService = new LaboratoryService();
@@ -42,13 +42,8 @@ export const handler: Handler = async (
     // Lookup by LaboratoryId to confirm existence before updating
     const existing: Laboratory = await laboratoryService.queryByLaboratoryId(id);
 
-    // Only Organisation Admins and Laboratory Managers are allowed to edit laboratories
-    if (
-      !(
-        validateOrganizationAdminAccess(event, existing.OrganizationId) ||
-        validateLaboratoryManagerAccess(event, existing.OrganizationId, existing.LaboratoryId)
-      )
-    ) {
+    // Only Organisation Admins are allowed to edit laboratories
+    if (validateOrganizationAdminAccess(event, existing.OrganizationId)) {
       throw new UnauthorizedAccessError();
     }
 

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/user/add-laboratory-user.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/user/add-laboratory-user.lambda.ts
@@ -50,7 +50,7 @@ export const handler: Handler = async (
 
     // Only Organisation Admins and Laboratory Managers are allowed to edit laboratories
     if (
-      !validateOrganizationAdminAccess(event, laboratory.OrganizationId) ||
+      !validateOrganizationAdminAccess(event, laboratory.OrganizationId) &&
       !validateLaboratoryManagerAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId)
     ) {
       throw new UnauthorizedAccessError();

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/user/add-laboratory-user.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/user/add-laboratory-user.lambda.ts
@@ -50,8 +50,10 @@ export const handler: Handler = async (
 
     // Only Organisation Admins and Laboratory Managers are allowed to edit laboratories
     if (
-      !validateOrganizationAdminAccess(event, laboratory.OrganizationId) &&
-      !validateLaboratoryManagerAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId)
+      !(
+        validateOrganizationAdminAccess(event, laboratory.OrganizationId) ||
+        validateLaboratoryManagerAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId)
+      )
     ) {
       throw new UnauthorizedAccessError();
     }

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/user/edit-laboratory-user.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/user/edit-laboratory-user.lambda.ts
@@ -45,8 +45,10 @@ export const handler: Handler = async (
 
     // Only Organisation Admins and Laboratory Managers are allowed to create workflows
     if (
-      !validateOrganizationAdminAccess(event, laboratory.OrganizationId) &&
-      !validateLaboratoryManagerAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId)
+      !(
+        validateOrganizationAdminAccess(event, laboratory.OrganizationId) ||
+        validateLaboratoryManagerAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId)
+      )
     ) {
       throw new UnauthorizedAccessError();
     }

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/user/edit-laboratory-user.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/user/edit-laboratory-user.lambda.ts
@@ -45,7 +45,7 @@ export const handler: Handler = async (
 
     // Only Organisation Admins and Laboratory Managers are allowed to create workflows
     if (
-      !validateOrganizationAdminAccess(event, laboratory.OrganizationId) ||
+      !validateOrganizationAdminAccess(event, laboratory.OrganizationId) &&
       !validateLaboratoryManagerAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId)
     ) {
       throw new UnauthorizedAccessError();

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/user/remove-laboratory-user.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/user/remove-laboratory-user.lambda.ts
@@ -42,8 +42,10 @@ export const handler: Handler = async (
 
     // Only Organisation Admins and Laboratory Managers are allowed to edit laboratories
     if (
-      !validateOrganizationAdminAccess(event, laboratory.OrganizationId) &&
-      !validateLaboratoryManagerAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId)
+      !(
+        validateOrganizationAdminAccess(event, laboratory.OrganizationId) ||
+        validateLaboratoryManagerAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId)
+      )
     ) {
       throw new UnauthorizedAccessError();
     }

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/user/remove-laboratory-user.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/user/remove-laboratory-user.lambda.ts
@@ -42,7 +42,7 @@ export const handler: Handler = async (
 
     // Only Organisation Admins and Laboratory Managers are allowed to edit laboratories
     if (
-      !validateOrganizationAdminAccess(event, laboratory.OrganizationId) ||
+      !validateOrganizationAdminAccess(event, laboratory.OrganizationId) &&
       !validateLaboratoryManagerAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId)
     ) {
       throw new UnauthorizedAccessError();

--- a/packages/back-end/src/app/controllers/easy-genomics/organization/read-organization.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/organization/read-organization.lambda.ts
@@ -17,7 +17,7 @@ export const handler: Handler = async (
     if (id === '') throw new RequiredIdNotFoundError();
 
     // Only System Admins or Users with access to the Organization can view the organization
-    if (!validateSystemAdminAccess(event) && !validateOrganizationAccess(event, id)) {
+    if (!(validateSystemAdminAccess(event) || validateOrganizationAccess(event, id))) {
       throw new UnauthorizedAccessError();
     }
 

--- a/packages/back-end/src/app/controllers/easy-genomics/organization/update-organization.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/organization/update-organization.lambda.ts
@@ -24,7 +24,7 @@ export const handler: Handler = async (
     if (id === '') throw new RequiredIdNotFoundError();
 
     // Only System Admins or Organisation Admins allowed
-    if (!validateSystemAdminAccess(event) && !validateOrganizationAdminAccess(event, id)) {
+    if (!(validateSystemAdminAccess(event) || validateOrganizationAdminAccess(event, id))) {
       throw new UnauthorizedAccessError();
     }
 

--- a/packages/back-end/src/app/controllers/easy-genomics/organization/user/add-organization-user.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/organization/user/add-organization-user.lambda.ts
@@ -35,7 +35,7 @@ export const handler: Handler = async (
     if (!AddOrganizationUserSchema.safeParse(request).success) throw new InvalidRequestError();
 
     // Only System Admins or Organisation Admins are allowed to add Org users
-    if (!validateSystemAdminAccess(event) && !validateOrganizationAdminAccess(event, request.OrganizationId)) {
+    if (!(validateSystemAdminAccess(event) || validateOrganizationAdminAccess(event, request.OrganizationId))) {
       throw new UnauthorizedAccessError();
     }
 

--- a/packages/back-end/src/app/controllers/easy-genomics/organization/user/edit-organization-user.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/organization/user/edit-organization-user.lambda.ts
@@ -35,7 +35,7 @@ export const handler: Handler = async (
     if (!EditOrganizationUserSchema.safeParse(request).success) throw new InvalidRequestError();
 
     // Only System Admins or Organisation Admins are allowed to add Org users
-    if (!validateSystemAdminAccess(event) && !validateOrganizationAdminAccess(event, request.OrganizationId)) {
+    if (!(validateSystemAdminAccess(event) || validateOrganizationAdminAccess(event, request.OrganizationId))) {
       throw new UnauthorizedAccessError();
     }
 

--- a/packages/back-end/src/app/controllers/easy-genomics/organization/user/remove-organization-user.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/organization/user/remove-organization-user.lambda.ts
@@ -25,7 +25,7 @@ export const handler: Handler = async (
     if (!RemoveOrganizationUserSchema.safeParse(request).success) throw new InvalidRequestError();
 
     // Only System Admins or Organisation Admins are allowed to remove Org users
-    if (!validateSystemAdminAccess(event) && !validateOrganizationAdminAccess(event, request.OrganizationId)) {
+    if (!(validateSystemAdminAccess(event) || validateOrganizationAdminAccess(event, request.OrganizationId))) {
       throw new UnauthorizedAccessError();
     }
 

--- a/packages/back-end/src/app/controllers/easy-genomics/organization/user/request-organization-user.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/organization/user/request-organization-user.lambda.ts
@@ -18,7 +18,7 @@ export const handler: Handler = async (
     // Data validation safety check
     if (!RequestOrganizationUserSchema.safeParse(request).success) throw new InvalidRequestError();
 
-    if (!validateSystemAdminAccess(event) && !validateOrganizationAdminAccess(event, request.OrganizationId)) {
+    if (!(validateSystemAdminAccess(event) || validateOrganizationAdminAccess(event, request.OrganizationId))) {
       throw new UnauthorizedAccessError();
     }
 


### PR DESCRIPTION
I made a mistake with the user access when adding lab manager restrictions. The validation check should be failing if neither of the requirements are met, not either of them.