### PR TITLE
feat(EG-799): add timeout to EditOrg

### DIFF
--- a/packages/front-end/tests/e2e/EditOrg.spec.e2e.ts
+++ b/packages/front-end/tests/e2e/EditOrg.spec.e2e.ts
@@ -21,6 +21,7 @@ test('Update an Org Successfully', async ({ page, baseURL }) => {
     await page.getByPlaceholder('Describe your organization').fill('This is the default Organization back to original');
     await page.getByRole('button', { name: 'Save changes' }).click();
     await page.getByText('Organization updated', { exact: true }).isVisible();
+    await page.waitForTimeout(5000);
     await expect(page.getByText('Default Organization').nth(0)).toBeVisible();
     await expect(page.getByText('This is the default Organization back to original').nth(0)).toBeVisible();
   } else {


### PR DESCRIPTION
This is to address the timeout issue shown when running the EditOrg script
**EditOrg.spec.e2e.ts > Update an Org Successfully**
Error: Timed out 5000ms waiting for expect(locator).toBeVisible()

Locator: getByText('This is the default Organization back to original').first()
Expected: visible
Received: <element(s) not found>
Call log:
 - expect.toBeVisible with timeout 5000ms
 - waiting for getByText('This is the default Organization back to original').first()

Error: Timed out 5000ms waiting for expect(locator).toBeVisible()