### PR TITLE
feat(EG-872): add '/aws-healthomics/run/list-runs' API endpoint

### DIFF
--- a/packages/back-end/src/app/controllers/aws-healthomics/run/list-runs.lambda.ts
+++ b/packages/back-end/src/app/controllers/aws-healthomics/run/list-runs.lambda.ts
@@ -20,9 +20,9 @@ const laboratoryService = new LaboratoryService();
 const omicsService = new OmicsService();
 
 /**
- * This GET /aws-healthomics/workflow/run/list-private-workflow-runs?laboratoryId={LaboratoryId}
+ * This GET /aws-healthomics/run/list-runs?laboratoryId={LaboratoryId}
  * API queries the same region's AWS HealthOmics service to retrieve a list of
- * Private Workflow Runs, and it expects:
+ * Runs, and it expects:
  *  - Required Query Parameter:
  *    - 'laboratoryId': to retrieve the Laboratory to verify access to AWS HealthOmics
  *  - Optional Query Parameters:

--- a/packages/back-end/src/app/controllers/aws-healthomics/workflow/list-private-workflows.lambda.ts
+++ b/packages/back-end/src/app/controllers/aws-healthomics/workflow/list-private-workflows.lambda.ts
@@ -66,6 +66,7 @@ export const handler: Handler = async (
     const response = await omicsService.listWorkflows(<ListWorkflowsCommandInput>{
       type: 'PRIVATE',
       ...queryParameters,
+      status: undefined, // Explicitly exclude status filter for Workflows
     });
     return buildResponse(200, JSON.stringify(response), event);
   } catch (err: any) {

--- a/packages/back-end/src/app/controllers/aws-healthomics/workflow/list-private-workflows.lambda.ts
+++ b/packages/back-end/src/app/controllers/aws-healthomics/workflow/list-private-workflows.lambda.ts
@@ -20,7 +20,7 @@ const laboratoryService = new LaboratoryService();
 const omicsService = new OmicsService();
 
 /**
- * This GET /aws-healthomics/workflow/list-workflows?laboratoryId={LaboratoryId}
+ * This GET /aws-healthomics/workflow/list-private-workflows?laboratoryId={LaboratoryId}
  * API queries the same region's AWS HealthOmics service to retrieve a list of
  * Private Workflows, and it expects:
  *  - Required Query Parameter:

--- a/packages/back-end/src/app/controllers/aws-healthomics/workflow/run/list-private-workflow-runs.lambda.ts
+++ b/packages/back-end/src/app/controllers/aws-healthomics/workflow/run/list-private-workflow-runs.lambda.ts
@@ -1,0 +1,106 @@
+import { ListRunsCommandInput, RunStatus } from '@aws-sdk/client-omics';
+import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/lib/app/utils/common';
+import {
+  LaboratoryNotFoundError,
+  RequiredIdNotFoundError,
+  UnauthorizedAccessError,
+} from '@easy-genomics/shared-lib/lib/app/utils/HttpError';
+import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
+import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
+import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
+import { OmicsService } from '@BE/services/omics-service';
+import {
+  validateLaboratoryManagerAccess,
+  validateLaboratoryTechnicianAccess,
+  validateOrganizationAdminAccess,
+} from '@BE/utils/auth-utils';
+import { AwsHealthOmicsQueryParameters, getAwsHealthOmicsApiQueryParameters } from '@BE/utils/rest-api-utils';
+
+const laboratoryService = new LaboratoryService();
+const omicsService = new OmicsService();
+
+/**
+ * This GET /aws-healthomics/workflow/run/list-workflow-runs?laboratoryId={LaboratoryId}
+ * API queries the same region's AWS HealthOmics service to retrieve a list of
+ * Private Workflow Runs, and it expects:
+ *  - Required Query Parameter:
+ *    - 'laboratoryId': to retrieve the Laboratory to verify access to AWS HealthOmics
+ *  - Optional Query Parameters:
+ *    - 'maxResults': pagination number of results
+ *    - 'nextToken': pagination results offset index
+ *    - 'name': string to search by the Workflow name attribute
+ *    - 'status': string to search by Status of Workflow Run
+ *
+ * @param event
+ */
+export const handler: Handler = async (
+  event: APIGatewayProxyWithCognitoAuthorizerEvent,
+): Promise<APIGatewayProxyResult> => {
+  console.log('EVENT: \n' + JSON.stringify(event, null, 2));
+  try {
+    // Get required query parameter
+    const laboratoryId: string = event.queryStringParameters?.laboratoryId || '';
+    if (laboratoryId === '') throw new RequiredIdNotFoundError('laboratoryId');
+
+    const laboratory: Laboratory = await laboratoryService.queryByLaboratoryId(laboratoryId);
+
+    if (!laboratory) {
+      throw new LaboratoryNotFoundError();
+    }
+
+    if (!laboratory.AwsHealthOmicsEnabled) {
+      throw new UnauthorizedAccessError('Laboratory does not have AWS HealthOmics enabled');
+    }
+
+    // Only available for Org Admins or Laboratory Managers and Technicians
+    if (
+      !(
+        validateOrganizationAdminAccess(event, laboratory.OrganizationId) ||
+        validateLaboratoryManagerAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId) ||
+        validateLaboratoryTechnicianAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId)
+      )
+    ) {
+      throw new UnauthorizedAccessError();
+    }
+
+    const queryParameters: AwsHealthOmicsQueryParameters = getAwsHealthOmicsApiQueryParameters(event);
+    const response = await omicsService.listRuns(<ListRunsCommandInput>{
+      ...queryParameters,
+      status: validateRunStatusQueryParameter(queryParameters.status),
+    });
+    return buildResponse(200, JSON.stringify(response), event);
+  } catch (err: any) {
+    console.error(err);
+    return buildErrorResponse(err, event);
+  }
+};
+
+/**
+ * Helper function to validate status query parameter and return the corresponding RunStatus filter.
+ */
+function validateRunStatusQueryParameter(status: string | undefined): RunStatus | undefined {
+  if (!status) {
+    return undefined;
+  }
+
+  switch (status.toUpperCase()) {
+    case 'CANCELLED':
+      return RunStatus.CANCELLED;
+    case 'COMPLETED':
+      return RunStatus.COMPLETED;
+    case 'DELETED':
+      return RunStatus.DELETED;
+    case 'FAILED':
+      return RunStatus.FAILED;
+    case 'PENDING':
+      return RunStatus.PENDING;
+    case 'RUNNING':
+      return RunStatus.RUNNING;
+    case 'STARTING':
+      return RunStatus.STARTING;
+    case 'STOPPING':
+      return RunStatus.STOPPING;
+    default:
+      return undefined;
+  }
+}

