### PR TITLE
fix(EG-840): fix create-user-forgot-password-request API error handling

### DIFF
--- a/packages/shared-lib/src/app/utils/HttpError.ts
+++ b/packages/shared-lib/src/app/utils/HttpError.ts
@@ -372,3 +372,14 @@ export class UserNotInOrganizationError extends HttpError {
     super('User not permitted access without first granted access to the Organization', 409, 'EG-405', messageOpt);
   }
 }
+
+/**
+ * User deactivated
+ *
+ * @param messageOpt - optional additional message
+ */
+export class UserDeactivatedError extends HttpError {
+  constructor(messageOpt?: string) {
+    super('User deactivated', 403, 'EG-406', messageOpt);
+  }
+}

--- a/packages/shared-lib/src/app/utils/HttpError.ts
+++ b/packages/shared-lib/src/app/utils/HttpError.ts
@@ -372,14 +372,3 @@ export class UserNotInOrganizationError extends HttpError {
     super('User not permitted access without first granted access to the Organization', 409, 'EG-405', messageOpt);
   }
 }
-
-/**
- * User deactivated
- *
- * @param messageOpt - optional additional message
- */
-export class UserDeactivatedError extends HttpError {
-  constructor(messageOpt?: string) {
-    super('User deactivated', 403, 'EG-406', messageOpt);
-  }
-}


### PR DESCRIPTION
This PR fixes the `/easy-genomics/user/create-user-forgot-password-request` API so that it always returns a false positive (200 OK response) if it encounters an error from:
* Invalid Forgot Password JWT
* User Account deactivated (Status = `'Inactive'`)
* User Cognito Account deactivated

These errors will continue to be logged in the respective AWS CloudWatch logs for debugging.

But it is important for this API to return a false positive to the FE in order to prevent snooping of User account emails.