### PR TITLE
feat(EG-762): increase run name char limit

### DIFF
--- a/packages/front-end/src/app/components/EGLabDetailsForm.vue
+++ b/packages/front-end/src/app/components/EGLabDetailsForm.vue
@@ -353,7 +353,7 @@
   <UForm v-else :validate="validate" :schema="LabDetailsSchema" :state="state" @submit="onSubmit">
     <EGCard>
       <!-- Lab Name -->
-      <EGFormGroup label="Lab Name*" name="Name" eager-validation>
+      <EGFormGroup label="Lab Name" name="Name" eager-validation required>
         <EGInput
           v-model="state.Name"
           :disabled="isNameFieldDisabled"
@@ -374,8 +374,9 @@
 
       <EGFormGroup
         v-if="useUserStore().isOrgAdmin(useUserStore().currentOrgId)"
-        label="Default S3 bucket directory*"
+        label="Default S3 bucket directory"
         name="DefaultS3BucketDirectory"
+        required
       >
         <EGSelect
           :options="s3Directories"

--- a/packages/front-end/src/app/components/EGRunPipelineFormRunDetails.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineFormRunDetails.vue
@@ -30,13 +30,13 @@
    * viralrecon-illumina_community-showcase_20240712_5686910e783b4b2
    */
   const MAX_TOTAL_LENGTH = 80;
-  const maxRunNameLength = ref(MAX_TOTAL_LENGTH - props.pipelineName.length - 8 - 15 - 2);
+  const MAX_RUN_NAME_LENGTH = 50;
 
   const runNameSchema = z
     .string()
     .trim()
     .min(1, 'Pipeline run name must be at least 1 character')
-    .max(maxRunNameLength.value, `Pipeline run name must be ${maxRunNameLength.value} characters or less`);
+    .max(MAX_RUN_NAME_LENGTH, `Pipeline run name must be ${MAX_RUN_NAME_LENGTH} characters or less`);
 
   const formStateSchema = z.object({
     pipelineDescription: z.string(), // Seqera API spec doesn't define a max length for pipeline description
@@ -146,7 +146,7 @@
           @input.prevent="handleRunNameInput"
           autofocus
         />
-        <EGCharacterCounter :value="runNameCharCount" :max="maxRunNameLength" />
+        <EGCharacterCounter :value="runNameCharCount" :max="MAX_RUN_NAME_LENGTH" />
       </EGFormGroup>
 
       <EGFormGroup label="Description" name="pipelineDescription">


### PR DESCRIPTION
- Increases pipeline run name to 50 chars max
- Also makes some mandatory field names consistently styled. 