### PR TITLE
fix(EG-814): fix BE main infra stack to pass sysAdminEmail & sysAdminPassword for data provisioning

### DIFF
--- a/packages/back-end/src/main.ts
+++ b/packages/back-end/src/main.ts
@@ -270,6 +270,8 @@ new BackEndStack(app, `${envName}-main-back-end-stack`, {
   namePrefix: namePrefix,
   // Generate random value for JWT signature secret on deployment if jwt-secret-key configuration undefined
   jwtSecretKey: jwtSecretKey ? jwtSecretKey : randomUUID(),
+  sysAdminEmail: sysAdminEmail,
+  sysAdminPassword: sysAdminPassword,
   testUsers: testUsers,
   seqeraApiBaseUrl: seqeraApiBaseUrl.replace(/\/+$/, ''), // Remove trailing slashes
   vpcPeering: vpcPeering,


### PR DESCRIPTION
This PR fixes a regression from recent enhancements to the BE user data provisioning logic.

The `sysAdminEmail` and `sysAdminPassword` were inadvertently excluded from being passed to the data provisioning stack for processing. 