### PR TITLE
feat(EG-841): download actual samplesheet

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/upload/create-file-upload-sample-sheet.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/upload/create-file-upload-sample-sheet.lambda.ts
@@ -90,7 +90,6 @@ export const handler: Handler = async (
           Region: s3Region,
           S3Url: s3Url,
         },
-        SampleSheetContents: sampleSheetCsv,
       };
       return buildResponse(200, JSON.stringify(response), event);
     }

--- a/packages/front-end/src/app/components/EGRunPipelineFormUploadData.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineFormUploadData.vue
@@ -14,6 +14,7 @@
     UploadedFilePairInfo,
   } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/upload/s3-file-upload-sample-sheet';
   import { useWorkflowStore, useToastStore } from '@FE/stores';
+  import usePipeline from '@FE/composables/usePipeline';
 
   type UploadStatus = 'idle' | 'uploading' | 'success' | 'failed';
 
@@ -37,6 +38,7 @@
   const { $api } = useNuxtApp();
   const $route = useRoute();
   const workflowStore = useWorkflowStore();
+  const { downloadSampleSheet } = usePipeline($api);
 
   const emit = defineEmits(['next-step', 'previous-step', 'step-validated']);
 
@@ -544,7 +546,7 @@
         variant="secondary"
         class="mr-2"
         label="Download sample sheet"
-        @click="usePipeline().downloadSampleSheet(workflowTempId)"
+        @click="downloadSampleSheet(workflowTempId)"
       />
       <EGButton
         @click="startUploadProcess"

