### PR TITLE
feat(EG-834): add request-list-bucket-objects api

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/file/request-list-bucket-objects.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/file/request-list-bucket-objects.lambda.ts
@@ -1,0 +1,69 @@
+import { ListObjectsV2CommandOutput } from '@aws-sdk/client-s3';
+import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/lib/app/utils/common';
+import { InvalidRequestError, UnauthorizedAccessError } from '@easy-genomics/shared-lib/lib/app/utils/HttpError';
+import { RequestListBucketObjectsSchema } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/file/request-list-bucket-objects';
+import { RequestListBucketObjects } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/file/request-list-bucket-objects';
+import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
+import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
+import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
+import { S3Service } from '@BE/services/s3-service';
+import {
+  validateLaboratoryManagerAccess,
+  validateLaboratoryTechnicianAccess,
+  validateOrganizationAdminAccess,
+} from '@BE/utils/auth-utils';
+
+const laboratoryService = new LaboratoryService();
+const s3Service = new S3Service();
+
+/**
+ * This API enables the Easy Genomics FE to request the specified S3 Bucket's
+ * objects for display in the File Manager UI.
+ *
+ * @param event
+ */
+export const handler: Handler = async (
+  event: APIGatewayProxyWithCognitoAuthorizerEvent,
+): Promise<APIGatewayProxyResult> => {
+  console.log('EVENT: \n' + JSON.stringify(event, null, 2));
+  try {
+    // Post Request Body
+    const request: RequestListBucketObjects = event.isBase64Encoded
+      ? JSON.parse(atob(event.body!))
+      : JSON.parse(event.body!);
+    // Data validation safety check
+    if (!RequestListBucketObjectsSchema.safeParse(request).success) {
+      throw new InvalidRequestError();
+    }
+
+    const laboratoryId: string = request.LaboratoryId;
+    const laboratory: Laboratory = await laboratoryService.queryByLaboratoryId(laboratoryId);
+
+    // Only Organisation Admins and Laboratory Members are allowed to access downloads
+    if (
+      !(
+        validateOrganizationAdminAccess(event, laboratory.OrganizationId) ||
+        validateLaboratoryManagerAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId) ||
+        validateLaboratoryTechnicianAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId)
+      )
+    ) {
+      throw new UnauthorizedAccessError();
+    }
+
+    const s3Bucket: string = request.S3Bucket ? request.S3Bucket : laboratory.S3Bucket || '';
+    const s3Prefix: string = request.S3Prefix
+      ? request.S3Prefix
+      : `${laboratory.OrganizationId}/${laboratory.LaboratoryId}/`;
+
+    const response: ListObjectsV2CommandOutput = await s3Service.listBucketObjectsV2({
+      Bucket: s3Bucket,
+      Prefix: s3Prefix,
+      MaxKeys: request.MaxKeys,
+    });
+
+    return buildResponse(200, JSON.stringify(response), event);
+  } catch (err: any) {
+    console.error(err);
+    return buildErrorResponse(err, event);
+  }
+};

