### PR TITLE
feat(EG-870): add '/aws-healthomics/workflow/list-private-workflows' API

### DIFF
--- a/packages/back-end/src/app/controllers/aws-healthomics/workflow/list-private-workflows.lambda.ts
+++ b/packages/back-end/src/app/controllers/aws-healthomics/workflow/list-private-workflows.lambda.ts
@@ -26,9 +26,9 @@ const omicsService = new OmicsService();
  *  - Required Query Parameter:
  *    - 'laboratoryId': to retrieve the Laboratory to verify access to AWS HealthOmics
  *  - Optional Query Parameters:
- *    - 'max': pagination number of results
- *    - 'offset': pagination results offset index
- *    - 'search': string to search by the Workflow name attribute
+ *    - 'maxResults': pagination number of results
+ *    - 'nextToken': pagination results offset index
+ *    - 'name': string to search by the Workflow name attribute
  *
  * @param event
  */

--- a/packages/back-end/src/app/controllers/aws-healthomics/workflow/list-private-workflows.lambda.ts
+++ b/packages/back-end/src/app/controllers/aws-healthomics/workflow/list-private-workflows.lambda.ts
@@ -1,0 +1,75 @@
+import { ListWorkflowsCommandInput } from '@aws-sdk/client-omics/dist-types/commands/ListWorkflowsCommand';
+import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/lib/app/utils/common';
+import {
+  LaboratoryNotFoundError,
+  RequiredIdNotFoundError,
+  UnauthorizedAccessError,
+} from '@easy-genomics/shared-lib/lib/app/utils/HttpError';
+import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
+import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
+import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
+import { OmicsService } from '@BE/services/omics-service';
+import {
+  validateLaboratoryManagerAccess,
+  validateLaboratoryTechnicianAccess,
+  validateOrganizationAdminAccess,
+} from '@BE/utils/auth-utils';
+import { AwsHealthOmicsQueryParameters, getAwsHealthOmicsApiQueryParameters } from '@BE/utils/rest-api-utils';
+
+const laboratoryService = new LaboratoryService();
+const omicsService = new OmicsService();
+
+/**
+ * This GET /aws-healthomics/workflow/list-workflows?laboratoryId={LaboratoryId}
+ * API queries the same region's AWS HealthOmics service to retrieve a list of
+ * Private Workflows, and it expects:
+ *  - Required Query Parameter:
+ *    - 'laboratoryId': to retrieve the Laboratory to verify access to AWS HealthOmics
+ *  - Optional Query Parameters:
+ *    - 'max': pagination number of results
+ *    - 'offset': pagination results offset index
+ *    - 'search': string to search by the Workflow name attribute
+ *
+ * @param event
+ */
+export const handler: Handler = async (
+  event: APIGatewayProxyWithCognitoAuthorizerEvent,
+): Promise<APIGatewayProxyResult> => {
+  console.log('EVENT: \n' + JSON.stringify(event, null, 2));
+  try {
+    // Get required query parameter
+    const laboratoryId: string = event.queryStringParameters?.laboratoryId || '';
+    if (laboratoryId === '') throw new RequiredIdNotFoundError('laboratoryId');
+
+    const laboratory: Laboratory = await laboratoryService.queryByLaboratoryId(laboratoryId);
+
+    if (!laboratory) {
+      throw new LaboratoryNotFoundError();
+    }
+
+    if (!laboratory.AwsHealthOmicsEnabled) {
+      throw new UnauthorizedAccessError('Laboratory does not have AWS HealthOmics enabled');
+    }
+
+    // Only available for Org Admins or Laboratory Managers and Technicians
+    if (
+      !(
+        validateOrganizationAdminAccess(event, laboratory.OrganizationId) ||
+        validateLaboratoryManagerAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId) ||
+        validateLaboratoryTechnicianAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId)
+      )
+    ) {
+      throw new UnauthorizedAccessError();
+    }
+
+    const queryParameters: AwsHealthOmicsQueryParameters = getAwsHealthOmicsApiQueryParameters(event);
+    const response = await omicsService.listWorkflows(<ListWorkflowsCommandInput>{
+      type: 'PRIVATE',
+      ...queryParameters,
+    });
+    return buildResponse(200, JSON.stringify(response), event);
+  } catch (err: any) {
+    console.error(err);
+    return buildErrorResponse(err, event);
+  }
+};

