### PR TITLE
feat(EG-828): make ci/cd test execution failover

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -456,7 +456,7 @@ frontEndApp.addScripts({
   ['nuxt-preview']: 'nuxt preview',
   ['nuxt-postinstall']: 'nuxt prepare',
   ['test-e2e']:
-    'pnpm run test-e2e:sys-admin && pnpm run test-e2e:org-admin && pnpm run test-e2e:lab-manager && pnpm run test-e2e:lab-technician',
+    'pnpm run test-e2e:sys-admin || true && pnpm run test-e2e:org-admin || true && pnpm run test-e2e:lab-manager || true && pnpm run test-e2e:lab-technician || true',
   ['test-e2e:sys-admin']: 'USER_TYPE=sys-admin npx playwright test --project=quality-sys-admin',
   ['test-e2e:org-admin']: 'USER_TYPE=org-admin npx playwright test --project=quality-org-admin',
   ['test-e2e:lab-manager']: 'USER_TYPE=lab-manager npx playwright test --project=quality-lab-manager',

--- a/packages/front-end/package.json
+++ b/packages/front-end/package.json
@@ -28,7 +28,7 @@
     "nuxt-prepare": "nuxt prepare",
     "nuxt-preview": "nuxt preview",
     "nuxt-postinstall": "nuxt prepare",
-    "test-e2e": "pnpm run test-e2e:sys-admin && pnpm run test-e2e:org-admin && pnpm run test-e2e:lab-manager && pnpm run test-e2e:lab-technician",
+    "test-e2e": "pnpm run test-e2e:sys-admin || true && pnpm run test-e2e:org-admin || true && pnpm run test-e2e:lab-manager || true && pnpm run test-e2e:lab-technician || true",
     "test-e2e:sys-admin": "USER_TYPE=sys-admin npx playwright test --project=quality-sys-admin",
     "test-e2e:org-admin": "USER_TYPE=org-admin npx playwright test --project=quality-org-admin",
     "test-e2e:lab-manager": "USER_TYPE=lab-manager npx playwright test --project=quality-lab-manager",


### PR DESCRIPTION
Makes the `test-e2e` command failover so that if any of the test scripts fail the next script will try and execute. 

e.g. Currently tests for Sys Admin run before Org Admin. If any of the Sys Admin tests fail, the entire script exists, preventing Org Admin tests from running.