### PR TITLE
fix(EG-841): fix request-file-download-url API to handle us-east-1 S3 requests

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/file/request-file-download-url.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/file/request-file-download-url.lambda.ts
@@ -1,3 +1,4 @@
+import { BucketLocationConstraint } from '@aws-sdk/client-s3';
 import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/lib/app/utils/common';
 import { InvalidRequestError, UnauthorizedAccessError } from '@easy-genomics/shared-lib/lib/app/utils/HttpError';
 import { RequestFileDownloadUrlSchema } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/file/request-file-download-url';
@@ -62,15 +63,17 @@ export const handler: Handler = async (
 
     // Check the S3 Bucket exists in the same AWS Region before creating Pre-Signed S3 Download URL
     const s3BucketLocation = await s3Service.getBucketLocation({ Bucket: s3Bucket });
+    // S3 Buckets in 'us-east-1' returns a LocationConstrain of null
+    const locationConstraint: BucketLocationConstraint | undefined = s3BucketLocation.LocationConstraint;
+
     if (
-      // S3 Buckets in 'us-east-1' returns a LocationConstrain of null
-      (s3BucketLocation.LocationConstraint == null && process.env.REGION !== 'us-east-1') ||
-      s3BucketLocation.LocationConstraint !== process.env.REGION
+      (process.env.REGION === 'us-east-1' && locationConstraint && locationConstraint !== 'us-east-1') ||
+      (process.env.REGION !== 'us-east-1' && locationConstraint && locationConstraint !== process.env.REGION)
     ) {
       console.error(
         `Requested S3 Bucket '${s3Bucket}' file download belongs in a different AWS Region from ${process.env.REGION}`,
       );
-      throw new InvalidRequestError();
+      throw new InvalidRequestError('file download belongs in a different AWS Region');
     }
 
     const preSignedS3DownloadUrl: string = await s3Service.getPreSignedDownloadUrl({


### PR DESCRIPTION
This PR fixes the `/easy-genomics/file/request-file-download-url` API to generate pre-signed download URLs for the specified download file.

The S3 API `getBucketLocation()` call returns null for S3 Bucket's that are located in `us-east-1`. S3 Bucket's located in other S3 regions will return always return their region value.

The fix improves the  locationConstraint checking for `us-east-1`. If the S3 API response was to be modified in the future to return `us-east-1` instead of null, the logic will still work.