### PR TITLE
fix(EG-836): remove SES IAM restrictions on email identities to enable broader end-user testing

### DIFF
--- a/packages/back-end/src/infra/stacks/auth-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/auth-nested-stack.ts
@@ -84,8 +84,7 @@ export class AuthNestedStack extends NestedStack {
       new PolicyStatement({
         resources: [
           `arn:aws:ses:${this.props.env.region!}:${this.props.env.account!}:identity/${this.props.appDomainName}`,
-          `arn:aws:ses:${this.props.env.region!}:${this.props.env.account!}:identity/*@twobulls.com`, // TODO: remove (only for Dev/Quality testing purposes)
-          `arn:aws:ses:${this.props.env.region!}:${this.props.env.account!}:identity/*@deptagency.com`, // TODO: remove (only for Dev/Quality testing purposes)
+          `arn:aws:ses:${this.props.env.region!}:${this.props.env.account!}:identity/*@*`,
           `arn:aws:ses:${this.props.env.region!}:${this.props.env.account!}:template/*`,
         ],
         actions: ['ses:SendTemplatedEmail'],

--- a/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
@@ -601,8 +601,7 @@ export class EasyGenomicsNestedStack extends NestedStack {
       new PolicyStatement({
         resources: [
           `arn:aws:ses:${this.props.env.region!}:${this.props.env.account!}:identity/${this.props.appDomainName}`,
-          `arn:aws:ses:${this.props.env.region!}:${this.props.env.account!}:identity/*@twobulls.com`, // TODO: remove (only for Dev/Quality testing purposes)
-          `arn:aws:ses:${this.props.env.region!}:${this.props.env.account!}:identity/*@deptagency.com`, // TODO: remove (only for Dev/Quality testing purposes)
+          `arn:aws:ses:${this.props.env.region!}:${this.props.env.account!}:identity/*@*`,
           `arn:aws:ses:${this.props.env.region!}:${this.props.env.account!}:template/*`,
         ],
         actions: ['ses:SendTemplatedEmail'],


### PR DESCRIPTION
This PR removes the SES IAM restrictions for email identities `'*@twobulls.com'`, and `'*@deptagency.com'` to allow for broader testing, and also enable customers to invite users to their own deployment properly.