### PR TITLE
feat(EG-874): omics get workflow api

### DIFF
--- a/packages/back-end/src/app/controllers/aws-healthomics/workflow/read-private-workflow.lambda.ts
+++ b/packages/back-end/src/app/controllers/aws-healthomics/workflow/read-private-workflow.lambda.ts
@@ -1,0 +1,75 @@
+import { GetWorkflowCommandInput } from '@aws-sdk/client-omics/dist-types/commands/GetWorkflowCommand';
+import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/lib/app/utils/common';
+import {
+  LaboratoryNotFoundError,
+  RequiredIdNotFoundError,
+  UnauthorizedAccessError,
+} from '@easy-genomics/shared-lib/lib/app/utils/HttpError';
+import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
+import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
+import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
+import { OmicsService } from '@BE/services/omics-service';
+import {
+  validateLaboratoryManagerAccess,
+  validateLaboratoryTechnicianAccess,
+  validateOrganizationAdminAccess,
+} from '@BE/utils/auth-utils';
+
+const laboratoryService = new LaboratoryService();
+const omicsService = new OmicsService();
+
+/**
+ * This GET /aws-healthomics/workflow/read-private-workflow/{:id}?workflowId={workflowId}
+ * API queries the same region's AWS HealthOmics service to retrieve a Private Workflow.
+ * This endpoint expects:
+ *  - Required Path Parameter:
+ *    - 'id': NextFlow Tower Workflow Id
+ *  - Required Query Parameter:
+ *    - 'laboratoryId': to retrieve the Laboratory to verify access to AWS HealthOmics
+ *
+ * @param event
+ */
+export const handler: Handler = async (
+  event: APIGatewayProxyWithCognitoAuthorizerEvent,
+): Promise<APIGatewayProxyResult> => {
+  console.log('EVENT: \n' + JSON.stringify(event, null, 2));
+  try {
+    // Get required path parameter
+    const id: string = event.pathParameters?.id || '';
+    if (id === '') throw new RequiredIdNotFoundError();
+
+    // Get required query parameter
+    const laboratoryId: string = event.queryStringParameters?.laboratoryId || '';
+    if (laboratoryId === '') throw new RequiredIdNotFoundError('laboratoryId');
+
+    const laboratory: Laboratory = await laboratoryService.queryByLaboratoryId(laboratoryId);
+
+    if (!laboratory) {
+      throw new LaboratoryNotFoundError();
+    }
+
+    if (!laboratory.AwsHealthOmicsEnabled) {
+      throw new UnauthorizedAccessError('Laboratory does not have AWS HealthOmics enabled');
+    }
+
+    // Only available for Org Admins or Laboratory Managers and Technicians
+    if (
+      !(
+        validateOrganizationAdminAccess(event, laboratory.OrganizationId) ||
+        validateLaboratoryManagerAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId) ||
+        validateLaboratoryTechnicianAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId)
+      )
+    ) {
+      throw new UnauthorizedAccessError();
+    }
+
+    const response = await omicsService.getWorkflow(<GetWorkflowCommandInput>{
+      type: 'PRIVATE',
+      id: id,
+    });
+    return buildResponse(200, JSON.stringify(response), event);
+  } catch (err: any) {
+    console.error(err);
+    return buildErrorResponse(err, event);
+  }
+};

--- a/packages/back-end/src/app/controllers/aws-healthomics/workflow/read-private-workflow.lambda.ts
+++ b/packages/back-end/src/app/controllers/aws-healthomics/workflow/read-private-workflow.lambda.ts
@@ -21,7 +21,7 @@ const laboratoryService = new LaboratoryService();
 const omicsService = new OmicsService();
 
 /**
- * This GET /aws-healthomics/workflow/read-private-workflow/{:id}?workflowId={workflowId}
+ * This GET /aws-healthomics/workflow/read-private-workflow/{:id}?laboratoryId={laboratoryId}
  * API queries the same region's AWS HealthOmics service to retrieve a Private Workflow.
  * This endpoint expects:
  *  - Required Path Parameter:

--- a/packages/back-end/src/infra/stacks/aws-healthomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/aws-healthomics-nested-stack.ts
@@ -119,6 +119,22 @@ export class AwsHealthOmicsNestedStack extends NestedStack {
       }),
     ]);
 
+    // /aws-healthomics/workflow/read-private-workflow
+    this.iam.addPolicyStatements('/aws-healthomics/workflow/read-private-workflow', [
+      new PolicyStatement({
+        resources: [
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table`,
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table/index/*`,
+        ],
+        actions: ['dynamodb:Query'],
+      }),
+      new PolicyStatement({
+        resources: [`arn:aws:omics:${this.props.env.region!}:${this.props.env.account!}:workflow/*`],
+        actions: ['omics:GetWorkflow'],
+        effect: Effect.ALLOW,
+      }),
+    ]);
+
     // /aws-healthomics/run/list-runs
     this.iam.addPolicyStatements('/aws-healthomics/run/list-runs', [
       new PolicyStatement({

--- a/packages/shared-lib/src/app/utils/HttpError.ts
+++ b/packages/shared-lib/src/app/utils/HttpError.ts
@@ -407,3 +407,17 @@ export class UserNotInOrganizationError extends HttpError {
     super('User not permitted access without first granted access to the Organization', 409, 'EG-405', messageOpt);
   }
 }
+
+// AWS Omics errors
+
+/**
+ * Omics Workflow not found
+ *
+ * @param workflowId
+ * @param messageOpt - optional additional message
+ */
+export class OmicsWorkflowNotFoundError extends HttpError {
+  constructor(workflowId: string, messageOpt?: string) {
+    super(`Workflow '${workflowId}' could not be found`, 404, 'EG-503', messageOpt);
+  }
+}


### PR DESCRIPTION
## Title
AWS Omics get workflow api

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
This new endpoint takes in a workflowId (as `id`) in the path and a laboratoryId as a query param. The laboratory is used for checking if the laboratory has access to AWS Omics, and also for user permissions. This is only for private workflows.

## Testing
You will need to have a private workflow already setup in AWS Omics. You can use the _list-private-workflows_ endpoint to list out existing private workflows, then use the id's with this endpoint. If there are no private workflows you will need to create one in AWS, either through the console or the command line.

## Impact
No other changes or impacts to the project outside of added functionality

## Additional Information
Laboratories at present can't be enabled for AWS Omics via the FE, this may change in the future but I had to manually enable this via dynamodb, as well as adding a private workflow.

Not all AWS regions have AWS Omics. If your environment is set up in a region without Omics, you won't be able to use these features.

## Checklist
- [ ] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [ ] Code has been commented in particularly hard-to-understand areas.