--- a/packages/front-end/src/app/components/EGRunPipelineFormUploadData.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineFormUploadData.vue
@@ -287,7 +287,6 @@
     const uploadedFilePairs: UploadedFilePairInfo[] = getUploadedFilePairs(uploadManifest);
     const sampleSheetResponse: SampleSheetResponse = await getSampleSheetCsv(uploadedFilePairs);
     useWorkflowStore().updateWipWorkflow(workflowTempId, {
-      sampleSheetCsv: sampleSheetResponse.SampleSheetContents,
       sampleSheetS3Url: sampleSheetResponse.SampleSheetInfo.S3Url,
       s3Bucket: sampleSheetResponse.SampleSheetInfo.Bucket,
       s3Path: sampleSheetResponse.SampleSheetInfo.Path,

--- a/packages/front-end/src/app/composables/usePipeline.ts
+++ b/packages/front-end/src/app/composables/usePipeline.ts
@@ -1,7 +1,3 @@
-import {
-  FileDownloadUrlResponse,
-  RequestFileDownloadUrl,
-} from '@easy-genomics/shared-lib/src/app/types/easy-genomics/file/request-file-download-url';
 import { useWorkflowStore } from '@FE/stores';
 import { WipWorkflowData } from '@FE/stores/workflow';
 
@@ -12,14 +8,14 @@ export default function usePipeline($api: any) {
   async function downloadSampleSheet(workflowTempId: string) {
     const wipWorkflow: WipWorkflowData = useWorkflowStore().wipWorkflows[workflowTempId];
 
-    const req: RequestFileDownloadUrl = {
+    const fileDownloadUrlResponse = await $api.files.requestFileDownloadUrl({
       LaboratoryId: `${wipWorkflow.laboratoryId}`,
       S3Uri: `${wipWorkflow.sampleSheetS3Url}`,
-    };
-    const fileDownloadUrlResponse: FileDownloadUrlResponse = await $api.files.requestFileDownloadUrl(req);
+    });
+    const sampleSheetCsvData = await (await fetch(fileDownloadUrlResponse.DownloadUrl)).text();
     const link = document.createElement('a');
-    link.setAttribute('href', fileDownloadUrlResponse.DownloadUrl);
-    link.setAttribute('download', `samplesheet-${wipWorkflow.pipelineName}--${wipWorkflow.userPipelineRunName}.csv`);
+    link.href = `data:text/csv;charset=utf-8,${sampleSheetCsvData}`;
+    link.download = `samplesheet-${wipWorkflow.pipelineName}--${wipWorkflow.userPipelineRunName}.csv`;
     link.style.visibility = 'hidden';
     document.body.appendChild(link);
     link.click();

--- a/packages/front-end/src/app/composables/usePipeline.ts
+++ b/packages/front-end/src/app/composables/usePipeline.ts
@@ -1,16 +1,24 @@
-export default function usePipeline() {
+import {
+  FileDownloadUrlResponse,
+  RequestFileDownloadUrl,
+} from '@easy-genomics/shared-lib/src/app/types/easy-genomics/file/request-file-download-url';
+import { useWorkflowStore } from '@FE/stores';
+import { WipWorkflowData } from '@FE/stores/workflow';
+
+export default function usePipeline($api: any) {
   /**
    * Downloads the sample sheet as a CSV file.
    */
-  function downloadSampleSheet(workflowTempId: string) {
+  async function downloadSampleSheet(workflowTempId: string) {
     const wipWorkflow: WipWorkflowData = useWorkflowStore().wipWorkflows[workflowTempId];
 
-    const csvString = wipWorkflow.sampleSheetCsv;
-    const blob = new Blob([csvString], { type: 'text/csv;charset=utf-8;' });
+    const req: RequestFileDownloadUrl = {
+      LaboratoryId: `${wipWorkflow.laboratoryId}`,
+      S3Uri: `${wipWorkflow.sampleSheetS3Url}`,
+    };
+    const fileDownloadUrlResponse: FileDownloadUrlResponse = await $api.files.requestFileDownloadUrl(req);
     const link = document.createElement('a');
-    const url = URL.createObjectURL(blob);
-
-    link.setAttribute('href', url);
+    link.setAttribute('href', fileDownloadUrlResponse.DownloadUrl);
     link.setAttribute('download', `samplesheet-${wipWorkflow.pipelineName}--${wipWorkflow.userPipelineRunName}.csv`);
     link.style.visibility = 'hidden';
     document.body.appendChild(link);

--- a/packages/front-end/src/app/pages/labs/[labId]/[pipelineId]/run-pipeline.vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/[pipelineId]/run-pipeline.vue
@@ -74,7 +74,10 @@
       ...originalSchema,
       definitions: filteredDefinitions,
     };
-    workflowStore.updateWipWorkflow(workflowTempId, { pipelineDescription: schema.value.description });
+    workflowStore.updateWipWorkflow(workflowTempId, {
+      laboratoryId: labId,
+      pipelineDescription: schema.value.description,
+    });
     if (res.params) {
       workflowStore.updateWipWorkflow(workflowTempId, { params: JSON.parse(res.params) });
     }

--- a/packages/front-end/src/app/plugins/api.ts
+++ b/packages/front-end/src/app/plugins/api.ts
@@ -1,4 +1,5 @@
 import { defineNuxtPlugin } from '#app';
+import FilesModule from '@FE/repository/modules/files';
 import InfraModules from '@FE/repository/modules/infra';
 import LabsModule from '@FE/repository/modules/labs';
 import OrgsModule from '@FE/repository/modules/orgs';
@@ -8,6 +9,7 @@ import UsersModule from '@FE/repository/modules/users';
 import WorkflowsModules from '@FE/repository/modules/workflows';
 
 interface IApiInstance {
+  files: FilesModule;
   infra: InfraModules;
   labs: LabsModule;
   orgs: OrgsModule;
@@ -26,6 +28,7 @@ const createFetchOptions = (nuxtApp): FetchOptions => ({
 });
 
 const createApiInstance = (apiFetcher: any): IApiInstance => ({
+  files: new FilesModule(apiFetcher),
   infra: new InfraModules(apiFetcher),
   labs: new LabsModule(apiFetcher),
   orgs: new OrgsModule(apiFetcher),

--- a/packages/front-end/src/app/repository/modules/files.ts
+++ b/packages/front-end/src/app/repository/modules/files.ts
@@ -1,0 +1,19 @@
+import {
+  RequestFileDownloadUrl,
+  FileDownloadUrlResponse,
+} from '@easy-genomics/shared-lib/src/app/types/easy-genomics/file/request-file-download-url';
+import HttpFactory from '@FE/repository/factory';
+
+class FilesModule extends HttpFactory {
+  async requestFileDownloadUrl(req: RequestFileDownloadUrl): Promise<FileDownloadUrlResponse> {
+    const res = await this.call<FileDownloadUrlResponse>('POST', '/file/request-file-download-url', req);
+
+    if (!res) {
+      throw new Error('Failed to request file download url');
+    }
+
+    return res;
+  }
+}
+
+export default FilesModule;

--- a/packages/front-end/src/app/stores/workflow.ts
+++ b/packages/front-end/src/app/stores/workflow.ts
@@ -7,6 +7,7 @@ launched yet. They're addressed by workflowTempId which is generated on pipeline
 This allows multiple workflows to be configured simultaneously without overwriting each other.
 */
 export interface WipWorkflowData {
+  laboratoryId?: string;
   pipelineId?: number;
   pipelineName?: string;
   pipelineDescription?: string;

--- a/packages/front-end/src/app/stores/workflow.ts
+++ b/packages/front-end/src/app/stores/workflow.ts
@@ -13,7 +13,6 @@ export interface WipWorkflowData {
   transactionId?: string;
   userPipelineRunName?: string;
   params?: object;
-  sampleSheetCsv?: string;
   sampleSheetS3Url?: string;
   s3Bucket?: string;
   s3Path?: string;

--- a/packages/shared-lib/src/app/types/easy-genomics/upload/s3-file-upload-sample-sheet.d.ts
+++ b/packages/shared-lib/src/app/types/easy-genomics/upload/s3-file-upload-sample-sheet.d.ts
@@ -24,7 +24,6 @@ export type UploadedFileInfo = {
 export type SampleSheetResponse = {
   TransactionId: string;
   SampleSheetInfo: SampleSheetInfo;
-  SampleSheetContents: string;
 };
 
 export type SampleSheetInfo = {


### PR DESCRIPTION
This PR updates the `Run Pipeline Step 2` UI's `Download sample sheet` button logic to leverage the `/easy-genomics/file/request-file-download-url` API to retrieve the current samplesheet.csv file store on S3.

This replaces the previous implementation which obtained a copy of the CSV content from the BE API `/easy-genomics/upload/create-file-upload-sample-sheet` API which is only called once after all the files are uploaded.

The use of the `/easy-genomics/file/request-file-download-url` API allows the UI to reliably download the the latest samplesheet.csv file from S3. This will complement the planned `Run Pipeline Step 2` UI's enhancement to allow the end-user to also upload their own samplesheet.csv file to S3.