### PR TITLE
feat(EG-770): add s3 bucket tags to enable bucket filtering for list-buckets API

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/list-buckets.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/list-buckets.lambda.ts
@@ -1,4 +1,4 @@
-import { Bucket, ListBucketsCommandOutput } from '@aws-sdk/client-s3';
+import { Bucket, GetBucketTaggingCommandOutput, ListBucketsCommandOutput, Tag } from '@aws-sdk/client-s3';
 import { S3Bucket } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/s3-bucket';
 import { buildResponse } from '@easy-genomics/shared-lib/src/app/utils/common';
 import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
@@ -11,6 +11,11 @@ const s3Service = new S3Service();
  * S3 buckets within their AWS account with the intent of allowing the
  * Organization Administrator to select an existing S3 Bucket for use by a
  * Laboratory instead of the auto-provisioned S3 Bucket.
+ *
+ * The list of existing S3 Buckets returned by this API is filtered by reading
+ * the respective Bucket's tags and checking if it contains the tag key/value
+ * pair:
+ *  - 'easy-genomics:s3-bucket-type': 'data'
  */
 export const handler: Handler = async (
   event: APIGatewayProxyWithCognitoAuthorizerEvent,
@@ -19,16 +24,30 @@ export const handler: Handler = async (
   try {
     const response: ListBucketsCommandOutput = await s3Service.listBuckets({});
     if (response.Buckets) {
-      // Exclude CDK, Amplify, and FE Hosting/CloudFront S3 Buckets
-      const buckets: S3Bucket[] = response.Buckets.filter(
-        (bucket: Bucket) =>
-          !bucket.Name?.startsWith('cdk') &&
-          !bucket.Name?.startsWith('amplify') &&
-          !bucket.Name?.startsWith(process.env.DOMAIN_NAME),
-      ).flatMap((bucket: Bucket) => {
-        return <S3Bucket>{ Name: bucket.Name };
+      // Exclude CDK, and Amplify S3 Buckets
+      const buckets: Bucket[] = response.Buckets.filter(
+        (bucket: Bucket) => !bucket.Name?.startsWith('cdk') && !bucket.Name?.startsWith('amplify'),
+      );
+
+      // Lookup all the name filtered Bucket's tags asynchronously in parallel
+      const bucketTags: Awaited<GetBucketTaggingCommandOutput>[] = await Promise.all(
+        buckets.map((bucket: Bucket) => s3Service.getBucketTagging({ Bucket: bucket.Name })),
+      );
+
+      // Filter for only Buckets with readable Tags and have matching tag key/values:
+      //  - 'easy-genomics:s3-bucket-type': 'data'
+      const filteredBuckets: S3Bucket[] = [];
+      bucketTags.forEach((bucketTag: GetBucketTaggingCommandOutput | undefined, index: number) => {
+        // AWS S3 prevents looking up a Bucket's tags if the Bucket exists in a different AWS Region,
+        // so the bucketTag's undefined response can be used effectively to identify Bucket's to ignore.
+        if (bucketTag) {
+          const ts: Tag[] | undefined = bucketTag.TagSet;
+          if (ts && ts.find((t: Tag) => t.Key === 'easy-genomics:s3-bucket-type' && t.Value === 'data')) {
+            filteredBuckets.push(<S3Bucket>{ Name: buckets[index].Name });
+          }
+        }
       });
-      return buildResponse(200, JSON.stringify(buckets), event);
+      return buildResponse(200, JSON.stringify(filteredBuckets), event);
     } else {
       throw new Error(`Unable to list Buckets: ${JSON.stringify(response)}`);
     }

--- a/packages/back-end/src/infra/stacks/data-provisioning-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/data-provisioning-nested-stack.ts
@@ -45,7 +45,6 @@ export class DataProvisioningNestedStack extends NestedStack {
     // Setup S3 Construct
     this.s3Construct = new S3Construct(this, `${this.props.constructNamespace}-s3-bucket`, {});
     Tags.of(this.s3Construct).add('easy-genomics:s3-bucket-type', 'data');
-    Tags.of(this.s3Construct).add('easy-genomics:s3-bucket-region', this.props.env.region!);
 
     if (this.props.sysAdminEmail && this.props.sysAdminPassword) {
       try {

--- a/packages/back-end/src/infra/stacks/data-provisioning-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/data-provisioning-nested-stack.ts
@@ -18,7 +18,7 @@ import {
 import { UniqueReference } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/unique-reference';
 import { User } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/user';
 import { TestUserDetails } from '@easy-genomics/shared-lib/src/infra/types/main-stack';
-import { NestedStack, RemovalPolicy } from 'aws-cdk-lib';
+import { NestedStack, RemovalPolicy, Tags } from 'aws-cdk-lib';
 import { Table } from 'aws-cdk-lib/aws-dynamodb';
 import { AwsCustomResource, AwsCustomResourcePolicy } from 'aws-cdk-lib/custom-resources';
 import { Construct } from 'constructs';
@@ -44,6 +44,8 @@ export class DataProvisioningNestedStack extends NestedStack {
     });
     // Setup S3 Construct
     this.s3Construct = new S3Construct(this, `${this.props.constructNamespace}-s3-bucket`, {});
+    Tags.of(this.s3Construct).add('easy-genomics:s3-bucket-type', 'data');
+    Tags.of(this.s3Construct).add('easy-genomics:s3-bucket-region', this.props.env.region!);
 
     if (this.props.sysAdminEmail && this.props.sysAdminPassword) {
       try {

--- a/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
@@ -701,7 +701,7 @@ export class EasyGenomicsNestedStack extends NestedStack {
     this.iam.addPolicyStatements('/easy-genomics/list-buckets', [
       new PolicyStatement({
         resources: ['arn:aws:s3:::*'],
-        actions: ['s3:ListAllMyBuckets'],
+        actions: ['s3:ListAllMyBuckets', 's3:GetBucketTagging'],
         effect: Effect.ALLOW,
       }),
     ]);

--- a/packages/front-end/src/infra/constructs/www-hosting-construct.ts
+++ b/packages/front-end/src/infra/constructs/www-hosting-construct.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import path from 'path';
 import { S3Construct } from '@easy-genomics/shared-lib/src/infra/constructs/s3-construct';
 import { FrontEndStackProps } from '@easy-genomics/shared-lib/src/infra/types/main-stack';
-import { CfnOutput, Duration, RemovalPolicy } from 'aws-cdk-lib';
+import { CfnOutput, Duration, RemovalPolicy, Tags } from 'aws-cdk-lib';
 import { Certificate, ICertificate } from 'aws-cdk-lib/aws-certificatemanager';
 import {
   AllowedMethods,
@@ -97,6 +97,8 @@ export class WwwHostingConstruct extends Construct {
   private setupS3Buckets = () => {
     const appDomainName: string = this.props.appDomainName;
     const s3: S3Construct = new S3Construct(this, `${this.props.constructNamespace}-s3-www`, {});
+    Tags.of(s3).add('easy-genomics:s3-bucket-type', 'www');
+    Tags.of(s3).add('easy-genomics:s3-bucket-region', this.props.env.region!);
 
     let wwwBucketProps: BucketProps = {
       accessControl: BucketAccessControl.PRIVATE,

--- a/packages/front-end/src/infra/constructs/www-hosting-construct.ts
+++ b/packages/front-end/src/infra/constructs/www-hosting-construct.ts
@@ -98,7 +98,6 @@ export class WwwHostingConstruct extends Construct {
     const appDomainName: string = this.props.appDomainName;
     const s3: S3Construct = new S3Construct(this, `${this.props.constructNamespace}-s3-www`, {});
     Tags.of(s3).add('easy-genomics:s3-bucket-type', 'www');
-    Tags.of(s3).add('easy-genomics:s3-bucket-region', this.props.env.region!);
 
     let wwwBucketProps: BucketProps = {
       accessControl: BucketAccessControl.PRIVATE,


### PR DESCRIPTION
This PR adds S3 Bucket tagging to:

| Bucket | Tags |
|--------|------|
| **FE www hosting bucket** | `'easy-genomics:s3-bucket-type': 'www'` |
| **BE provisioned lab bucket** | `'easy-genomics:s3-bucket-type': 'data'` |

The `list-buckets` API has been enhanced to lookup the S3 Bucket's Tag details and then filter for only the S3 Buckets containing the Tag key/value pair: `'easy-genomics:s3-bucket-type': 'data'`.

This will allow customers to create their own S3 Buckets / use their existing S3 Buckets with Easy Genomics if they belong to the same AWS Region as the Easy Genomics deployment and have added the tag `'easy-genomics:s3-bucket-type': 'data'`.

AWS S3 prevents looking up an S3 Bucket's tags if the Bucket does not belong to the same AWS Region as the caller (i.e. Easy Genomics deployment). 

As a result, the inability to read an S3 Bucket's tag details can be used as a proxy to identify S3 Buckets in the same AWS Region.