### PR TITLE
feat(EG-776): verify current user org access for list endpoints

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/list-laboratories.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/list-laboratories.lambda.ts
@@ -1,20 +1,25 @@
 import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
+import { User } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/user';
 import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/src/app/utils/common';
 import {
+  ExpiredOrganizationAccessError,
   NoLabratoriesFoundError,
   RequiredIdNotFoundError,
   UnauthorizedAccessError,
 } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
 import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
+import { UserService } from '@BE/services/easy-genomics/user-service';
 import {
   getLaboratoryAccessLaboratoryIds,
   validateOrganizationAccess,
   validateOrganizationAdminAccess,
   validateSystemAdminAccess,
+  verifyCurrentOrganizationAccess,
 } from '@BE/utils/auth-utils';
 
 const laboratoryService = new LaboratoryService();
+const userService = new UserService();
 
 export const handler: Handler = async (
   event: APIGatewayProxyWithCognitoAuthorizerEvent,
@@ -28,6 +33,17 @@ export const handler: Handler = async (
     const isSystemAdmin: boolean = validateSystemAdminAccess(event);
     const isOrgAdmin: boolean = validateOrganizationAdminAccess(event, organizationId);
     const isAdmin: boolean = isSystemAdmin || isOrgAdmin;
+
+    if (!isSystemAdmin) {
+      // For regular users only
+      const userId = event.requestContext.authorizer.claims['cognito:username'];
+      const user: User = await userService.get(userId);
+
+      // Check if users org access is current, if not let the FE know
+      if (!verifyCurrentOrganizationAccess(event, user)) {
+        throw new ExpiredOrganizationAccessError();
+      }
+    }
 
     // Only the SystemAdmin or any User with access to the Organization is allowed access to this API
     if (!(isSystemAdmin || validateOrganizationAccess(event, organizationId))) {

--- a/packages/back-end/src/app/controllers/easy-genomics/organization/list-organizations.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/organization/list-organizations.lambda.ts
@@ -1,10 +1,18 @@
 import { Organization } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/organization';
+import { User } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/user';
 import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/src/app/utils/common';
+import { ExpiredOrganizationAccessError } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
 import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
 import { OrganizationService } from '@BE/services/easy-genomics/organization-service';
-import { getOrganizationAccessOrganizationIds, validateSystemAdminAccess } from '@BE/utils/auth-utils';
+import { UserService } from '@BE/services/easy-genomics/user-service';
+import {
+  getOrganizationAccessOrganizationIds,
+  verifyCurrentOrganizationAccess,
+  validateSystemAdminAccess,
+} from '@BE/utils/auth-utils';
 
 const organizationService = new OrganizationService();
+const userService = new UserService();
 
 /**
  * This API is returns a list of Organizations depending on the User's Cognito
@@ -25,6 +33,13 @@ export const handler: Handler = async (
       const response: Organization[] = await organizationService.list();
       return buildResponse(200, JSON.stringify(response), event);
     } else {
+      const userId = event.requestContext.authorizer.claims['cognito:username'];
+      const user: User = await userService.get(userId);
+
+      if (!verifyCurrentOrganizationAccess(event, user)) {
+        throw new ExpiredOrganizationAccessError();
+      }
+
       const organizationIds = getOrganizationAccessOrganizationIds(event);
 
       const response: Organization[] = await organizationService.list();

--- a/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
@@ -138,6 +138,12 @@ export class EasyGenomicsNestedStack extends NestedStack {
     this.iam.addPolicyStatements('/easy-genomics/organization/list-organizations', [
       new PolicyStatement({
         resources: [
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-user-table`,
+        ],
+        actions: ['dynamodb:GetItem'],
+      }),
+      new PolicyStatement({
+        resources: [
           `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-organization-table`,
         ],
         actions: ['dynamodb:Scan'],
@@ -330,6 +336,12 @@ export class EasyGenomicsNestedStack extends NestedStack {
     ]);
     // /easy-genomics/laboratory/list-laboratories
     this.iam.addPolicyStatements('/easy-genomics/laboratory/list-laboratories', [
+      new PolicyStatement({
+        resources: [
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-user-table`,
+        ],
+        actions: ['dynamodb:GetItem'],
+      }),
       new PolicyStatement({
         resources: [
           `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table`,

--- a/packages/shared-lib/src/app/utils/HttpError.ts
+++ b/packages/shared-lib/src/app/utils/HttpError.ts
@@ -56,6 +56,15 @@ export class UnauthorizedAccessError extends HttpError {
   }
 }
 
+/**
+ * The users organization access in Authorizer is out of date
+ */
+export class ExpiredOrganizationAccessError extends HttpError {
+  constructor() {
+    super('Expired organization access', 409, 'EG-110');
+  }
+}
+
 // Organization Errors
 
 /**


### PR DESCRIPTION
Users who have been given/removed access for Organizations and Laboratories won't have their org access in their ID Token updated to reflect that unless they log out and log back in.

Here we will check on the Org and Lab list endpoints if that org access is current and throw an error to let the FE know to refresh the users ID Token and try again.