### PR TITLE
fix(EG-856): improve create-user-invitation-request API logic

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/user/create-user-invitation-request.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/user/create-user-invitation-request.lambda.ts
@@ -42,17 +42,26 @@ export const handler: Handler = async (
     const existingUser: User | undefined = (await userService.queryByEmail(request.Email)).shift();
 
     if (!existingUser) {
+      console.log(
+        `New User to invite to Platform & Organization: Email=${request.Email}, OrganizationId=${organization.OrganizationId}`,
+      );
       // New User processing logic
       await inviteNewUserToOrganization(organization, request.Email, currentUserId);
       return buildResponse(200, JSON.stringify({ Status: 'Success' }), event);
     } else {
       // Existing User processing logic
       switch (existingUser.Status) {
-        case 'Invited': // Existing User's Status is still 'Invited' so continue to treat as New User and resend invite
-          await inviteNewUserToOrganization(organization, request.Email, currentUserId, true);
+        case 'Invited': // Existing User's Status is still 'Invited' so resend invite via Cognito
+          console.log(
+            `Existing User to re-invite to Platform & Organization: Email=${existingUser.Email}, OrganizationId=${organization.OrganizationId}`,
+          );
+          await reinviteExistingUserToOrganization(organization, existingUser, currentUserId);
           return buildResponse(200, JSON.stringify({ Status: 'Re-inviting' }), event);
         case 'Active':
-          await inviteExistingUserToOrganization(organization, existingUser, currentUserId);
+          console.log(
+            `Existing User to add to Organization: Email=${existingUser.Email}, OrganizationId=${organization.OrganizationId}`,
+          );
+          await addExistingUserToOrganization(organization, existingUser, currentUserId);
           return buildResponse(200, JSON.stringify({ Status: 'Success' }), event);
         default:
           throw new Error(
@@ -66,49 +75,92 @@ export const handler: Handler = async (
   }
 };
 
-async function inviteNewUserToOrganization(
-  organization: Organization,
-  email: string,
-  createdBy: string,
-  resend?: boolean,
-) {
+/**
+ * Helper function to create new User account and trigger invitation email to the Platform and specified Organization.
+ *
+ * @param organization
+ * @param email
+ * @param createdBy
+ */
+async function inviteNewUserToOrganization(organization: Organization, email: string, createdBy: string) {
   // Attempt to create new Cognito User account - will trigger Cognito process-custom-email-sender to send SES email template
   const userId: string = await cognitoIdpService.adminCreateUser(
     email.toLowerCase(),
     organization.OrganizationId,
     organization.Name,
-    resend,
   );
 
-  if (!resend) {
-    // Attempt to add the new User record, and add the Organization-User access mapping in one transaction
-    await platformUserService.addNewUserToOrganization(
-      {
-        UserId: userId,
-        Email: email.toLowerCase(),
-        Status: 'Invited',
-        CreatedAt: new Date().toISOString(),
-        CreatedBy: createdBy,
-      },
-      {
-        OrganizationId: organization.OrganizationId,
-        UserId: userId,
-        Status: 'Invited',
-        OrganizationAdmin: false,
-        CreatedAt: new Date().toISOString(),
-        CreatedBy: createdBy,
-      },
-    );
-  }
+  // Attempt to add the new User record, and add the Organization-User access mapping in one transaction
+  await platformUserService.addNewUserToOrganization(
+    {
+      UserId: userId,
+      Email: email.toLowerCase(),
+      Status: 'Invited',
+      CreatedAt: new Date().toISOString(),
+      CreatedBy: createdBy,
+    },
+    {
+      OrganizationId: organization.OrganizationId,
+      UserId: userId,
+      Status: 'Invited',
+      OrganizationAdmin: false,
+      CreatedAt: new Date().toISOString(),
+      CreatedBy: createdBy,
+    },
+  );
 }
 
-async function inviteExistingUserToOrganization(organization: Organization, user: User, modifiedBy: string) {
+/**
+ * Helper function to re-invite existing Invited User to the Platform and specified Organization.
+ *
+ * @param organization
+ * @param user
+ * @param modifiedBy
+ */
+async function reinviteExistingUserToOrganization(organization: Organization, user: User, modifiedBy: string) {
   // Try to find existing OrganizationUser record
   const existingOrganizationUser: OrganizationUser | void = await organizationUserService
     .get(organization.OrganizationId, user.UserId)
     .catch(() => {});
 
-  if (existingOrganizationUser && existingOrganizationUser.Status === 'Active') {
+  // Attempt to re-trigger Cognito process-custom-email-sender to send SES email template
+  await cognitoIdpService.adminCreateUser(user.Email, organization.OrganizationId, organization.Name, true);
+
+  if (!existingOrganizationUser) {
+    // Attempt to update the existing User record, and add the Organization-User access mapping in one transaction
+    await platformUserService.addExistingUserToOrganization(
+      {
+        ...user,
+        ModifiedAt: new Date().toISOString(),
+        ModifiedBy: modifiedBy,
+      },
+      {
+        OrganizationId: organization.OrganizationId,
+        UserId: user.UserId,
+        Status: 'Invited',
+        OrganizationAdmin: false,
+        CreatedAt: new Date().toISOString(),
+        CreatedBy: modifiedBy,
+      },
+    );
+  }
+}
+
+/**
+ * Helper function to add an existing Active User to an Organization and send courtesy notification.
+ * Immediately set Organization User access mapping to 'Active' to provide better end-user convenience.
+ *
+ * @param organization
+ * @param user
+ * @param modifiedBy
+ */
+async function addExistingUserToOrganization(organization: Organization, user: User, modifiedBy: string) {
+  // Try to find existing OrganizationUser record
+  const existingOrganizationUser: OrganizationUser | void = await organizationUserService
+    .get(organization.OrganizationId, user.UserId)
+    .catch(() => {});
+
+  if (user.Status === 'Active' && existingOrganizationUser && existingOrganizationUser.Status === 'Active') {
     return; // Do nothing
   }
 
@@ -129,9 +181,9 @@ async function inviteExistingUserToOrganization(organization: Organization, user
       };
 
   // Send out courtesy notification email to advise user they have been added to an Organization
-  await sesService.sendExistingUserInvitationEmail(user.Email, organization.Name);
+  await sesService.sendExistingUserCourtesyEmail(user.Email, organization.Name);
 
-  // Attempt to add the new User record, and add the Organization-User access mapping in one transaction
+  // Attempt to update the existing User record, and add the Organization-User access mapping in one transaction
   await platformUserService.addExistingUserToOrganization(
     {
       ...user,

--- a/packages/back-end/src/app/services/ses-service.ts
+++ b/packages/back-end/src/app/services/ses-service.ts
@@ -50,11 +50,11 @@ export class SesService {
     }
   }
 
-  public async sendExistingUserInvitationEmail(
+  public async sendExistingUserCourtesyEmail(
     toAddress: string,
     organizationName: string,
   ): Promise<SendTemplatedEmailCommandOutput> {
-    const logRequestMessage = `Send Existing User Invitation Email request: ${toAddress}`;
+    const logRequestMessage = `Send Existing User Courtesy Email request: ${toAddress}`;
     console.info(logRequestMessage);
 
     const sendTemplatedEmailCommand: SendTemplatedEmailCommand = new SendTemplatedEmailCommand({
@@ -65,7 +65,7 @@ export class SesService {
       ReplyToAddresses: [`no.reply@${this.props.domainName}`],
       ReturnPath: `no.reply@${this.props.domainName}`,
       SourceArn: `arn:aws:ses:${this.props.region}:${this.props.accountId}:identity/${this.props.domainName}`,
-      Template: 'ExistingUserInvitationEmailTemplate',
+      Template: 'ExistingUserCourtesyEmailTemplate',
       TemplateData: JSON.stringify({
         COPYRIGHT_YEAR: `${new Date().getFullYear()}`,
         DOMAIN_NAME: this.props.domainName,
@@ -76,7 +76,7 @@ export class SesService {
 
     try {
       const response = await this.sesClient.send<SendTemplatedEmailCommand>(sendTemplatedEmailCommand);
-      console.info(`Send Existing User Invitation Email to ${toAddress} response: `, response);
+      console.info(`Send Existing User Courtesy Email to ${toAddress} response: `, response);
       return response;
     } catch (error: unknown) {
       throw new Error(`${logRequestMessage} unsuccessful: ${error.message}`);

--- a/packages/back-end/src/infra/constructs/ses-construct.ts
+++ b/packages/back-end/src/infra/constructs/ses-construct.ts
@@ -37,7 +37,7 @@ export class SesConstruct extends Construct {
       emailDomainIdentity.applyRemovalPolicy(RemovalPolicy.DESTROY);
 
       this.setupNewUserInvitationEmailTemplate();
-      this.setupExistingUserInvitationEmailTemplate();
+      this.setupExistingUserCourtesyEmailTemplate();
       this.setupUserForgotPasswordEmailTemplate();
     }
   }
@@ -479,10 +479,10 @@ export class SesConstruct extends Construct {
     return newUserInvitationEmailTemplate;
   }
 
-  private setupExistingUserInvitationEmailTemplate() {
-    const invitationEmailTemplate: CfnTemplate = new CfnTemplate(this, 'ExistingUserInvitationEmailTemplate', {
+  private setupExistingUserCourtesyEmailTemplate() {
+    const invitationEmailTemplate: CfnTemplate = new CfnTemplate(this, 'ExistingUserCourtesyEmailTemplate', {
       template: {
-        templateName: 'ExistingUserInvitationEmailTemplate',
+        templateName: 'ExistingUserCourtesyEmailTemplate',
         subjectPart: 'You’ve been added to an Easy Genomics Organization',
         htmlPart: `
          <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">


### PR DESCRIPTION
This PR improves the `/easy-genomics/user/create-user-invitation-request` API to properly support:

1. Inviting new a User to the Platform and Organization
2. Re-inviting an existing Invited User to the Platform and Organization (did not complete invitation workflow, and was removed from an invited Organization).
3. Adding an existing Active User to an Organization

The bug that was identified was caused by workflow 2 due to the shared logic.

The logic is now refactored to separate functions for easier understandability and maintenance.
 - inviteNewUserToOrganization()
 - reinviteExistingUserToOrganization()
 - addExistingUserToOrganization()

The SES `ExistingUserInvitationEmailTemplate` template has also been renamed to `ExistingUserCourtesyEmailTemplate` to avoid confusion with the `NewUserInvitationEmailTemplate` template.