### PR TITLE
fix(EG-808): add store helper to check if can add lab user

### DIFF
--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -443,7 +443,12 @@
     :back-action="() => $router.push('/labs')"
     :show-back="true"
   >
-    <EGButton label="Add Lab Users" :disabled="!canAddUsers" @click="showAddUserModule = !showAddUserModule" />
+    <EGButton
+      label="Add Lab Users"
+      v-if="!superuser"
+      :disabled="!canAddUsers"
+      @click="showAddUserModule = !showAddUserModule"
+    />
     <EGAddLabUsersModule
       v-if="showAddUserModule"
       @added-user-to-lab="handleUserAddedToLab()"

--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -217,6 +217,7 @@
           await getLabUsers();
         } else {
           await Promise.all([getPipelines(), pollFetchWorkflows(), getLabUsers()]);
+          canAddUsers.value = useUserStore().canAddLabUsers(orgId, props.labId);
         }
       } else {
         // missing personal access token message

--- a/packages/front-end/src/app/components/EGToast.vue
+++ b/packages/front-end/src/app/components/EGToast.vue
@@ -9,7 +9,7 @@
       variant?: ToastVariant;
     }>(),
     {
-      timeout: 5000,
+      timeout: 3000,
       variant: 'info',
     },
   );

--- a/packages/front-end/src/app/stores/user.ts
+++ b/packages/front-end/src/app/stores/user.ts
@@ -71,6 +71,11 @@ const useUserStore = defineStore('userStore', {
       (_state: UserStoreState) =>
       (orgId: string): boolean =>
         useUserStore().isOrgAdmin(orgId),
+
+    canAddLabUsers:
+      (_state: UserStoreState) =>
+      (orgId: string, labId: string): boolean =>
+        useUserStore().isOrgAdmin(orgId) || useUserStore().isLabManager(orgId, labId),
   },
 
   actions: {


### PR DESCRIPTION
- Checks in the Lab view if a user is an Org Admin or Lab Manager. 
- Hides "Add Lab Users" button for `superuser` (Admin view)
- Reduce toast timer globally to 3 seconds to improve UX