### PR TITLE
feat(EG-819): set automation org

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,4 +93,3 @@ packages/front-end/test-results
 packages/front-end/tests/e2e/.auth/*.json
 packages/front-end/playwright-report
 !/.projenrc.ts
-.nx

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -455,7 +455,7 @@ frontEndApp.addScripts({
   ['nuxt-prepare']: 'nuxt prepare', // Required to create front-end/.nuxt/tsconfig.json
   ['nuxt-preview']: 'nuxt preview',
   ['nuxt-postinstall']: 'nuxt prepare',
-  ['test-e2e']: 'pnpm run test-e2e:org-admin && pnpm run test-e2e:sys-admin',
+  ['test-e2e']: 'pnpm run pnpm run test-e2e:sys-admin && test-e2e:org-admin',
   ['test-e2e:sys-admin']: 'USER_TYPE=sys-admin npx playwright test --project=quality-sys-admin',
   ['test-e2e:org-admin']: 'USER_TYPE=org-admin npx playwright test --project=quality-org-admin',
   ['test-e2e:headed']: 'pnpm run test-e2e:org-admin:headed && pnpm run test-e2e:sys-admin:headed',

--- a/packages/front-end/package.json
+++ b/packages/front-end/package.json
@@ -28,7 +28,7 @@
     "nuxt-prepare": "nuxt prepare",
     "nuxt-preview": "nuxt preview",
     "nuxt-postinstall": "nuxt prepare",
-    "test-e2e": "pnpm run test-e2e:org-admin && pnpm run test-e2e:sys-admin",
+    "test-e2e": "pnpm run pnpm run test-e2e:sys-admin && test-e2e:org-admin",
     "test-e2e:sys-admin": "USER_TYPE=sys-admin npx playwright test --project=quality-sys-admin",
     "test-e2e:org-admin": "USER_TYPE=org-admin npx playwright test --project=quality-org-admin",
     "test-e2e:headed": "pnpm run test-e2e:org-admin:headed && pnpm run test-e2e:sys-admin:headed",


### PR DESCRIPTION
This PR contains few improvement on existing and new test scripts all housed in the 'Organizations_System_Admin'
01 - Remove an Organization Successfully
02 - Create a new Organization Successfully
03 - Invite a user to an Org Successfully
04 - Change a user's Organization Admin access
05 - Remove Invited user to an Org Successfully
06 - Update an Org Successfully

Please note that the succeeding runs will fail due to a dependency on a bug fix for **EG-811**
