### PR TITLE
feat(EG-833): add dynamodb laboratory-run-table

### DIFF
--- a/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
@@ -1023,6 +1023,45 @@ export class EasyGenomicsNestedStack extends NestedStack {
     );
     this.dynamoDBTables.set(laboratoryUserTableName, laboratoryUserTable);
 
+    // Laboratory Run table
+    const laboratoryRunTableName = `${this.props.namePrefix}-laboratory-run-table`;
+    const laboratoryRunTable = this.dynamoDB.createTable(
+      laboratoryRunTableName,
+      {
+        partitionKey: {
+          name: 'LaboratoryId',
+          type: AttributeType.STRING,
+        },
+        sortKey: {
+          name: 'RunId',
+          type: AttributeType.STRING,
+        },
+        gsi: [
+          {
+            partitionKey: {
+              name: 'RunId', // Global Secondary Index to support Laboratory lookup by RunId requests
+              type: AttributeType.STRING,
+            },
+          },
+          {
+            partitionKey: {
+              name: 'UserId', // Global Secondary Index to support Laboratory lookup by UserId requests
+              type: AttributeType.STRING,
+            },
+          },
+          {
+            partitionKey: {
+              name: 'OrganizationId', // Global Secondary Index to support lookup by OrganizationId requests
+              type: AttributeType.STRING,
+            },
+          },
+        ],
+        lsi: baseLSIAttributes,
+      },
+      this.props.devEnv,
+    );
+    this.dynamoDBTables.set(laboratoryRunTableName, laboratoryRunTable);
+
     // Unique-Reference table
     const uniqueReferenceTableName = `${this.props.namePrefix}-unique-reference-table`;
     const uniqueReferenceTable = this.dynamoDB.createTable(

--- a/packages/shared-lib/src/app/schema/easy-genomics/laboratory-run.ts
+++ b/packages/shared-lib/src/app/schema/easy-genomics/laboratory-run.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod';
+
+export const LaboratoryRunSchema = z
+  .object({
+    LaboratoryId: z.string().uuid(),
+    RunId: z.string().uuid(),
+    UserId: z.string().uuid(),
+    OrganizationId: z.string().uuid(),
+    Type: z.enum(['AWS HealthOmics', 'Seqera Cloud']),
+    Status: z.string(),
+    Title: z.string().optional(),
+    WorkflowName: z.string().optional(),
+    S3Input: z.string().optional(),
+    S3Output: z.string().optional(),
+    Settings: z.string().optional(), // JSON
+    CreatedAt: z.string().optional(),
+    CreatedBy: z.string().optional(),
+    ModifiedAt: z.string().optional(),
+    ModifiedBy: z.string().optional(),
+  })
+  .strict();
+
+export const AddLaboratoryRunSchema = z
+  .object({
+    LaboratoryId: z.string().uuid(),
+    RunId: z.string().uuid(),
+    UserId: z.string().uuid(),
+    OrganizationId: z.string().uuid(),
+    Type: z.enum(['AWS HealthOmics', 'Seqera Cloud']),
+    Status: z.string(),
+    Title: z.string().optional(),
+    WorkflowName: z.string().optional(),
+    S3Input: z.string().optional(),
+    S3Output: z.string().optional(),
+    Settings: z.string().optional(), // JSON
+  })
+  .strict();
+
+export const EditLaboratoryRunSchema = z
+  .object({
+    LaboratoryId: z.string().uuid(),
+    RunId: z.string().uuid(),
+    Title: z.string().optional(),
+    Status: z.string(),
+  })
+  .strict();
+export type EditLaboratoryRun = z.infer<typeof EditLaboratoryRunSchema>;
+
+export const RemoveLaboratoryRunSchema = z
+  .object({
+    LaboratoryId: z.string().uuid(),
+    RunId: z.string().uuid(),
+  })
+  .strict();
+
+export const RequestLaboratoryRunSchema = z
+  .object({
+    LaboratoryId: z.string().uuid(),
+    RunId: z.string().uuid(),
+  })
+  .strict();

--- a/packages/shared-lib/src/app/types/base-entity.d.ts
+++ b/packages/shared-lib/src/app/types/base-entity.d.ts
@@ -13,3 +13,5 @@ export type Status = 'Active' | 'Inactive';
 export type UserStatus = 'Active' | 'Inactive' | 'Invited';
 
 export type OrgUserStatus = 'Active' | 'Inactive' | 'Invited';
+
+export type RunType = 'AWS HealthOmics' | 'Seqera Cloud';

--- a/packages/shared-lib/src/app/types/easy-genomics/laboratory-run.d.ts
+++ b/packages/shared-lib/src/app/types/easy-genomics/laboratory-run.d.ts
@@ -1,0 +1,41 @@
+/**
+ * The following LaboratoryRun model represents the data stored in the
+ * laboratory-run-table to support tracking Seqera NextFlow / AWS HealthOmics
+ * runs for each Laboratory.
+ *
+ * The LaboratoryId serves as the DynamoDB HashKey, and the RunId
+ * serves as the DynamoDB SortKey - and cannot be modified after creation.
+ *
+ * {
+ *   LaboratoryId: <string>,
+ *   RunId: <string>,
+ *   UserId: <string>,
+ *   OrganizationId: <string>,
+ *   Type: <string>,
+ *   Status: <string>,
+ *   Title?: <string>,
+ *   WorkflowName?: <string>,
+ *   S3Input?: <string>,
+ *   S3Output?: <string>,
+ *   Settings?: <string>, // JSON
+ *   CreatedAt?: <string>,
+ *   CreatedBy?: <string>,
+ *   ModifiedAt?: <string>,
+ *   ModifiedBy?: <string>,
+ * }
+ */
+import { BaseAttributes, RunType } from "../base-entity";
+
+export interface LaboratoryRun extends BaseAttributes {
+  LaboratoryId: string; // DynamoDB Partition Key (String)
+  RunId: string; // DynamoDB Sort Key (String) & Global Secondary Index (String)
+  UserId: string; // Global Secondary Index (String)
+  OrganizationId: string; // Global Secondary Index (String)
+  Type: RunType,
+  Status: string;
+  Title?: string;
+  WorkflowName?: string;
+  S3Input?: string;
+  S3Output?: string;
+  Settings?: string; // JSON
+}


### PR DESCRIPTION
This PR adds a new DynamoDB `laboratory-run-table` for tracking AWS HealthOmics / Seqera Cloud launched runs for a Laboratory.

The `laboratory-run-table` leverages the following indexes for support easier lookup of records by:
- LaboratoryId // DynamoDB Partition Key (String)
- RunId // DynamoDB Sort Key (String) & Global Secondary Index (String)
- UserId // Global Secondary Index (String)
- OrganizationId // Global Secondary Index (String)

This PR also adds the `laboratory-run` type definition and Zod validation schemas.