### PR TITLE
fix(EG-811): update organization-service delete() to correctly remove unique reference

### DIFF
--- a/packages/back-end/src/app/services/easy-genomics/organization-service.ts
+++ b/packages/back-end/src/app/services/easy-genomics/organization-service.ts
@@ -207,7 +207,7 @@ export class OrganizationService extends DynamoDBService implements Service {
           Delete: {
             TableName: this.UNIQUE_REFERENCE_TABLE_NAME,
             Key: {
-              Value: { S: organization.Name.toString() },
+              Value: { S: organization.Name.toLowerCase() },
               Type: { S: 'organization-name' },
             },
           },


### PR DESCRIPTION
This PR fixes the organization-service delete() method to correctly remove the Organization's lower-case name from the DynamoDB unique-reference table.