### PR TITLE
feat(EG-807): update BE data provisioning to inc lab manager & lab technician accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,10 @@ obtain the Easy Genomics project source code and install the project dependencie
 
             # Back-End specific settings
             back-end:
-               test-user-email: 'demouser@easygenomics.com'
-               test-user-password: # Demo User Password - must be minimum 8 chars long and contain: 1 number, 1 special char, 1 uppercase letter, 1 lowercase letter
+               sys-admin-email: 'sysadmin@easygenomics.org' # Replace with your institution's preferred System Admin account
+               sys-admin-password: # System Admin Password - must be minimum 8 chars long and contain: 1 number, 1 special char, 1 uppercase letter, 1 lowercase letter
+               org-admin-email: 'admin@easygenomics.org' # Replace with your institution's preferred Admin account
+               org-admin-password: # Admin Password - must be minimum 8 chars long and contain: 1 number, 1 special char, 1 uppercase letter, 1 lowercase letter
                seqera-api-base-url: # Optional: Update for self-hosted Seqera API Base URL; if unspecified this defaults to 'https://api.cloud.seqera.io'
    ```
 
@@ -233,8 +235,8 @@ obtain the Easy Genomics project source code and install the project dependencie
    - NOTE: If the `aws-hosted-zone-id` and/or the `aws-certificate-arn` are not defined in the `easy-genomics.yaml`, the
      `ApplicationUrl` returned will be the CloudFront Distribution URL.
 
-   Finally, use the `${easy-genomics root-dir}/config/easy-genomics.yaml` file's configured`test-user-email` and
-   `test-user-password` account details to log in into Easy Genomics to test the functionality.
+   Finally, use the `${easy-genomics root-dir}/config/easy-genomics.yaml` file's configured `org-admin-email` and
+   `org-admin-password` account details to log in into Easy Genomics to test the functionality.
 
    Once you have completed an initial deployment of the Back-End and Front-End application logic, you can subsequently
    use the `build-and-deploy` short-cut command from the `${easy-genomics root-dir}` directory to conveniently complete

--- a/config/easy-genomics.example.yaml
+++ b/config/easy-genomics.example.yaml
@@ -13,7 +13,7 @@ easy-genomics:
         # Back-End specific settings
         back-end:
             jwt-secret-key: '123e4567-e89b-12d3-a456-426614174000'
-            sys-admin-email:  'yoursysadmin@easygenomics.org',
+            sys-admin-email:  'sysadmin@easygenomics.org', # Replace with your institution's preferred System Admin account
             sys-admin-password: # System Admin Password - must be minimum 8 chars long and contain: 1 number, 1 special char, 1 uppercase letter, 1 lowercase letter
-            test-user-email: 'yourtestuser@easygenomics.org'
-            test-user-password: # Demo User Password - must be minimum 8 chars long and contain: 1 number, 1 special char, 1 uppercase letter, 1 lowercase letter
+            org-admin-email: 'admin@easygenomics.org' # Replace with your institution's preferred Admin account
+            org-admin-password: # Admin Password - must be minimum 8 chars long and contain: 1 number, 1 special char, 1 uppercase letter, 1 lowercase letter

--- a/packages/back-end/src/infra/stacks/data-provisioning-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/data-provisioning-nested-stack.ts
@@ -4,14 +4,20 @@ import { LaboratoryUser } from '@easy-genomics/shared-lib/src/app/types/easy-gen
 import { Organization } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/organization';
 import { OrganizationUser } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/organization-user';
 import {
+  labManagerUser,
+  labManagerUserLaboratoryMapping,
+  labManagerUserOrganizationMapping,
   laboratory,
-  laboratoryUser,
+  labTechnicianUser,
+  labTechnicianUserLaboratoryMapping,
+  labTechnicianUserOrganizationMapping,
+  orgAdminUser,
+  orgAdminUserOrganizationMapping,
   organization,
-  organizationUser,
-  user,
 } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/sample-data';
 import { UniqueReference } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/unique-reference';
 import { User } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/user';
+import { TestUserDetails } from '@easy-genomics/shared-lib/src/infra/types/main-stack';
 import { NestedStack, RemovalPolicy } from 'aws-cdk-lib';
 import { Table } from 'aws-cdk-lib/aws-dynamodb';
 import { AwsCustomResource, AwsCustomResourcePolicy } from 'aws-cdk-lib/custom-resources';
@@ -24,6 +30,7 @@ export class DataProvisioningNestedStack extends NestedStack {
   private props: DataProvisioningNestedStackProps;
   private cognitoUserConstruct: CognitoUserConstruct;
   private s3Construct: S3Construct;
+  private uniqueReferences: UniqueReference[] = [];
 
   constructor(scope: Construct, id: string, props: DataProvisioningNestedStackProps) {
     super(scope, id);
@@ -52,11 +59,13 @@ export class DataProvisioningNestedStack extends NestedStack {
     }
 
     if (this.props.devEnv) {
-      const uniqueReferences: UniqueReference[] = [];
-
       // Add seed data to DynamoDB Tables
-      this.addDynamoDBSeedData<Organization>(`${this.props.namePrefix}-organization-table`, organization);
-      uniqueReferences.push({
+      this.addDynamoDBSeedData<Organization>(
+        organization.OrganizationId,
+        `${this.props.namePrefix}-organization-table`,
+        organization,
+      );
+      this.uniqueReferences.push({
         Value: organization.Name.toLowerCase(),
         Type: 'organization-name',
       });
@@ -66,56 +75,110 @@ export class DataProvisioningNestedStack extends NestedStack {
       if (s3BucketFullName.length > 63) {
         throw new Error(`S3 Bucket Name: "${s3BucketFullName}" is too long`);
       }
-      this.addDynamoDBSeedData<Laboratory>(`${this.props.namePrefix}-laboratory-table`, {
+      this.addDynamoDBSeedData<Laboratory>(laboratory.LaboratoryId, `${this.props.namePrefix}-laboratory-table`, {
         ...laboratory,
         S3Bucket: s3BucketFullName, // Save the shared S3 Bucket's Full Name in Laboratory DynamoDB record
       });
-      uniqueReferences.push({
+      this.uniqueReferences.push({
         Value: laboratory.Name.toLowerCase(),
         Type: `organization-${laboratory.OrganizationId}-laboratory-name`,
       });
       // Add shared S3 Bucket for seeded 'Test Laboratory'
       this.s3Construct.createBucket(s3BucketFullName, this.props.devEnv);
 
-      if (this.props.orgAdminEmail && this.props.orgAdminPassword) {
-        try {
-          // Add test user to Cognito User Pool
-          this.cognitoUserConstruct.addUser(this.props.orgAdminEmail, this.props.orgAdminPassword);
+      // Seed User accounts for development and testing
+      const testUsers: TestUserDetails[] | undefined = this.props.testUsers;
+      if (testUsers) {
+        testUsers.forEach((testUser: TestUserDetails) => {
+          // Add Test User to Cognito User Pool
+          this.cognitoUserConstruct.addUser(testUser.UserEmail, testUser.UserPassword);
 
-          this.addDynamoDBSeedData<User>(`${this.props.namePrefix}-user-table`, {
-            ...user,
-            Email: this.props.orgAdminEmail,
-          });
+          // Add Test User's necessary User Record, OrganizationUser Mapping Record, LaboratoryUser Mapping Record
+          switch (testUser.Access) {
+            case 'OrganizationAdmin':
+              this.addOrgAdmin(testUser);
+              break;
+            case 'LabManager':
+              this.addLabManager(testUser);
+              break;
+            case 'LabTechnician':
+              this.addLabTechnician(testUser);
+              break;
+          }
 
-          uniqueReferences.push({
-            Value: user.Email.toLowerCase(),
+          // Add Test User's email to Unique References list to prevent duplicates
+          this.uniqueReferences.push({
+            Value: testUser.UserEmail.toLowerCase(),
             Type: 'user-email',
           });
-        } catch (err: unknown) {
-          console.error('Unable to create Test User Account: ', err);
-        }
-
-        // Add User mapping data to DynamoDB Tables
-        this.addDynamoDBSeedData<OrganizationUser>(
-          `${this.props.namePrefix}-organization-user-table`,
-          organizationUser,
-        );
-        this.addDynamoDBSeedData<LaboratoryUser>(`${this.props.namePrefix}-laboratory-user-table`, laboratoryUser);
+        });
       }
 
       // Bulk add unique references to UniqueReferences DynamoDB Table
       this.bulkAddDynamoDBSeedData<UniqueReference>(
         `${this.props.namePrefix}-unique-reference-table`,
-        uniqueReferences,
+        this.uniqueReferences,
       );
     }
   }
 
-  private addDynamoDBSeedData<T>(tableName: string, testRecord: T) {
+  // Seeds Org Admin User for development and testing
+  private addOrgAdmin(testUser: TestUserDetails) {
+    this.addDynamoDBSeedData<User>(orgAdminUser.UserId, `${this.props.namePrefix}-user-table`, {
+      ...orgAdminUser,
+      Email: testUser.UserEmail,
+    });
+    // Add User mapping data to DynamoDB Tables
+    this.addDynamoDBSeedData<OrganizationUser>(
+      orgAdminUser.UserId,
+      `${this.props.namePrefix}-organization-user-table`,
+      orgAdminUserOrganizationMapping,
+    );
+  }
+
+  // Seeded Lab Manager User for development and testing
+  private addLabManager(testUser: TestUserDetails) {
+    this.addDynamoDBSeedData<User>(labManagerUser.UserId, `${this.props.namePrefix}-user-table`, {
+      ...labManagerUser,
+      Email: testUser.UserEmail,
+    });
+    // Add User mapping data to DynamoDB Tables
+    this.addDynamoDBSeedData<OrganizationUser>(
+      labManagerUser.UserId,
+      `${this.props.namePrefix}-organization-user-table`,
+      labManagerUserOrganizationMapping,
+    );
+    this.addDynamoDBSeedData<LaboratoryUser>(
+      labManagerUser.UserId,
+      `${this.props.namePrefix}-laboratory-user-table`,
+      labManagerUserLaboratoryMapping,
+    );
+  }
+
+  // Seeded Lab Technician User for development and testing
+  private addLabTechnician(testUser: TestUserDetails) {
+    this.addDynamoDBSeedData<User>(labTechnicianUser.UserId, `${this.props.namePrefix}-user-table`, {
+      ...labTechnicianUser,
+      Email: testUser.UserEmail,
+    });
+    // Add User mapping data to DynamoDB Tables
+    this.addDynamoDBSeedData<OrganizationUser>(
+      labTechnicianUser.UserId,
+      `${this.props.namePrefix}-organization-user-table`,
+      labTechnicianUserOrganizationMapping,
+    );
+    this.addDynamoDBSeedData<LaboratoryUser>(
+      labTechnicianUser.UserId,
+      `${this.props.namePrefix}-laboratory-user-table`,
+      labTechnicianUserLaboratoryMapping,
+    );
+  }
+
+  private addDynamoDBSeedData<T>(recordId: string, tableName: string, testRecord: T) {
     const table: Table | undefined = this.props.dynamoDBTables.get(tableName);
 
     if (table) {
-      new AwsCustomResource(this, `${tableName}_InitData`, {
+      new AwsCustomResource(this, `${tableName}-${recordId}_InitData`, {
         onCreate: {
           service: 'DynamoDB',
           action: 'putItem',

--- a/packages/shared-lib/src/app/schema/configuration.ts
+++ b/packages/shared-lib/src/app/schema/configuration.ts
@@ -24,6 +24,10 @@ export const ConfigurationSettingsSchema = z
       ['sys-admin-password']: z.string().nullable().optional(), // Initial Cognito password
       ['org-admin-email']: z.string(),
       ['org-admin-password']: z.string(), // Initial Cognito password
+      ['lab-manager-email']: z.string().nullable().optional(),
+      ['lab-manager-password']: z.string().nullable().optional(), // Initial Cognito password
+      ['lab-technician-email']: z.string().nullable().optional(),
+      ['lab-technician-password']: z.string().nullable().optional(), // Initial Cognito password
       ['seqera-api-base-url']: z.string().nullable().optional(), // Optional: Update for self-hosted Seqera API Base URL; if unspecified this defaults to 'https://api.cloud.seqera.io'
       ['vpc-peering']: z.object(VpcPeeringSchema.shape).nullable().optional(), // Optional: VPC Peering Accepter details
     }),

--- a/packages/shared-lib/src/app/types/configuration.d.ts
+++ b/packages/shared-lib/src/app/types/configuration.d.ts
@@ -21,7 +21,11 @@ export interface ConfigurationSettings {
     ['sys-admin-email']?: string;
     ['sys-admin-password']?: string; // Initial Cognito password
     ['org-admin-email']: string;
-    ['org-admin-password']: string;
+    ['org-admin-password']: string; // Initial Cognito password
+    ['lab-manager-email']?: string,
+    ['lab-manager-password']?: string, // Initial Cognito password
+    ['lab-technician-email']?: string,
+    ['lab-technician-password']?: string, // Initial Cognito password
     ['seqera-api-base-url']?: string; // Optional: Update for self-hosted Seqera API Base URL; if unspecified this defaults to 'https://api.cloud.seqera.io'
     ['vpc-peering']?: VpcPeeringSettings; // Optional: VPC Peering Accepter details
   };

--- a/packages/shared-lib/src/app/types/easy-genomics/sample-data.ts
+++ b/packages/shared-lib/src/app/types/easy-genomics/sample-data.ts
@@ -6,7 +6,9 @@ import { User } from './user';
 
 const organizationId = '61c86013-74f2-4d30-916a-70b03a97ba14';
 const laboratoryId = 'bbac4190-0446-4db4-a084-cfdbc8102297';
-const userId = 'c6705721-90ba-4d4a-9460-af2828bb4181';
+const orgAdminUserId = 'c6705721-90ba-4d4a-9460-af2828bb4181';
+const labManagerUserId = 'd03035ae-a93d-4f50-bdd5-9db2197348a5';
+const labTechnicianUserId = '0577f36a-13b5-4eb6-bef0-38429e3806a1';
 
 export const organization: Organization = {
   OrganizationId: organizationId,
@@ -27,20 +29,47 @@ export const laboratory: Laboratory = {
   CreatedAt: new Date().toISOString(),
 };
 
-export const user: User = {
-  UserId: userId,
-  Email: 'test.user@easygenomics.org',
-  Title: 'Dr',
-  FirstName: 'Rick',
-  LastName: 'Sanchez',
+// Seeded Org Admin User for development and testing
+export const orgAdminUser: User = {
+  UserId: orgAdminUserId,
+  Email: 'admin@easygenomics.org',
+  FirstName: 'Org',
+  LastName: 'Admin',
   Status: 'Active',
   OrganizationAccess: {
     [organizationId]: {
       Status: 'Active',
       OrganizationAdmin: true,
+      LaboratoryAccess: {},
+    },
+  },
+  CreatedAt: new Date().toISOString(),
+};
+
+export const orgAdminUserOrganizationMapping: OrganizationUser = {
+  OrganizationId: organizationId,
+  UserId: orgAdminUserId,
+  Status: 'Active',
+  OrganizationAdmin: true,
+  CreatedAt: new Date().toISOString(),
+};
+
+// Seeded Lab Manager User for development and testing
+export const labManagerUser: User = {
+  UserId: labManagerUserId,
+  Email: 'lab.manager@easygenomics.org',
+  FirstName: 'Lab',
+  LastName: 'Manager',
+  Status: 'Active',
+  OrganizationAccess: {
+    [organizationId]: {
+      Status: 'Active',
+      OrganizationAdmin: false,
       LaboratoryAccess: {
         [laboratoryId]: {
           Status: 'Active',
+          LabManager: true,
+          LabTechnician: false,
         },
       },
     },
@@ -48,19 +77,59 @@ export const user: User = {
   CreatedAt: new Date().toISOString(),
 };
 
-export const organizationUser: OrganizationUser = {
+export const labManagerUserOrganizationMapping: OrganizationUser = {
   OrganizationId: organizationId,
-  UserId: userId,
+  UserId: labManagerUserId,
   Status: 'Active',
-  OrganizationAdmin: true,
+  OrganizationAdmin: false,
   CreatedAt: new Date().toISOString(),
 };
 
-export const laboratoryUser: LaboratoryUser = {
+export const labManagerUserLaboratoryMapping: LaboratoryUser = {
   LaboratoryId: laboratoryId,
-  UserId: userId,
+  UserId: labManagerUserId,
   Status: 'Active',
   LabManager: true,
+  LabTechnician: false,
+  CreatedAt: new Date().toISOString(),
+};
+
+// Seeded Lab Technician User for development and testing
+export const labTechnicianUser: User = {
+  UserId: labTechnicianUserId,
+  Email: 'lab.technician@easygenomics.org',
+  FirstName: 'Lab',
+  LastName: 'Technician',
+  Status: 'Active',
+  OrganizationAccess: {
+    [organizationId]: {
+      Status: 'Active',
+      OrganizationAdmin: false,
+      LaboratoryAccess: {
+        [laboratoryId]: {
+          Status: 'Active',
+          LabManager: false,
+          LabTechnician: true,
+        },
+      },
+    },
+  },
+  CreatedAt: new Date().toISOString(),
+};
+
+export const labTechnicianUserOrganizationMapping: OrganizationUser = {
+  OrganizationId: organizationId,
+  UserId: labTechnicianUserId,
+  Status: 'Active',
+  OrganizationAdmin: false,
+  CreatedAt: new Date().toISOString(),
+};
+
+export const labTechnicianUserLaboratoryMapping: LaboratoryUser = {
+  LaboratoryId: laboratoryId,
+  UserId: labTechnicianUserId,
+  Status: 'Active',
+  LabManager: false,
   LabTechnician: true,
   CreatedAt: new Date().toISOString(),
 };

--- a/packages/shared-lib/src/infra/types/main-stack.d.ts
+++ b/packages/shared-lib/src/infra/types/main-stack.d.ts
@@ -1,4 +1,5 @@
 import { Environment, StackProps } from 'aws-cdk-lib';
+import { OrganizationRoles } from "@SharedLib/types/easy-genomics/roles";
 
 // Defines the BaseStack shared props for Front-End & Back-End subprojects
 export interface BaseStackProps extends StackProps {
@@ -29,8 +30,14 @@ export interface BackEndStackProps extends BaseStackProps {
   jwtSecretKey: string;
   sysAdminEmail?: string;
   sysAdminPassword?: string;
-  orgAdminEmail?: string;
-  orgAdminPassword?: string;
+  testUsers?: TestUserDetails[];
   seqeraApiBaseUrl: string;
   vpcPeering?: VpcPeering;
+}
+
+// Defines Test User Accounts to provision for DevEnv deployments
+export interface TestUserDetails {
+    UserEmail: string;
+    UserPassword: string;
+    Access: 'OrganizationAdmin' | 'LabManager' | 'LabTechnician'
 }


### PR DESCRIPTION
This PR updates the BE infra to provision Lab Manager and Lab Technician User accounts based on the optional specified settings in the `easy-genomics.yaml` configuration file:
* `lab-manager-email` / `lab-manager-password`
* `lab-technician-email` / `lab-technician-password`

The aim of this enhancement to allow for automated FE testing to be written to verify Lab Manager and Lab Technician access.

The following is an example of `easy-genomics.yaml` configuration file with the various User Roles declared for provisioning:

```
easy-genomics:
  configurations:
    - test:
          aws-account-id: '...'
          aws-region: '...'
          env-type: 'dev'
          app-domain-name: 'test.dev.easygenomics.org'
          # The following settings will need to be pre-configured in AWS and defined when 'env-type' is 'pre-prod' or 'prod'.
          aws-hosted-zone-id: '...'
          aws-certificate-arn: 'arn:aws:acm:..'

          # Back-End specific settings
          back-end:
              jwt-secret-key: '...'
              system-admin-email: 'sysadmin@easygenomics.org'
              system-admin-password: '...'
              org-admin-email: 'admin@easygenomics.org'
              org-admin-password: '...'
              lab-manager-email: 'lab.manager@easygenomics.org'
              lab-manager-password: '...'
              lab-technician-email: 'lab.technician@easygenomics.org'
              lab-technician-password: '...'
```