--- a/packages/back-end/src/app/services/s3-service.ts
+++ b/packages/back-end/src/app/services/s3-service.ts
@@ -36,6 +36,7 @@ import {
   ListMultipartUploadsCommandInput,
   ListObjectsV2Command,
   ListObjectsV2CommandInput,
+  ListObjectsV2CommandOutput,
   ListPartsCommand,
   ListPartsCommandInput,
   NoSuchBucket,
@@ -69,7 +70,7 @@ export enum S3Command {
   // Manage S3 Bucket objects
   COPY_BUCKET_OBJECT = 'copy-bucket-object',
   DELETE_BUCKET_OBJECT = 'delete-bucket-object',
-  LIST_BUCKET_OBJECTS = 'list-bucket-objects',
+  LIST_BUCKET_OBJECTS_V2 = 'list-bucket-objects-v2',
   HEAD_OBJECT = 'head-object',
   GET_OBJECT = 'get-object',
   PUT_OBJECT = 'put-object',
@@ -145,6 +146,15 @@ export class S3Service {
 
   public listBuckets = async (listBucketsInput: ListBucketsCommandInput): Promise<ListBucketsCommandOutput> => {
     return this.s3Request<ListBucketsCommandInput, ListBucketsCommandOutput>(S3Command.LIST_BUCKETS, listBucketsInput);
+  };
+
+  public listBucketObjectsV2 = async (
+    listObjectsV2Input: ListObjectsV2CommandInput,
+  ): Promise<ListObjectsV2CommandOutput> => {
+    return this.s3Request<ListObjectsV2CommandInput, ListObjectsV2CommandOutput>(
+      S3Command.LIST_BUCKET_OBJECTS_V2,
+      listObjectsV2Input,
+    );
   };
 
   public getBucketLocation = async (
@@ -262,7 +272,7 @@ export class S3Service {
         return new CopyObjectCommand(data as CopyObjectCommandInput);
       case S3Command.DELETE_BUCKET_OBJECT:
         return new DeleteObjectCommand(data as DeleteObjectCommandInput);
-      case S3Command.LIST_BUCKET_OBJECTS:
+      case S3Command.LIST_BUCKET_OBJECTS_V2:
         return new ListObjectsV2Command(data as ListObjectsV2CommandInput);
       case S3Command.HEAD_OBJECT:
         return new HeadObjectCommand(data as HeadObjectCommandInput);

--- a/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
@@ -836,6 +836,21 @@ export class EasyGenomicsNestedStack extends NestedStack {
         effect: Effect.ALLOW,
       }),
     ]);
+    // /easy-genomics/file/request-list-bucket-objects
+    this.iam.addPolicyStatements('/easy-genomics/file/request-list-bucket-objects', [
+      new PolicyStatement({
+        resources: [
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table`,
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table/index/*`,
+        ],
+        actions: ['dynamodb:Query'],
+      }),
+      new PolicyStatement({
+        resources: ['arn:aws:s3:::*'],
+        actions: ['s3:ListBucket'],
+        effect: Effect.ALLOW,
+      }),
+    ]);
 
     // /easy-genomics/upload/create-file-upload-request
     this.iam.addPolicyStatements('/easy-genomics/upload/create-file-upload-request', [

--- a/packages/shared-lib/src/app/schema/easy-genomics/file/request-list-bucket-objects.ts
+++ b/packages/shared-lib/src/app/schema/easy-genomics/file/request-list-bucket-objects.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+// request-list-bucket-objects API request validation schemas
+export const RequestListBucketObjectsSchema = z
+  .object({
+    LaboratoryId: z.string(),
+    S3Bucket: z.string().optional(),
+    S3Prefix: z.string().optional(),
+    MaxKeys: z.number().optional(),
+  })
+  .strict();

--- a/packages/shared-lib/src/app/types/easy-genomics/file/request-list-bucket-objects.d.ts
+++ b/packages/shared-lib/src/app/types/easy-genomics/file/request-list-bucket-objects.d.ts
@@ -1,0 +1,7 @@
+// request-list-bucket-objects API type definition
+export type RequestListBucketObjects = {
+  LaboratoryId: string;
+  S3Bucket?: string;
+  S3Prefix?: string;
+  MaxKeys?: number;
+};


### PR DESCRIPTION
This PR adds the `/easy-genomics/file/request-list-bucket-objects` API to help support the new File Manager UI.

It requires the following example JSON payload:

```
{
    "LaboratoryId": "bbac4190-0446-4db4-a084-cfdbc8102297",
    "S3Bucket": "851725267090-dev-test-lab-bucket",    // Optional
    "S3Prefix": "61c86013-74f2-4d30-916a-70b03a97ba14/bbac4190-0446-4db4-a084-cfdbc8102297/next-flow/e80511e9-d9d9-44ce-a18d-7b8c20043bae/",    // Optional
    "MaxKeys": 1000    // Optional
}
```

- If the `S3Bucket` is omitted, then it will default to the Lab's configured `S3Bucket`.
- If the `S3Prefix` is omitted, then it will default to the Lab's reserved S3 path comprising of the Lab's `OrganizationId`, and `LaboratoryId` (e.g. `61c86013-74f2-4d30-916a-70b03a97ba14/bbac4190-0446-4db4-a084-cfdbc8102297/`).