--- a/packages/back-end/src/app/utils/rest-api-utils.ts
+++ b/packages/back-end/src/app/utils/rest-api-utils.ts
@@ -67,66 +67,53 @@ export async function httpRequest<T>(
 }
 
 /**
- * Helper utility function to retrieve common basic query parameters from the
- * Easy Genomics FE which are supported by Seqera Cloud / NextFlow Tower APIs
- * and AWS HealthOmics.
- * @param event
- */
-export function getApiParameters(event: APIGatewayProxyEvent): URLSearchParams {
-  const parameters: URLSearchParams = new URLSearchParams();
-
-  const max: string | undefined = event.queryStringParameters?.max;
-  if (max && parseInt(max) > 0) {
-    parameters.set('max', max);
-  }
-  const offset: string | undefined = event.queryStringParameters?.offset;
-  if (offset && parseInt(offset) > 0) {
-    parameters.set('offset', offset);
-  }
-  const search: string | undefined = event.queryStringParameters?.search;
-  if (search) {
-    parameters.set('search', search);
-  }
-
-  return parameters;
-}
-
-/**
  * Helper utility function to set the NextFlow Tower API query parameters.
  * @param event
  * @param workspaceId
  */
 export function getNextFlowApiQueryParameters(event: APIGatewayProxyEvent, workspaceId?: string): string {
-  const apiParameters: URLSearchParams = getApiParameters(event);
-  if (workspaceId) {
-    apiParameters.set('workspaceId', workspaceId);
+  const apiQueryParameters: URLSearchParams = new URLSearchParams();
+
+  const max: string | undefined = event.queryStringParameters?.max;
+  if (max && parseInt(max) > 0) {
+    apiQueryParameters.set('max', max);
   }
-  return apiParameters.toString();
+  const offset: string | undefined = event.queryStringParameters?.offset;
+  if (offset && parseInt(offset) > 0) {
+    apiQueryParameters.set('offset', offset);
+  }
+  const search: string | undefined = event.queryStringParameters?.search;
+  if (search) {
+    apiQueryParameters.set('search', search);
+  }
+
+  if (workspaceId) {
+    apiQueryParameters.set('workspaceId', workspaceId);
+  }
+
+  return apiQueryParameters.toString();
 }
 
 /**
- * Helper utility function to convert the Easy Genomics FE query parameters to
- * AWS HealthOmics pagination parameters.
- *
+ * Helper utility function to set the AWS HealthOmics query parameters.
  * @param event
  */
 export function getAwsHealthOmicsApiQueryParameters(event: APIGatewayProxyEvent): AwsHealthOmicsQueryParameters {
-  const apiParameters: URLSearchParams = getApiParameters(event);
-
   const apiQueryParameters: AwsHealthOmicsQueryParameters = {};
-  const name: string | undefined = apiParameters.get('search') || undefined;
-  const maxResults: string | undefined = apiParameters.get('max') || undefined;
-  const startingToken: string | undefined = apiParameters.get('offset') || undefined;
+
+  const name: string | undefined = event.queryStringParameters?.name || undefined;
+  const maxResults: string | undefined = event.queryStringParameters?.maxResults || undefined;
+  const nextToken: string | undefined = event.queryStringParameters?.nextToken || undefined;
 
   if (name) {
     apiQueryParameters.name = name;
   }
 
-  if (maxResults) {
+  if (maxResults && parseInt(maxResults) > 0) {
     apiQueryParameters.maxResults = parseInt(maxResults);
 
-    if (startingToken) {
-      apiQueryParameters.startingToken = startingToken;
+    if (nextToken) {
+      apiQueryParameters.startingToken = nextToken;
     }
   }
 

--- a/packages/back-end/src/app/utils/rest-api-utils.ts
+++ b/packages/back-end/src/app/utils/rest-api-utils.ts
@@ -9,6 +9,12 @@ export const enum REST_API_METHOD {
   DELETE = 'DELETE',
 }
 
+export type AwsHealthOmicsQueryParameters = {
+  name?: string;
+  startingToken?: string;
+  maxResults?: number;
+};
+
 /**
  * Helper utility function to perform HTTP REST API requests and return the
  * expected JSON response object type.
@@ -62,7 +68,8 @@ export async function httpRequest<T>(
 
 /**
  * Helper utility function to retrieve common basic query parameters from the
- * Easy Genomics FE which are supported by Seqera Cloud / NextFlow Tower APIs.
+ * Easy Genomics FE which are supported by Seqera Cloud / NextFlow Tower APIs
+ * and AWS HealthOmics.
  * @param event
  */
 export function getApiParameters(event: APIGatewayProxyEvent): URLSearchParams {
@@ -95,4 +102,33 @@ export function getNextFlowApiQueryParameters(event: APIGatewayProxyEvent, works
     apiParameters.set('workspaceId', workspaceId);
   }
   return apiParameters.toString();
+}
+
+/**
+ * Helper utility function to convert the Easy Genomics FE query parameters to
+ * AWS HealthOmics pagination parameters.
+ *
+ * @param event
+ */
+export function getAwsHealthOmicsApiQueryParameters(event: APIGatewayProxyEvent): AwsHealthOmicsQueryParameters {
+  const apiParameters: URLSearchParams = getApiParameters(event);
+
+  const apiQueryParameters: AwsHealthOmicsQueryParameters = {};
+  const name: string | undefined = apiParameters.get('search') || undefined;
+  const maxResults: string | undefined = apiParameters.get('max') || undefined;
+  const startingToken: string | undefined = apiParameters.get('offset') || undefined;
+
+  if (name) {
+    apiQueryParameters.name = name;
+  }
+
+  if (maxResults) {
+    apiQueryParameters.maxResults = parseInt(maxResults);
+
+    if (startingToken) {
+      apiQueryParameters.startingToken = startingToken;
+    }
+  }
+
+  return apiQueryParameters;
 }

--- a/packages/back-end/src/infra/stacks/aws-healthomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/aws-healthomics-nested-stack.ts
@@ -2,13 +2,13 @@ import { NestedStack } from 'aws-cdk-lib';
 import { Effect, PolicyDocument, PolicyStatement, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
 import { IamConstruct, IamConstructProps } from '../constructs/iam-construct';
-// import { LambdaConstruct } from '../constructs/lambda-construct';
+import { LambdaConstruct } from '../constructs/lambda-construct';
 import { AwsHealthOmicsNestedStackProps } from '../types/back-end-stack';
 
 export class AwsHealthOmicsNestedStack extends NestedStack {
   readonly props: AwsHealthOmicsNestedStackProps;
   iam: IamConstruct;
-  // lambda: LambdaConstruct;
+  lambda: LambdaConstruct;
 
   constructor(scope: Construct, id: string, props: AwsHealthOmicsNestedStackProps) {
     super(scope, id);
@@ -19,20 +19,20 @@ export class AwsHealthOmicsNestedStack extends NestedStack {
     });
     this.setupIamPolicies();
 
-    // this.lambda = new LambdaConstruct(this, `${this.props.constructNamespace}`, {
-    //   ...this.props,
-    //   iamPolicyStatements: this.iam.policyStatements, // Pass declared Auth IAM policies for attaching to respective Lambda function
-    //   lambdaFunctionsDir: 'src/app/controllers/aws-healthomics',
-    //   lambdaFunctionsNamespace: `${this.props.constructNamespace}`,
-    //   lambdaFunctionsResources: {}, // Used for setting specific resources for a given Lambda function (e.g. environment settings, trigger events)
-    //   environment: {
-    //     // Defines the common environment settings for all lambda functions
-    //     ACCOUNT_ID: this.props.env.account!,
-    //     REGION: this.props.env.region!,
-    //     DOMAIN_NAME: this.props.appDomainName,
-    //     NAME_PREFIX: this.props.namePrefix,
-    //   },
-    // });
+    this.lambda = new LambdaConstruct(this, `${this.props.constructNamespace}`, {
+      ...this.props,
+      iamPolicyStatements: this.iam.policyStatements, // Pass declared Auth IAM policies for attaching to respective Lambda function
+      lambdaFunctionsDir: 'src/app/controllers/aws-healthomics',
+      lambdaFunctionsNamespace: `${this.props.constructNamespace}`,
+      lambdaFunctionsResources: {}, // Used for setting specific resources for a given Lambda function (e.g. environment settings, trigger events)
+      environment: {
+        // Defines the common environment settings for all lambda functions
+        ACCOUNT_ID: this.props.env.account!,
+        REGION: this.props.env.region!,
+        DOMAIN_NAME: this.props.appDomainName,
+        NAME_PREFIX: this.props.namePrefix,
+      },
+    });
   }
 
   // AWS HealthOmics specific IAM policies
@@ -102,5 +102,21 @@ export class AwsHealthOmicsNestedStack extends NestedStack {
         },
       }),
     );
+
+    // /aws-healthomics/workflow/list-private-workflows
+    this.iam.addPolicyStatements('/aws-healthomics/workflow/list-private-workflows', [
+      new PolicyStatement({
+        resources: [
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table`,
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table/index/*`,
+        ],
+        actions: ['dynamodb:Query'],
+      }),
+      new PolicyStatement({
+        resources: [`arn:aws:omics:${this.props.env.region!}:${this.props.env.account!}:workflow/*`],
+        actions: ['omics:ListWorkflows'],
+        effect: Effect.ALLOW,
+      }),
+    ]);
   };
 }


