### PR TITLE
fix(EG-867): lock pipeline run page stepper tabs on click of launch pipeline

### DIFF
--- a/packages/front-end/src/app/components/EGRunPipelineFormReviewPipeline.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineFormReviewPipeline.vue
@@ -19,7 +19,7 @@
   const labName = useLabsStore().labs[labId].Name;
   const workflowTempId = $route.query.workflowTempId as string;
   const isLaunchingWorkflow = ref(false);
-  const emit = defineEmits(['launch-workflow', 'has-launched', 'previous-tab']);
+  const emit = defineEmits(['submit-launch-request', 'has-launched', 'previous-tab']);
 
   const remountAccordionKey = ref(0);
   const areAccordionsOpen = ref(true);
@@ -30,6 +30,8 @@
   const schema = JSON.parse(JSON.stringify(props.schema));
 
   async function launchWorkflow() {
+    emit('submit-launch-request');
+
     try {
       isLaunchingWorkflow.value = true;
       const pipelineId = wipWorkflow.value?.pipelineId;

--- a/packages/front-end/src/app/components/EGRunPipelineStepper.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineStepper.vue
@@ -150,8 +150,11 @@
 
   function handleLaunchSuccess() {
     hasLaunched.value = true;
-    disableAllSteps();
     emit('has-launched');
+  }
+
+  function handleSubmitLaunchRequest() {
+    disableAllSteps();
   }
 </script>
 
@@ -204,6 +207,7 @@
               :can-launch="true"
               :schema="props.schema"
               :params="wipWorkflow?.params"
+              @submit-launch-request="handleSubmitLaunchRequest()"
               @has-launched="handleLaunchSuccess()"
               @previous-tab="() => previousStep()"
             />

--- a/packages/front-end/src/app/stores/ui.ts
+++ b/packages/front-end/src/app/stores/ui.ts
@@ -14,6 +14,7 @@ type PendingRequest =
   | 'getPipelines'
   | 'getWorkflows'
   | 'loadWorkflow'
+  | 'launchWorkflow'
   | 'cancelWorkflow'
   | 'createOrg'
   | 'fetchOrgData'


### PR DESCRIPTION
This fixes the backtrack-to-steps-upload bug because as soon as you click Launch Workflow Run the tabs will disable.