### PR TITLE
fix(EG-729): resolve NextFlow launch Run error

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/upload/create-file-upload-request.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/upload/create-file-upload-request.lambda.ts
@@ -95,9 +95,11 @@ export const handler: Handler = async (
           throw new Error(`File size is too large: '${file.Name}'`);
         } else {
           /**
-           * The S3 Key will consist of: uploads/{laboratoryId}/{transactionId}/{file name}
+           * The S3 Key will consist of: {organizationId}/{laboratoryId}/next-flow/{transactionId}/{file name}
            */
-          const s3Key: string = `uploads/${laboratoryId}/${transactionId}/${file.Name}`;
+          const s3Path: string = `${laboratory.OrganizationId}/${laboratory.LaboratoryId}/next-flow/${transactionId}`;
+          const s3Key: string = `${s3Path}/${file.Name}`;
+
           const preSignedUrl = await s3Service.getPreSignedUploadUrl({
             Bucket: s3Bucket,
             Key: s3Key,

--- a/packages/back-end/src/app/controllers/easy-genomics/upload/create-file-upload-sample-sheet.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/upload/create-file-upload-sample-sheet.lambda.ts
@@ -53,7 +53,8 @@ export const handler: Handler = async (
       throw new Error(`Laboratory ${laboratoryId} S3 Bucket needs to be configured`);
     }
 
-    const s3Key: string = `uploads/${laboratoryId}/${transactionId}/sample-sheet.csv`;
+    const s3Path: string = `${laboratory.OrganizationId}/${laboratory.LaboratoryId}/next-flow/${transactionId}`;
+    const s3Key: string = `${s3Path}/sample-sheet.csv`;
     const s3Url: string = `s3://${s3Bucket}/${s3Key}`;
     const bucketLocation = (await s3Service.getBucketLocation({ Bucket: s3Bucket })).LocationConstraint;
 
@@ -85,6 +86,7 @@ export const handler: Handler = async (
           Checksum: sampleSheetCsvChecksum,
           Bucket: s3Bucket,
           Key: s3Key,
+          Path: s3Path,
           Region: s3Region,
           S3Url: s3Url,
         },

--- a/packages/front-end/src/app/components/EGRunPipelineFormEditParameters.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineFormEditParameters.vue
@@ -18,6 +18,7 @@
     params: {
       ...props.params,
       input: pipelineRunStore.sampleSheetS3Url,
+      outdir: `s3://${usePipelineRunStore().s3Bucket}/${usePipelineRunStore().s3Path}/results`,
     },
   });
 

--- a/packages/front-end/src/app/components/EGRunPipelineFormEditParameters.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineFormEditParameters.vue
@@ -17,7 +17,7 @@
     schema: props.schema,
     params: {
       ...props.params,
-      input: pipelineRunStore.S3Url,
+      input: pipelineRunStore.sampleSheetS3Url,
     },
   });
 

--- a/packages/front-end/src/app/components/EGRunPipelineFormUploadData.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineFormUploadData.vue
@@ -283,8 +283,7 @@
     const uploadedFilePairs: UploadedFilePairInfo[] = getUploadedFilePairs(uploadManifest);
     const sampleSheetResponse: SampleSheetResponse = await getSampleSheetCsv(uploadedFilePairs);
     usePipelineRunStore().setSampleSheetCsv(sampleSheetResponse.SampleSheetContents);
-    usePipelineRunStore().setS3Url(sampleSheetResponse.SampleSheetInfo.S3Url);
-
+    usePipelineRunStore().setSampleSheetS3Url(sampleSheetResponse.SampleSheetInfo.S3Url);
     canProceed.value = true;
   }
 

--- a/packages/front-end/src/app/components/EGRunPipelineFormUploadData.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineFormUploadData.vue
@@ -284,6 +284,8 @@
     const sampleSheetResponse: SampleSheetResponse = await getSampleSheetCsv(uploadedFilePairs);
     usePipelineRunStore().setSampleSheetCsv(sampleSheetResponse.SampleSheetContents);
     usePipelineRunStore().setSampleSheetS3Url(sampleSheetResponse.SampleSheetInfo.S3Url);
+    usePipelineRunStore().setS3Bucket(sampleSheetResponse.SampleSheetInfo.Bucket);
+    usePipelineRunStore().setS3Path(sampleSheetResponse.SampleSheetInfo.Path);
     canProceed.value = true;
   }
 

--- a/packages/front-end/src/app/components/EGRunPipelineParameterInputs.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineParameterInputs.vue
@@ -72,7 +72,7 @@
           propertyName === 'input'
         "
       >
-        <EGInput name="input" v-model="pipelineRunStore.S3Url" />
+        <EGInput name="input" v-model="pipelineRunStore.sampleSheetS3Url" />
       </template>
     </div>
   </div>