### PR DESCRIPTION
This PR adds the `/aws-healthomics/workflow/list-private-workflows?laboratoryId={Laboratory ID}` API to return a list of available Private Workflows from the AWS HealthOmics service in the region of the Easy Genomics deployment.

This API will require a `laboratoryId` query parameter in order to lookup the associated Laboratory in order to verify access it has `AwsHealthOmicsEnabled` (similar to the `/nf-tower/pipeline/list-pipelines?laboratoryId={Laboratory ID}` API).

```
    if (!laboratory.AwsHealthOmicsEnabled) {
      throw new UnauthorizedAccessError('Laboratory does not have AWS HealthOmics enabled');
    }
```

The `/aws-healthomics/workflow/list-private-workflows` API also will support AWS HealthOmics pagination parameters and search filtering by name:
* `/aws-healthomics/workflow/list-private-workflows?name={Name of Private Workflow}`
* `/aws-healthomics/workflow/list-private-workflows?maxRecords={Integer value greater than 0}&nextToken={Optional NextToken Pagination Index Value}`

I decided against re-using / translating the existing Seqera Pagination / Filtering parameter names, and keep the AWS HealthOmics Pagination / Filtering parameter names to match the SDK values so its easier to debug and maintain.

This means the FE should have a separate module specific for the AWS HealthOmics API integration between the FE and BE so the code and terminology are clearly separated from the Seqera NextFlow APIs.