--- a/packages/back-end/src/app/controllers/aws-healthomics/workflow/run/list-private-workflow-runs.lambda.ts
+++ b/packages/back-end/src/app/controllers/aws-healthomics/workflow/run/list-private-workflow-runs.lambda.ts
@@ -20,7 +20,7 @@ const laboratoryService = new LaboratoryService();
 const omicsService = new OmicsService();
 
 /**
- * This GET /aws-healthomics/workflow/run/list-workflow-runs?laboratoryId={LaboratoryId}
+ * This GET /aws-healthomics/workflow/run/list-private-workflow-runs?laboratoryId={LaboratoryId}
  * API queries the same region's AWS HealthOmics service to retrieve a list of
  * Private Workflow Runs, and it expects:
  *  - Required Query Parameter:

--- a/packages/back-end/src/app/utils/rest-api-utils.ts
+++ b/packages/back-end/src/app/utils/rest-api-utils.ts
@@ -11,6 +11,7 @@ export const enum REST_API_METHOD {
 
 export type AwsHealthOmicsQueryParameters = {
   name?: string;
+  status?: string;
   startingToken?: string;
   maxResults?: number;
 };
@@ -104,9 +105,14 @@ export function getAwsHealthOmicsApiQueryParameters(event: APIGatewayProxyEvent)
   const name: string | undefined = event.queryStringParameters?.name || undefined;
   const maxResults: string | undefined = event.queryStringParameters?.maxResults || undefined;
   const nextToken: string | undefined = event.queryStringParameters?.nextToken || undefined;
+  const status: string | undefined = event.queryStringParameters?.status || undefined;
 
   if (name) {
     apiQueryParameters.name = name;
+  }
+
+  if (status) {
+    apiQueryParameters.status = status;
   }
 
   if (maxResults && parseInt(maxResults) > 0) {

--- a/packages/back-end/src/infra/stacks/aws-healthomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/aws-healthomics-nested-stack.ts
@@ -118,5 +118,21 @@ export class AwsHealthOmicsNestedStack extends NestedStack {
         effect: Effect.ALLOW,
       }),
     ]);
+
+    // /aws-healthomics/workflow/run/list-private-workflow-runs
+    this.iam.addPolicyStatements('/aws-healthomics/workflow/run/list-private-workflow-runs', [
+      new PolicyStatement({
+        resources: [
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table`,
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table/index/*`,
+        ],
+        actions: ['dynamodb:Query'],
+      }),
+      new PolicyStatement({
+        resources: [`arn:aws:omics:${this.props.env.region!}:${this.props.env.account!}:run/*`],
+        actions: ['omics:ListRuns'],
+        effect: Effect.ALLOW,
+      }),
+    ]);
   };
 }

--- a/packages/back-end/src/infra/stacks/aws-healthomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/aws-healthomics-nested-stack.ts
@@ -119,8 +119,8 @@ export class AwsHealthOmicsNestedStack extends NestedStack {
       }),
     ]);
 
-    // /aws-healthomics/workflow/run/list-private-workflow-runs
-    this.iam.addPolicyStatements('/aws-healthomics/workflow/run/list-private-workflow-runs', [
+    // /aws-healthomics/run/list-runs
+    this.iam.addPolicyStatements('/aws-healthomics/run/list-runs', [
       new PolicyStatement({
         resources: [
           `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table`,


### PR DESCRIPTION
This PR adds the `/aws-healthomics/run/list-runs` API endpoint.

It requires the query parameter `?laboratoryId={LaboratoryId}` to verify if the Lab has AWS HealthOmics access enabled.

It also supports the following optional query parameters:
 - `maxResults`: pagination limit
 - `nextToken`: pagination offset index
 - `name`: search filtering by run name
 - `status`: search filtering by run status 

Note: the  `/aws-healthomics/workflow/list-private-workflows` API does not support the status query parameter so it is explicitly removed to avoid SDK request type errors.