### PR TITLE
fix(EG-868): org dropdown not working for superuser

### DIFF
--- a/packages/front-end/src/app/components/EGHeader.vue
+++ b/packages/front-end/src/app/components/EGHeader.vue
@@ -110,10 +110,10 @@
 
                 <div class="flex flex-col items-start gap-1">
                   <div class="font-medium">
-                    {{ userStore.currentUserDetails.firstName }} {{ userStore.currentUserDetails.lastName }}
+                    {{ userStore.currentUserDisplayName }}
                   </div>
                   <div class="text-muted">
-                    {{ orgsStore.orgs[userStore.currentOrgId].Name }}
+                    {{ orgsStore.orgs[userStore.currentOrgId]?.Name || '' }}
                   </div>
                 </div>
               </div>

--- a/packages/front-end/src/app/components/EGHeader.vue
+++ b/packages/front-end/src/app/components/EGHeader.vue
@@ -34,7 +34,7 @@
       },
     ]);
 
-    if (otherOrgs.value.length > 0) {
+    if (!userStore.isSuperuser && otherOrgs.value.length > 0) {
       items.push([
         {
           slot: 'other-orgs',

--- a/packages/front-end/src/app/components/EGInitialsCircle.vue
+++ b/packages/front-end/src/app/components/EGInitialsCircle.vue
@@ -1,5 +1,5 @@
 <template>
   <div class="bg-primary flex h-8 w-8 items-center justify-center rounded-full text-xs text-white">
-    {{ useUserStore().initials }}
+    {{ useUserStore().currentUserInitials }}
   </div>
 </template>

--- a/packages/front-end/src/app/composables/useAuth.ts
+++ b/packages/front-end/src/app/composables/useAuth.ts
@@ -19,8 +19,8 @@ export default function useAuth() {
       useUiStore().setRequestPending('signIn');
       const user = await Auth.signIn(username, password);
       if (user) {
-        await useUserStore().loadCurrentUserPermissions();
-        await useUserStore().loadCurrentUserDetails();
+        const { $api } = useNuxtApp();
+        await useUser($api).setCurrentUserDataFromToken();
         await useOrgsStore().loadOrgs();
         if (useUserStore().isSuperuser) {
           await navigateTo('/orgs');

--- a/packages/front-end/src/app/composables/useUser.ts
+++ b/packages/front-end/src/app/composables/useUser.ts
@@ -79,22 +79,38 @@ export default function useUser($api?: any) {
   }
 
   /**
-   * @description Obtains the user's current org id from the auth JWT then sets it as the current org in the user store
+   * @description Obtains details about the current user from the auth JWT then sets them in the user store
    */
-  async function setCurrentUserOrg() {
+  async function setCurrentUserDataFromToken() {
     try {
-      if (useUserStore().isSuperuser) {
-        // superuser won't have org access data so we can't do this, and it shouldn't need it anyway
+      const userStore = useUserStore();
+
+      // decode token
+      const token = await useAuth().getToken();
+      const decodedToken: any = decodeJwt(token);
+
+      // retrieve and set account email
+      userStore.currentUserDetails.email = decodedToken.email;
+
+      // check and set superuser status
+      userStore.currentUserPermissions.isSuperuser = decodedToken['cognito:groups']?.includes('SystemAdmin');
+
+      // if superuser, quit now, as su accounts won't have any of the details retrieved in the rest of this function
+      if (userStore.currentUserPermissions.isSuperuser) {
         return;
       }
 
-      const token = await useAuth().getToken();
-      const decodedToken: any = decodeJwt(token);
+      // retrieve and set org access
       const parsedOrgAccess = JSON.parse(decodedToken.OrganizationAccess);
       const currentOrgId = Object.keys(parsedOrgAccess)[0];
       const orgs = await $api.orgs.list();
       const currentOrg = orgs.find((org: Organization) => org.OrganizationId === currentOrgId);
-      useUserStore().setOrgAccess(currentOrg);
+      userStore.setOrgAccess(currentOrg);
+
+      // retrieve and set personal details
+      userStore.currentUserDetails.firstName = decodedToken.FirstName;
+      userStore.currentUserDetails.lastName = decodedToken.LastName;
+      userStore.currentUserDetails.preferredName = decodedToken.PreferredName;
     } catch (error) {
       console.error('Error occurred setting the current organisation.', error);
       throw error;
@@ -106,6 +122,6 @@ export default function useUser($api?: any) {
     labsCount,
     invite,
     resendInvite,
-    setCurrentUserOrg,
+    setCurrentUserDataFromToken,
   };
 }

--- a/packages/front-end/src/app/composables/useUser.ts
+++ b/packages/front-end/src/app/composables/useUser.ts
@@ -1,5 +1,4 @@
 import { CreateUserInvitationRequestSchema } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/user-invitation';
-import { Organization } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/organization';
 import { OrganizationUserDetails } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/organization-user-details';
 import { CreateUserInvitationRequest } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/user-invitation';
 import { VALIDATION_MESSAGES } from '@FE/constants/validation';
@@ -100,12 +99,15 @@ export default function useUser($api?: any) {
         return;
       }
 
-      // retrieve and set org access
+      // retrieve and set current org id and org access
       const parsedOrgAccess = JSON.parse(decodedToken.OrganizationAccess);
+
       const currentOrgId = Object.keys(parsedOrgAccess)[0];
-      const orgs = await $api.orgs.list();
-      const currentOrg = orgs.find((org: Organization) => org.OrganizationId === currentOrgId);
-      userStore.setOrgAccess(currentOrg);
+      userStore.currentOrg.OrganizationId = currentOrgId;
+
+      userStore.currentUserPermissions.orgPermissions = {
+        [currentOrgId]: parsedOrgAccess[currentOrgId],
+      };
 
       // retrieve and set personal details
       userStore.currentUserDetails.firstName = decodedToken.FirstName;

--- a/packages/front-end/src/app/layouts/default.vue
+++ b/packages/front-end/src/app/layouts/default.vue
@@ -2,7 +2,7 @@
   const routeKey = ref(0);
 
   const { $api } = useNuxtApp();
-  const { setCurrentUserOrg } = useUser($api);
+  const { setCurrentUserDataFromToken } = useUser($api);
   const hasInit = ref(false);
 
   /**
@@ -10,7 +10,7 @@
    * future scope to add user display details (name, email, etc.)
    */
   onBeforeMount(async () => {
-    await setCurrentUserOrg();
+    await setCurrentUserDataFromToken();
     hasInit.value = true;
   });
 

--- a/packages/front-end/src/app/repository/factory.ts
+++ b/packages/front-end/src/app/repository/factory.ts
@@ -76,7 +76,8 @@ class HttpFactory {
 
       if (shouldRefresh && token) {
         // Ensure permissions are reloaded before remounting the app
-        await useUserStore().loadCurrentUserPermissions();
+        const { $api } = useNuxtApp();
+        await useUser($api).setCurrentUserDataFromToken();
         useUiStore().incrementRemountAppKey();
       }
 

--- a/packages/front-end/src/app/stores/user.ts
+++ b/packages/front-end/src/app/stores/user.ts
@@ -88,8 +88,32 @@ const useUserStore = defineStore('userStore', {
 
     // user details
 
-    initials: (_state: UserStoreState): string =>
-      (_state.currentUserDetails.firstName?.charAt(0) || '?') + (_state.currentUserDetails.lastName?.charAt(0) || '?'),
+    currentUserPreferredOrFirstName: (_state: UserStoreState): string | null =>
+      _state.currentUserDetails.preferredName || _state.currentUserDetails.firstName,
+
+    currentUserInitials: (_state: UserStoreState): string => {
+      if (_state.currentUserPermissions.isSuperuser) {
+        return '#';
+      }
+
+      const firstInitial: string = useUserStore().currentUserPreferredOrFirstName?.charAt(0) || '?';
+      const lastInitial: string = _state.currentUserDetails.lastName?.charAt(0) || '?';
+      return firstInitial + lastInitial;
+    },
+
+    currentUserDisplayName: (_state: UserStoreState): string => {
+      const preferredOrFirstName = useUserStore().currentUserPreferredOrFirstName;
+      const lastName = _state.currentUserDetails.lastName;
+      const email = _state.currentUserDetails.email;
+
+      if (preferredOrFirstName) {
+        return `${preferredOrFirstName} ${lastName}`;
+      } else if (email) {
+        return email;
+      } else {
+        return '???';
+      }
+    },
   },
 
   actions: {

--- a/packages/front-end/src/app/stores/user.ts
+++ b/packages/front-end/src/app/stores/user.ts
@@ -13,6 +13,8 @@ interface UserStoreState {
   currentUserDetails: {
     firstName: string | null;
     lastName: string | null;
+    preferredName: string | null;
+    email: string | null;
   };
 }
 
@@ -27,6 +29,8 @@ const initialState = (): UserStoreState => ({
   currentUserDetails: {
     firstName: null,
     lastName: null,
+    preferredName: null,
+    email: null,
   },
 });
 
@@ -94,29 +98,6 @@ const useUserStore = defineStore('userStore', {
     },
     reset() {
       Object.assign(this, initialState());
-    },
-
-    async loadCurrentUserPermissions(): Promise<void> {
-      const token = await useAuth().getToken();
-      const decodedToken: any = decodeJwt(token);
-
-      if (decodedToken['cognito:groups']?.includes('SystemAdmin')) {
-        this.currentUserPermissions.isSuperuser = true;
-        return;
-      }
-
-      this.currentUserPermissions.isSuperuser = false;
-
-      const parsedOrgAccess = JSON.parse(decodedToken.OrganizationAccess);
-      this.currentUserPermissions.orgPermissions = parsedOrgAccess;
-    },
-
-    async loadCurrentUserDetails(): Promise<void> {
-      const token = await useAuth().getToken();
-      const decodedToken: any = decodeJwt(token);
-
-      this.currentUserDetails.firstName = decodedToken.FirstName;
-      this.currentUserDetails.lastName = decodedToken.LastName;
     },
   },
 


### PR DESCRIPTION
## Title*
Fix org dropdown not working for superuser

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [X] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
I forgot to build the org switcher dropdown for superuser and it didn't work. In this PR I fixed this.

Also in this PR, I made some refactoring changes to the logic that pulls out user data from the token and saves it into the user store. My goal was to unify the code flows (have fewer functions doing roughly the same thing) and make it consistent and automatic, so that we can reference the data in the user store without needing to think about the state of the application.

I also moved some of the display logic (re: current user display name and initials) to getters in the user store.

## Testing*
e2e tests passed in build2.

## Impact
Should be no change to user space or development from refactors.

Dropdown now works for superuser.

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.