### PR TITLE
fix(EG-796): add Org description skeleton

### DIFF
--- a/packages/front-end/src/app/components/EGOrgView.vue
+++ b/packages/front-end/src/app/components/EGOrgView.vue
@@ -291,7 +291,7 @@
     :back-action="() => $router.push(adminPrefix + '/orgs')"
     :show-back="false"
     :is-loading="isLoading"
-    :skeleton-config="{ titleLines: 1, descriptionLines: 0 }"
+    :skeleton-config="{ titleLines: 1, descriptionLines: 1 }"
   >
     <EGButton label="Invite users" @click="() => (showInviteModule = !showInviteModule)" />
     <div class="mt-2 w-[500px]" v-if="showInviteModule">


### PR DESCRIPTION
Adds a single line skeleton loader for the Org description 