### PR TITLE
feat(EG-574): auto-refresh Runs data 

### DIFF
--- a/packages/front-end/src/app/pages/labs/[labId]/index.vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/index.vue
@@ -105,8 +105,7 @@
   const workflows = computed<Workflow[]>(() => workflowStore.workflowsForLab(labId));
 
   /**
-   * Fetch Lab details, pipelines, workflows and Lab users
-   * before component mount and start periodic fetching
+   * Fetch Lab details, pipelines, workflows and Lab users before component mount and start periodic fetching
    */
   onBeforeMount(async () => {
     // Check permissions to be on this page
@@ -117,7 +116,7 @@
     await loadLabData();
   });
 
-  // Set tabIndex according to query param
+  // set tabIndex according to query param
   onMounted(() => {
     const queryTab = $route.query.tab as string;
     const queryTabMatchIndex = tabItems.value.findIndex((tab) => tab.label === queryTab);
@@ -305,10 +304,10 @@
   watch(lab, async (lab) => {
     if (lab !== null) {
       if (lab.HasNextFlowTowerAccessToken) {
-        // Load pipelines/workflows/labUsers after lab loads
+        // load pipelines/workflows/labUsers after lab loads
         await Promise.all([getPipelines(), pollFetchWorkflows(), getLabUsers()]);
       } else {
-        // Missing personal access token message
+        // missing personal access token message
         missingPAT.value = true;
         showRedirectModal();
       }
@@ -358,10 +357,10 @@
       // Lab Manager users first
       if (userA.LabManager && !userB.LabManager) return -1;
       if (!userA.LabManager && userB.LabManager) return 1;
-      // Then Lab Technicians
+      // then Lab Technicians
       if (userA.LabTechnician && !userB.LabTechnician) return -1;
       if (!userA.LabTechnician && userB.LabTechnician) return 1;
-      // Then sort by name
+      // then sort by name
       return useSort().stringSortCompare(userA.displayName, userB.displayName);
     });
   });

--- a/packages/front-end/src/app/pages/labs/[labId]/index.vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/index.vue
@@ -17,49 +17,78 @@
   import { v4 as uuidv4 } from 'uuid';
   import { Workflow } from '@easy-genomics/shared-lib/src/app/types/nf-tower/nextflow-tower-api';
 
-  const $route = useRoute();
-
-  const workflowStore = useWorkflowStore();
-  const labStore = useLabsStore();
-
   const { $api } = useNuxtApp();
+  const $route = useRoute();
   const $router = useRouter();
-  const modal = useModal();
-
   const labId = $route.params.labId as string;
-  const orgId = labStore.labs[labId].OrganizationId;
 
+  const labStore = useLabsStore();
+  const modal = useModal();
+  const workflowStore = useWorkflowStore();
+
+  // Table columns
+  const pipelinesTableColumns = [
+    {
+      key: 'Name',
+      label: 'Name',
+    },
+    {
+      key: 'description',
+      label: 'Description',
+    },
+    {
+      key: 'actions',
+      label: 'Actions',
+    },
+  ];
+  const workflowsTableColumns = [
+    {
+      key: 'runName',
+      label: 'Run Name',
+    },
+    {
+      key: 'lastUpdated',
+      label: 'Last Updated',
+    },
+    {
+      key: 'status',
+      label: 'Status',
+    },
+    {
+      key: 'owner',
+      label: 'Owner',
+    },
+    {
+      key: 'actions',
+      label: 'Actions',
+    },
+  ];
+  const pipelinesActionItems = (pipeline: any) => [
+    [
+      {
+        label: 'Run',
+        click: () => viewRunPipeline(pipeline),
+      },
+    ],
+  ];
+
+  const canAddUsers = ref(false);
+  const isCancelDialogOpen = ref<boolean>(false);
+  const isUserDialogOpen = ref(false);
+  const labUsers = ref<LabUser[]>([]);
+  const missingPAT = ref<boolean>(false);
+  const orgId = labStore.labs[labId].OrganizationId;
+  const pipelines = ref<[]>([]);
+  const primaryMessage = ref('');
+  const runToCancel = ref<Workflow | null>(null);
+  const searchOutput = ref('');
+  const showAddUserModule = ref(false);
   const tabIndex = ref(0);
-  // set tabIndex according to query param
-  onMounted(() => {
-    const queryTab = $route.query.tab as string;
-    const queryTabMatchIndex = tabItems.value.findIndex((tab) => tab.label === queryTab);
-    tabIndex.value = queryTabMatchIndex !== -1 ? queryTabMatchIndex : 0;
-  });
+  const userToRemove = ref();
+  let intervalId: number | undefined;
 
   const lab = computed<Laboratory | null>(() => labStore.labs[labId] ?? null);
-
   const labName = computed<string>(() => lab.value?.Name || '');
-
-  const labUsers = ref<LabUser[]>([]);
-  const canAddUsers = ref(false);
-  const showAddUserModule = ref(false);
-  const searchOutput = ref('');
-  const pipelines = ref<[]>([]);
-  const workflows = computed<Workflow[]>(() => workflowStore.workflowsForLab(labId));
-
-  // Dynamic remove user dialog values
-  const isOpen = ref(false);
-  const primaryMessage = ref('');
-  const userToRemove = ref();
-
-  // check permissions to be on this page
-  if (!useUserStore().canViewLab(useUserStore().currentOrgId, labId)) {
-    $router.push('/labs');
-  }
-
-  const missingPAT = ref<boolean>(false);
-
   const tabItems = computed(() => [
     ...(!missingPAT.value
       ? [
@@ -73,11 +102,38 @@
       label: 'Details',
     },
   ]);
+  const workflows = computed<Workflow[]>(() => workflowStore.workflowsForLab(labId));
 
   /**
-   * Fetch Lab details, pipelines, workflows and Lab users before component mount
+   * Fetch Lab details, pipelines, workflows and Lab users
+   * before component mount and start periodic fetching
    */
-  onBeforeMount(loadLabData);
+  onBeforeMount(async () => {
+    // Check permissions to be on this page
+    if (!useUserStore().canViewLab(useUserStore().currentOrgId, labId)) {
+      await $router.push('/labs');
+    }
+
+    await loadLabData();
+  });
+
+  // Set tabIndex according to query param
+  onMounted(() => {
+    const queryTab = $route.query.tab as string;
+    const queryTabMatchIndex = tabItems.value.findIndex((tab) => tab.label === queryTab);
+    tabIndex.value = queryTabMatchIndex !== -1 ? queryTabMatchIndex : 0;
+  });
+
+  onUnmounted(() => {
+    if (intervalId) {
+      clearTimeout(intervalId);
+    }
+  });
+
+  async function pollFetchWorkflows() {
+    await getWorkflows();
+    intervalId = window.setTimeout(pollFetchWorkflows, 2 * 60 * 5000);
+  }
 
   function showRedirectModal() {
     modal.open(EGModal, {
@@ -96,13 +152,13 @@
   function showRemoveUserDialog(user: LabUser) {
     userToRemove.value = user;
     primaryMessage.value = `Are you sure you want to remove ${user.displayName} from ${labName.value}?`;
-    isOpen.value = true;
+    isUserDialogOpen.value = true;
   }
 
   async function handleRemoveUserFromLab() {
     let maybeDisplayName = 'user';
     try {
-      isOpen.value = false;
+      isUserDialogOpen.value = false;
       useUiStore().setRequestPending('removeUserFromLab');
       const { displayName, UserId } = userToRemove.value;
       maybeDisplayName = displayName;
@@ -156,53 +212,6 @@
       key: 'actions',
       label: 'Lab Access',
     },
-  ];
-
-  const pipelinesTableColumns = [
-    {
-      key: 'Name',
-      label: 'Name',
-    },
-    {
-      key: 'description',
-      label: 'Description',
-    },
-    {
-      key: 'actions',
-      label: 'Actions',
-    },
-  ];
-
-  const workflowsTableColumns = [
-    {
-      key: 'runName',
-      label: 'Run Name',
-    },
-    {
-      key: 'lastUpdated',
-      label: 'Last Updated',
-    },
-    {
-      key: 'status',
-      label: 'Status',
-    },
-    {
-      key: 'owner',
-      label: 'Owner',
-    },
-    {
-      key: 'actions',
-      label: 'Actions',
-    },
-  ];
-
-  const pipelinesActionItems = (pipeline: any) => [
-    [
-      {
-        label: 'Run',
-        click: () => viewRunPipeline(pipeline),
-      },
-    ],
   ];
 
   function workflowsActionItems(row: Workflow): object[] {
@@ -296,10 +305,10 @@
   watch(lab, async (lab) => {
     if (lab !== null) {
       if (lab.HasNextFlowTowerAccessToken) {
-        // load pipelines/workflows/labUsers after lab loads
-        await Promise.all([getPipelines(), getWorkflows(), getLabUsers()]);
+        // Load pipelines/workflows/labUsers after lab loads
+        await Promise.all([getPipelines(), pollFetchWorkflows(), getLabUsers()]);
       } else {
-        // missing personal access token message
+        // Missing personal access token message
         missingPAT.value = true;
         showRedirectModal();
       }
@@ -349,10 +358,10 @@
       // Lab Manager users first
       if (userA.LabManager && !userB.LabManager) return -1;
       if (!userA.LabManager && userB.LabManager) return 1;
-      // then Lab Technicians
+      // Then Lab Technicians
       if (userA.LabTechnician && !userB.LabTechnician) return -1;
       if (!userA.LabTechnician && userB.LabTechnician) return 1;
-      // then sort by name
+      // Then sort by name
       return useSort().stringSortCompare(userA.displayName, userB.displayName);
     });
   });
@@ -393,9 +402,6 @@
   function viewRunDetails(row: Workflow) {
     $router.push({ path: `/labs/${labId}/${row.id}`, query: { tab: 'Run Details' } });
   }
-
-  const isCancelDialogOpen = ref<boolean>(false);
-  const runToCancel = ref<Workflow | null>(null);
 
   async function handleCancelDialogAction() {
     const runId = runToCancel.value?.id;
@@ -537,7 +543,7 @@
           :cancelVariant="ButtonVariantEnum.enum.secondary"
           @action-triggered="handleRemoveUserFromLab"
           :primaryMessage="primaryMessage"
-          v-model="isOpen"
+          v-model="isUserDialogOpen"
         />
 
         <EGTable

--- a/packages/front-end/src/app/stores/workflow.ts
+++ b/packages/front-end/src/app/stores/workflow.ts
@@ -52,17 +52,23 @@ const useWorkflowStore = defineStore('workflowStore', {
     async loadWorkflowsForLab(labId: string): Promise<void> {
       const { $api } = useNuxtApp();
 
-      this.workflows[labId] = {};
-      this.workflowIdsByLab[labId] = [];
-
+      // fetch new workflows without modifying existing state
       const workflows: Workflow[] = await $api.workflows.list(labId);
+
+      // prepare temporary storage
+      const newWorkflows: Record<string, Workflow> = {};
+      const newWorkflowIds: string[] = [];
 
       for (const workflow of workflows) {
         if (workflow.id !== undefined) {
-          this.workflows[labId][workflow.id] = workflow;
-          this.workflowIdsByLab[labId].push(workflow.id);
+          newWorkflows[workflow.id] = workflow;
+          newWorkflowIds.push(workflow.id);
         }
       }
+
+      // update state with the new data
+      this.workflows[labId] = newWorkflows;
+      this.workflowIdsByLab[labId] = newWorkflowIds;
     },
 
     async loadSingleWorkflow(labId: string, workflowId: string): Promise<void> {


### PR DESCRIPTION
This PR adds an auto-refresh of the Laboratory Runs data every two minutes. 

Notable changes: 

- some refactoring of `stores/workflow.ts` was needed to remove the empty loading state each time the data refreshes. 
- re-organised the code structure which had gotten a bit unwieldily over time. 

