### PR TITLE
fix(EG-830): file explorer fixes + lab polling fix

### DIFF
--- a/packages/front-end/src/app/components/EGFileExplorer.vue
+++ b/packages/front-end/src/app/components/EGFileExplorer.vue
@@ -73,7 +73,12 @@
   const tableColumns = [
     { key: 'name', label: 'Name', sortable: true, sort: useSort().stringSortCompare },
     { key: 'type', label: 'Type', sortable: true, sort: useSort().stringSortCompare },
-    { key: 'dateModified', label: 'Date Modified', sortable: true, sort: useSort().dateSortCompare },
+    {
+      key: 'lastModified',
+      label: 'Date Modified',
+      sortable: true,
+      sort: useSort().dateSortCompare,
+    },
     { key: 'size', label: 'Size', sortable: true, sort: useSort().numberSortCompare },
     { key: 'actions', label: 'Actions' },
   ];
@@ -219,7 +224,7 @@
       <template #type-data="{ row }">
         {{ useChangeCase(row.type === 'directory' ? 'Folder' : row.type, 'sentenceCase') }}
       </template>
-      <template #dateModified-data="{ row }">
+      <template #lastModified-data="{ row }">
         {{ format(row.lastModified, 'MM/dd/yyyy') }}
       </template>
       <template #size-data="{ row }">

--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -199,6 +199,12 @@
     }
   });
 
+  onBeforeRouteLeave(() => {
+    if (intervalId) {
+      clearTimeout(intervalId);
+    }
+  });
+
   async function pollFetchWorkflows() {
     await getWorkflows();
     intervalId = window.setTimeout(pollFetchWorkflows, 2 * 60 * 1000);

--- a/packages/front-end/src/app/composables/useSort.ts
+++ b/packages/front-end/src/app/composables/useSort.ts
@@ -1,3 +1,5 @@
+import { parse, isValid } from 'date-fns';
+
 export default function useSort() {
   /**
    * Compares string values for sorting in a linguistically intuitive way
@@ -46,24 +48,22 @@ export default function useSort() {
   }
 
   /**
-   * Compares date values in yyyy-mm-dd format for sorting
-   *
-   * @param {string} inputA
-   * @param {string} inputB
-   * @param {'asc' | 'desc'} direction
-   * @return {number} comparison result
+   * Compares date values for sorting
+   * @param inputA - First date string in ISO 8601 format
+   * @param inputB - Second date string in ISO 8601 format
+   * @param direction
    */
-  function dateSortCompare(inputA: string, inputB: string, direction: 'asc' | 'desc' = 'asc') {
-    const dateA = new Date(inputA);
-    const dateB = new Date(inputB);
+  function dateSortCompare(inputA: string, inputB: string, direction: 'asc' | 'desc' = 'asc'): number {
+    const dateA = parse(inputA, "yyyy-MM-dd'T'HH:mm:ss.SSSX", new Date());
+    const dateB = parse(inputB, "yyyy-MM-dd'T'HH:mm:ss.SSSX", new Date());
 
-    let result = dateA.getTime() - dateB.getTime();
-
-    if (direction === 'desc') {
-      result *= -1;
+    if (!isValid(dateA) || !isValid(dateB)) {
+      throw new Error('Invalid date format');
     }
 
-    return result;
+    const result = dateA.getTime() - dateB.getTime();
+
+    return direction === 'asc' ? result : -result;
   }
 
   return {


### PR DESCRIPTION
Fixes include: 

- `Date modified` date column sorting now working as expected
- Page 2 onwards was not returning results if one level deep in the folder structure
- Cleared the Lab API polling on leaving the Lab view page, which would otherwise poll unnecessarily in the background even after navigating away from the page

Some refactoring was done on the `EGTable` component: general regression performed without noticing any impact to other table implementations.