--- a/packages/front-end/src/app/composables/usePipeline.ts
+++ b/packages/front-end/src/app/composables/usePipeline.ts
@@ -20,7 +20,7 @@ export default function usePipeline() {
   }
 
   const doesFileUrlExist = computed(() => {
-    return !!(usePipelineRunStore().S3Url || usePipelineRunStore().params?.input);
+    return !!(usePipelineRunStore().sampleSheetS3Url || usePipelineRunStore().params?.input);
   });
 
   /**

--- a/packages/front-end/src/app/stores/pipeline-run.ts
+++ b/packages/front-end/src/app/stores/pipeline-run.ts
@@ -12,6 +12,8 @@ export const pipelineRunStateSchema = z.object({
   params: z.object({}),
   sampleSheetCsv: z.string(),
   sampleSheetS3Url: z.string(),
+  s3Bucket: z.string(),
+  s3Path: z.string(),
 });
 export type PipeLineRunState = z.infer<typeof pipelineRunStateSchema>;
 
@@ -26,6 +28,8 @@ const initialState = (): PipeLineRunState => ({
   params: {},
   sampleSheetCsv: '',
   sampleSheetS3Url: '',
+  s3Bucket: '',
+  s3Path: '',
 });
 
 const usePipelineRunStore = defineStore('pipelineRunStore', {
@@ -70,6 +74,14 @@ const usePipelineRunStore = defineStore('pipelineRunStore', {
 
     setSampleSheetS3Url(path: string) {
       this.sampleSheetS3Url = path;
+    },
+
+    setS3Bucket(bucket: string) {
+      this.s3Bucket = bucket;
+    },
+
+    setS3Path(path: string) {
+      this.s3Path = path;
     },
 
     reset() {

--- a/packages/front-end/src/app/stores/pipeline-run.ts
+++ b/packages/front-end/src/app/stores/pipeline-run.ts
@@ -11,15 +11,7 @@ export const pipelineRunStateSchema = z.object({
   userPipelineRunName: z.string(),
   params: z.object({}),
   sampleSheetCsv: z.string(),
-  S3Url: z.string(),
-  // s3 path of uploaded file
-  // csv file
-  // org
-  // lab
-  // user
-  // date and time?
-  // pipeline default parameters
-  // run parameters
+  sampleSheetS3Url: z.string(),
 });
 export type PipeLineRunState = z.infer<typeof pipelineRunStateSchema>;
 
@@ -33,7 +25,7 @@ const initialState = (): PipeLineRunState => ({
   userPipelineRunName: '',
   params: {},
   sampleSheetCsv: '',
-  S3Url: '',
+  sampleSheetS3Url: '',
 });
 
 const usePipelineRunStore = defineStore('pipelineRunStore', {
@@ -76,8 +68,8 @@ const usePipelineRunStore = defineStore('pipelineRunStore', {
       this.sampleSheetCsv = sampleSheetCsv;
     },
 
-    setS3Url(path: string) {
-      this.S3Url = path;
+    setSampleSheetS3Url(path: string) {
+      this.sampleSheetS3Url = path;
     },
 
     reset() {

--- a/packages/shared-lib/src/app/types/easy-genomics/upload/s3-file-upload-sample-sheet.d.ts
+++ b/packages/shared-lib/src/app/types/easy-genomics/upload/s3-file-upload-sample-sheet.d.ts
@@ -32,6 +32,7 @@ export type SampleSheetInfo = {
   Size: number;
   Checksum: string;
   Bucket: string;
+  Path: string;
   Key: string;
   Region: string;
   S3Url: string;


### PR DESCRIPTION
This PR makes the following changes in order to fix the NextFlow Launch Run request error:

1. Modify the existing `create-file-upload-request` and `create-file-upload-sample-sheet` APIs to adopt the new S3 Path format: 

`s3://${ Lab's Set S3 Bucket }/${ laboratory.OrganizationId }/${ laboratory.LaboratoryId }/next-flow/${ transactionId }`

2. The `create-file-upload-sample-sheet` API has also been modified to return the s3Bucket, and s3Path in order to reuse these details for the Pipeline's `outdir` and `workDir` parameter settings so that the processing and output files can all be saved in the same S3 transaction location along side the uploaded data files and sample-sheet.

3. The Pipeline Launch Step 3 UI will now set the `input` and `outdir` settings so the results can be saved alongside the uploaded files.

4. Updated the Pipeline Launch Step 4 logic to craft a `CreateWorkflowLaunchRequest` JSON payload instead of using the previous `DescribePipelineLaunchResponse` JSON payload in order to successfully launch a Pipeline.
   * The `CreateWorkflowLaunchRequest` JSON payload also sets the `workDir` so the Pipeline Run's generated working files are also saved along side the uploaded files and results.

| File | S3 URL | 
|-----|--------|
| Sample-sheet | `s3://${ Lab's Set S3 Bucket }/${ laboratory.OrganizationId }/${ laboratory.LaboratoryId }/next-flow/${ transactionId }/sample-sheet.csv` |
| Example uploaded Fastq data file | `s3://${ Lab's Set S3 Bucket }/${ laboratory.OrganizationId }/${ laboratory.LaboratoryId }/next-flow/${ transactionId }/example_uploaded_data_file.fastq` |
| workDir | `s3://${ Lab's Set S3 Bucket }/${ laboratory.OrganizationId }/${ laboratory.LaboratoryId }/next-flow/${ transactionId }/work` |
| outdir | `s3://${ Lab's Set S3 Bucket }/${ laboratory.OrganizationId }/${ laboratory.LaboratoryId }/next-flow/${ transactionId }/results` |

This has successfully launched Dr Kelsey Florek's Workshop Pipeline (https://github.com/k-florek/workshop), but the Pipeline Run has encountered processing errors with the sample-sheet. With regards to the Next-Flow Community Workspace Pipelines, the launched runs have been unsuccessful due to 403 unauthorized errors which needs further investigation.

NOTE: There is an existing bug with the Pipeline Launch Step 3 UI, where a manual change to any of the settings is not reflected in the Step 4 review summary. Only when the user goes back to Step 3 and then forward again to Step 4 will the param details be updated and displayed properly in the review summary / launch payload. I've created a separate ticket EG-768 to get this bug resolved.

