### PR TITLE
feat(EG-878): add '/aws-healthomics/run/read-run' API endpoint

### DIFF
--- a/packages/back-end/src/app/controllers/aws-healthomics/run/read-run.lambda.ts
+++ b/packages/back-end/src/app/controllers/aws-healthomics/run/read-run.lambda.ts
@@ -1,0 +1,74 @@
+import { GetRunCommandInput } from '@aws-sdk/client-omics';
+import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/lib/app/utils/common';
+import {
+  LaboratoryNotFoundError,
+  RequiredIdNotFoundError,
+  UnauthorizedAccessError,
+} from '@easy-genomics/shared-lib/lib/app/utils/HttpError';
+import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
+import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
+import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
+import { OmicsService } from '@BE/services/omics-service';
+import {
+  validateLaboratoryManagerAccess,
+  validateLaboratoryTechnicianAccess,
+  validateOrganizationAdminAccess,
+} from '@BE/utils/auth-utils';
+
+const laboratoryService = new LaboratoryService();
+const omicsService = new OmicsService();
+
+/**
+ * This GET /aws-healthomics/run/read-run/:{RunId}?laboratoryId={LaboratoryId}
+ * API queries the same region's AWS HealthOmics service to retrieve a specific
+ * Run's details, and it expects:
+ *  - Required Path Parameter:
+ *    - 'runId': to retrieve the Run's details from AWS HealthOmics
+ *  - Required Query Parameter:
+ *    - 'laboratoryId': to retrieve the Laboratory to verify access to AWS HealthOmics
+ *
+ * @param event
+ */
+export const handler: Handler = async (
+  event: APIGatewayProxyWithCognitoAuthorizerEvent,
+): Promise<APIGatewayProxyResult> => {
+  console.log('EVENT: \n' + JSON.stringify(event, null, 2));
+  try {
+    // Get Path Parameter
+    const id: string = event.pathParameters?.id || '';
+    if (id === '') throw new RequiredIdNotFoundError();
+
+    // Get required query parameter
+    const laboratoryId: string = event.queryStringParameters?.laboratoryId || '';
+    if (laboratoryId === '') throw new RequiredIdNotFoundError('laboratoryId');
+
+    const laboratory: Laboratory = await laboratoryService.queryByLaboratoryId(laboratoryId);
+
+    if (!laboratory) {
+      throw new LaboratoryNotFoundError();
+    }
+
+    if (!laboratory.AwsHealthOmicsEnabled) {
+      throw new UnauthorizedAccessError('Laboratory does not have AWS HealthOmics enabled');
+    }
+
+    // Only available for Org Admins or Laboratory Managers and Technicians
+    if (
+      !(
+        validateOrganizationAdminAccess(event, laboratory.OrganizationId) ||
+        validateLaboratoryManagerAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId) ||
+        validateLaboratoryTechnicianAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId)
+      )
+    ) {
+      throw new UnauthorizedAccessError();
+    }
+
+    const response = await omicsService.getRun(<GetRunCommandInput>{
+      id: id,
+    });
+    return buildResponse(200, JSON.stringify(response), event);
+  } catch (err: any) {
+    console.error(err);
+    return buildErrorResponse(err, event);
+  }
+};

--- a/packages/back-end/src/app/services/omics-service.ts
+++ b/packages/back-end/src/app/services/omics-service.ts
@@ -45,7 +45,7 @@ export class OmicsService {
   };
 
   public getRun = async (getRunCommandInput: GetRunCommandInput): Promise<GetRunCommandOutput> => {
-    return this.omicsRequest<GetRunCommandInput, GetRunCommandOutput>(OmicsCommand.GET_WORKFLOW, getRunCommandInput);
+    return this.omicsRequest<GetRunCommandInput, GetRunCommandOutput>(OmicsCommand.GET_RUN, getRunCommandInput);
   };
 
   public getWorkflow = async (getWorkflowCommandInput: GetWorkflowCommandInput): Promise<GetWorkflowCommandOutput> => {

--- a/packages/back-end/src/infra/stacks/aws-healthomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/aws-healthomics-nested-stack.ts
@@ -134,5 +134,20 @@ export class AwsHealthOmicsNestedStack extends NestedStack {
         effect: Effect.ALLOW,
       }),
     ]);
+    // /aws-healthomics/run/read-run
+    this.iam.addPolicyStatements('/aws-healthomics/run/read-run', [
+      new PolicyStatement({
+        resources: [
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table`,
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table/index/*`,
+        ],
+        actions: ['dynamodb:Query'],
+      }),
+      new PolicyStatement({
+        resources: [`arn:aws:omics:${this.props.env.region!}:${this.props.env.account!}:run/*`],
+        actions: ['omics:GetRun'],
+        effect: Effect.ALLOW,
+      }),
+    ]);
   };
 }


### PR DESCRIPTION
This PR adds the HTTP GET `/aws-healthomics/run/read-run/{RunId}?laboratoryId={LaboratoryId}` API endpoint.

It requires:
 - `RunId` path parameter
 - `LaboratoryId` query parameter

This API basically returns the Run's result details for an AWS HealthOmics Workflow.