### PR TITLE
feat: error for labs missing access to nextflow or omics

### DIFF
--- a/packages/back-end/src/app/controllers/aws-healthomics/run/list-runs.lambda.ts
+++ b/packages/back-end/src/app/controllers/aws-healthomics/run/list-runs.lambda.ts
@@ -6,6 +6,7 @@ import {
   UnauthorizedAccessError,
 } from '@easy-genomics/shared-lib/lib/app/utils/HttpError';
 import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
+import { MissingAWSHealthOmicsAccessError } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
 import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
 import { OmicsService } from '@BE/services/omics-service';
@@ -48,10 +49,6 @@ export const handler: Handler = async (
       throw new LaboratoryNotFoundError();
     }
 
-    if (!laboratory.AwsHealthOmicsEnabled) {
-      throw new UnauthorizedAccessError('Laboratory does not have AWS HealthOmics enabled');
-    }
-
     // Only available for Org Admins or Laboratory Managers and Technicians
     if (
       !(
@@ -61,6 +58,11 @@ export const handler: Handler = async (
       )
     ) {
       throw new UnauthorizedAccessError();
+    }
+
+    // Requires AWS Health Omics access
+    if (!laboratory.AwsHealthOmicsEnabled) {
+      throw new MissingAWSHealthOmicsAccessError();
     }
 
     const queryParameters: AwsHealthOmicsQueryParameters = getAwsHealthOmicsApiQueryParameters(event);

--- a/packages/back-end/src/app/controllers/aws-healthomics/run/read-run.lambda.ts
+++ b/packages/back-end/src/app/controllers/aws-healthomics/run/read-run.lambda.ts
@@ -6,6 +6,7 @@ import {
   UnauthorizedAccessError,
 } from '@easy-genomics/shared-lib/lib/app/utils/HttpError';
 import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
+import { MissingAWSHealthOmicsAccessError } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
 import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
 import { OmicsService } from '@BE/services/omics-service';
@@ -48,10 +49,6 @@ export const handler: Handler = async (
       throw new LaboratoryNotFoundError();
     }
 
-    if (!laboratory.AwsHealthOmicsEnabled) {
-      throw new UnauthorizedAccessError('Laboratory does not have AWS HealthOmics enabled');
-    }
-
     // Only available for Org Admins or Laboratory Managers and Technicians
     if (
       !(
@@ -61,6 +58,11 @@ export const handler: Handler = async (
       )
     ) {
       throw new UnauthorizedAccessError();
+    }
+
+    // Requires AWS Health Omics access
+    if (!laboratory.AwsHealthOmicsEnabled) {
+      throw new MissingAWSHealthOmicsAccessError();
     }
 
     const response = await omicsService.getRun(<GetRunCommandInput>{

--- a/packages/back-end/src/app/controllers/aws-healthomics/workflow/list-private-workflows.lambda.ts
+++ b/packages/back-end/src/app/controllers/aws-healthomics/workflow/list-private-workflows.lambda.ts
@@ -6,6 +6,7 @@ import {
   UnauthorizedAccessError,
 } from '@easy-genomics/shared-lib/lib/app/utils/HttpError';
 import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
+import { MissingAWSHealthOmicsAccessError } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
 import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
 import { OmicsService } from '@BE/services/omics-service';
@@ -47,10 +48,6 @@ export const handler: Handler = async (
       throw new LaboratoryNotFoundError();
     }
 
-    if (!laboratory.AwsHealthOmicsEnabled) {
-      throw new UnauthorizedAccessError('Laboratory does not have AWS HealthOmics enabled');
-    }
-
     // Only available for Org Admins or Laboratory Managers and Technicians
     if (
       !(
@@ -60,6 +57,11 @@ export const handler: Handler = async (
       )
     ) {
       throw new UnauthorizedAccessError();
+    }
+
+    // Requires AWS Health Omics access
+    if (!laboratory.AwsHealthOmicsEnabled) {
+      throw new MissingAWSHealthOmicsAccessError();
     }
 
     const queryParameters: AwsHealthOmicsQueryParameters = getAwsHealthOmicsApiQueryParameters(event);

--- a/packages/back-end/src/app/controllers/aws-healthomics/workflow/read-private-workflow.lambda.ts
+++ b/packages/back-end/src/app/controllers/aws-healthomics/workflow/read-private-workflow.lambda.ts
@@ -4,6 +4,7 @@ import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomic
 import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/src/app/utils/common';
 import {
   LaboratoryNotFoundError,
+  MissingAWSHealthOmicsAccessError,
   OmicsWorkflowNotFoundError,
   RequiredIdNotFoundError,
   UnauthorizedAccessError,
@@ -50,10 +51,6 @@ export const handler: Handler = async (
       throw new LaboratoryNotFoundError();
     }
 
-    if (!laboratory.AwsHealthOmicsEnabled) {
-      throw new UnauthorizedAccessError('Laboratory does not have AWS HealthOmics enabled');
-    }
-
     // Only available for Org Admins or Laboratory Managers and Technicians
     if (
       !(
@@ -63,6 +60,11 @@ export const handler: Handler = async (
       )
     ) {
       throw new UnauthorizedAccessError();
+    }
+
+    // Requires AWS Health Omics access
+    if (!laboratory.AwsHealthOmicsEnabled) {
+      throw new MissingAWSHealthOmicsAccessError();
     }
 
     const response = await omicsService

--- a/packages/back-end/src/app/controllers/nf-tower/compute-env/list-compute-envs.lambda.ts
+++ b/packages/back-end/src/app/controllers/nf-tower/compute-env/list-compute-envs.lambda.ts
@@ -5,6 +5,7 @@ import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/src
 import {
   LaboratoryAccessTokenUnavailableError,
   LaboratoryNotFoundError,
+  MissingNextFlowTowerAccessError,
   RequiredIdNotFoundError,
   UnauthorizedAccessError,
 } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
@@ -58,6 +59,11 @@ export const handler: Handler = async (
       )
     ) {
       throw new UnauthorizedAccessError();
+    }
+
+    // Laboratory requires access to NextFlow Tower
+    if (!laboratory.NextFlowTowerEnabled) {
+      throw new MissingNextFlowTowerAccessError();
     }
 
     // Retrieve Seqera Cloud / NextFlow Tower AccessToken from SSM

--- a/packages/back-end/src/app/controllers/nf-tower/compute-env/read-compute-env.lambda.ts
+++ b/packages/back-end/src/app/controllers/nf-tower/compute-env/read-compute-env.lambda.ts
@@ -5,6 +5,7 @@ import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/src
 import {
   LaboratoryAccessTokenUnavailableError,
   LaboratoryNotFoundError,
+  MissingNextFlowTowerAccessError,
   RequiredIdNotFoundError,
   UnauthorizedAccessError,
 } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
@@ -60,6 +61,11 @@ export const handler: Handler = async (
       )
     ) {
       throw new UnauthorizedAccessError();
+    }
+
+    // Laboratory requires access to NextFlow Tower
+    if (!laboratory.NextFlowTowerEnabled) {
+      throw new MissingNextFlowTowerAccessError();
     }
 
     // Retrieve Seqera Cloud / NextFlow Tower AccessToken from SSM

--- a/packages/back-end/src/app/controllers/nf-tower/file/request-file-download.lambda.ts
+++ b/packages/back-end/src/app/controllers/nf-tower/file/request-file-download.lambda.ts
@@ -8,6 +8,10 @@ import {
 import { RequestFileDownloadSchema } from '@easy-genomics/shared-lib/src/app/schema/nf-tower/file/request-file-download';
 import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
 import { RequestFileDownload } from '@easy-genomics/shared-lib/src/app/types/nf-tower/file/request-file-download';
+import {
+  LaboratoryNotFoundError,
+  MissingNextFlowTowerAccessError,
+} from '@easy-genomics/shared-lib/src/app/utils/HttpError';
 import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
 import { SsmService } from '@BE/services/ssm-service';
@@ -40,6 +44,11 @@ export const handler: Handler = async (
 
     const laboratoryId: string = request.LaboratoryId;
     const laboratory: Laboratory = await laboratoryService.queryByLaboratoryId(laboratoryId);
+
+    if (!laboratory) {
+      throw new LaboratoryNotFoundError();
+    }
+
     // Only Organisation Admins and Laboratory Members are allowed to access downloads
     if (
       !(
@@ -49,6 +58,11 @@ export const handler: Handler = async (
       )
     ) {
       throw new UnauthorizedAccessError();
+    }
+
+    // Laboratory requires access to NextFlow Tower
+    if (!laboratory.NextFlowTowerEnabled) {
+      throw new MissingNextFlowTowerAccessError();
     }
 
     // Retrieve Seqera Cloud / NextFlow Tower AccessToken from SSM

--- a/packages/back-end/src/app/controllers/nf-tower/pipeline/list-pipelines.lambda.ts
+++ b/packages/back-end/src/app/controllers/nf-tower/pipeline/list-pipelines.lambda.ts
@@ -5,6 +5,7 @@ import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/src
 import {
   LaboratoryAccessTokenUnavailableError,
   LaboratoryNotFoundError,
+  MissingNextFlowTowerAccessError,
   RequiredIdNotFoundError,
   UnauthorizedAccessError,
 } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
@@ -58,6 +59,11 @@ export const handler: Handler = async (
       )
     ) {
       throw new UnauthorizedAccessError();
+    }
+
+    // Laboratory requires access to NextFlow Tower
+    if (!laboratory.NextFlowTowerEnabled) {
+      throw new MissingNextFlowTowerAccessError();
     }
 
     // Retrieve Seqera Cloud / NextFlow Tower AccessToken from SSM

--- a/packages/back-end/src/app/controllers/nf-tower/pipeline/read-pipeline-launch-details.lambda.ts
+++ b/packages/back-end/src/app/controllers/nf-tower/pipeline/read-pipeline-launch-details.lambda.ts
@@ -5,6 +5,7 @@ import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/src
 import {
   LaboratoryAccessTokenUnavailableError,
   LaboratoryNotFoundError,
+  MissingNextFlowTowerAccessError,
   RequiredIdNotFoundError,
   UnauthorizedAccessError,
 } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
@@ -60,6 +61,11 @@ export const handler: Handler = async (
       )
     ) {
       throw new UnauthorizedAccessError();
+    }
+
+    // Laboratory requires access to NextFlow Tower
+    if (!laboratory.NextFlowTowerEnabled) {
+      throw new MissingNextFlowTowerAccessError();
     }
 
     // Retrieve Seqera Cloud / NextFlow Tower AccessToken from SSM

--- a/packages/back-end/src/app/controllers/nf-tower/pipeline/read-pipeline-schema.lambda.ts
+++ b/packages/back-end/src/app/controllers/nf-tower/pipeline/read-pipeline-schema.lambda.ts
@@ -5,6 +5,7 @@ import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/src
 import {
   LaboratoryAccessTokenUnavailableError,
   LaboratoryNotFoundError,
+  MissingNextFlowTowerAccessError,
   RequiredIdNotFoundError,
   UnauthorizedAccessError,
 } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
@@ -60,6 +61,11 @@ export const handler: Handler = async (
       )
     ) {
       throw new UnauthorizedAccessError();
+    }
+
+    // Laboratory requires access to NextFlow Tower
+    if (!laboratory.NextFlowTowerEnabled) {
+      throw new MissingNextFlowTowerAccessError();
     }
 
     // Retrieve Seqera Cloud / NextFlow Tower AccessToken from SSM

--- a/packages/back-end/src/app/controllers/nf-tower/pipeline/read-pipeline.lambda.ts
+++ b/packages/back-end/src/app/controllers/nf-tower/pipeline/read-pipeline.lambda.ts
@@ -5,6 +5,7 @@ import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/src
 import {
   LaboratoryAccessTokenUnavailableError,
   LaboratoryNotFoundError,
+  MissingNextFlowTowerAccessError,
   RequiredIdNotFoundError,
   UnauthorizedAccessError,
 } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
@@ -60,6 +61,11 @@ export const handler: Handler = async (
       )
     ) {
       throw new UnauthorizedAccessError();
+    }
+
+    // Laboratory requires access to NextFlow Tower
+    if (!laboratory.NextFlowTowerEnabled) {
+      throw new MissingNextFlowTowerAccessError();
     }
 
     // Retrieve Seqera Cloud / NextFlow Tower AccessToken from SSM

--- a/packages/back-end/src/app/controllers/nf-tower/workflow/cancel-workflow-execution.lambda.ts
+++ b/packages/back-end/src/app/controllers/nf-tower/workflow/cancel-workflow-execution.lambda.ts
@@ -5,6 +5,7 @@ import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/src
 import {
   LaboratoryAccessTokenUnavailableError,
   LaboratoryNotFoundError,
+  MissingNextFlowTowerAccessError,
   RequiredIdNotFoundError,
   UnauthorizedAccessError,
 } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
@@ -60,6 +61,11 @@ export const handler: Handler = async (
       )
     ) {
       throw new UnauthorizedAccessError();
+    }
+
+    // Laboratory requires access to NextFlow Tower
+    if (!laboratory.NextFlowTowerEnabled) {
+      throw new MissingNextFlowTowerAccessError();
     }
 
     // Retrieve Seqera Cloud / NextFlow Tower AccessToken from SSM

--- a/packages/back-end/src/app/controllers/nf-tower/workflow/create-workflow-execution.lambda.ts
+++ b/packages/back-end/src/app/controllers/nf-tower/workflow/create-workflow-execution.lambda.ts
@@ -9,6 +9,7 @@ import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/src
 import {
   LaboratoryAccessTokenUnavailableError,
   LaboratoryNotFoundError,
+  MissingNextFlowTowerAccessError,
   RequiredIdNotFoundError,
   UnauthorizedAccessError,
 } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
@@ -65,6 +66,11 @@ export const handler: Handler = async (
       )
     ) {
       throw new UnauthorizedAccessError();
+    }
+
+    // Laboratory requires access to NextFlow Tower
+    if (!laboratory.NextFlowTowerEnabled) {
+      throw new MissingNextFlowTowerAccessError();
     }
 
     // Fetch the user

--- a/packages/back-end/src/app/controllers/nf-tower/workflow/list-workflows.lambda.ts
+++ b/packages/back-end/src/app/controllers/nf-tower/workflow/list-workflows.lambda.ts
@@ -5,6 +5,7 @@ import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/src
 import {
   LaboratoryAccessTokenUnavailableError,
   LaboratoryNotFoundError,
+  MissingNextFlowTowerAccessError,
   RequiredIdNotFoundError,
   UnauthorizedAccessError,
 } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
@@ -58,6 +59,11 @@ export const handler: Handler = async (
       )
     ) {
       throw new UnauthorizedAccessError();
+    }
+
+    // Laboratory requires access to NextFlow Tower
+    if (!laboratory.NextFlowTowerEnabled) {
+      throw new MissingNextFlowTowerAccessError();
     }
 
     // Retrieve Seqera Cloud / NextFlow Tower AccessToken from SSM

--- a/packages/back-end/src/app/controllers/nf-tower/workflow/read-workflow-metrics.lambda.ts
+++ b/packages/back-end/src/app/controllers/nf-tower/workflow/read-workflow-metrics.lambda.ts
@@ -5,6 +5,7 @@ import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/src
 import {
   LaboratoryAccessTokenUnavailableError,
   LaboratoryNotFoundError,
+  MissingNextFlowTowerAccessError,
   RequiredIdNotFoundError,
   UnauthorizedAccessError,
 } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
@@ -60,6 +61,11 @@ export const handler: Handler = async (
       )
     ) {
       throw new UnauthorizedAccessError();
+    }
+
+    // Laboratory requires access to NextFlow Tower
+    if (!laboratory.NextFlowTowerEnabled) {
+      throw new MissingNextFlowTowerAccessError();
     }
 
     // Retrieve Seqera Cloud / NextFlow Tower AccessToken from SSM

--- a/packages/back-end/src/app/controllers/nf-tower/workflow/read-workflow-progress.lambda.ts
+++ b/packages/back-end/src/app/controllers/nf-tower/workflow/read-workflow-progress.lambda.ts
@@ -5,6 +5,7 @@ import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/src
 import {
   LaboratoryAccessTokenUnavailableError,
   LaboratoryNotFoundError,
+  MissingNextFlowTowerAccessError,
   RequiredIdNotFoundError,
   UnauthorizedAccessError,
 } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
@@ -60,6 +61,11 @@ export const handler: Handler = async (
       )
     ) {
       throw new UnauthorizedAccessError();
+    }
+
+    // Laboratory requires access to NextFlow Tower
+    if (!laboratory.NextFlowTowerEnabled) {
+      throw new MissingNextFlowTowerAccessError();
     }
 
     // Retrieve Seqera Cloud / NextFlow Tower AccessToken from SSM

--- a/packages/back-end/src/app/controllers/nf-tower/workflow/read-workflow-reports.lambda.ts
+++ b/packages/back-end/src/app/controllers/nf-tower/workflow/read-workflow-reports.lambda.ts
@@ -2,7 +2,11 @@ import { GetParameterCommandOutput } from '@aws-sdk/client-ssm';
 import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
 import { DescribeWorkflowReportsResponse } from '@easy-genomics/shared-lib/src/app/types/nf-tower/workflow-reports';
 import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/src/app/utils/common';
-import { LaboratoryNotFoundError, UnauthorizedAccessError } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
+import {
+  LaboratoryNotFoundError,
+  MissingNextFlowTowerAccessError,
+  UnauthorizedAccessError,
+} from '@easy-genomics/shared-lib/src/app/utils/HttpError';
 import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
 import { SsmService } from '@BE/services/ssm-service';
@@ -55,6 +59,11 @@ export const handler: Handler = async (
       )
     ) {
       throw new UnauthorizedAccessError();
+    }
+
+    // Laboratory requires access to NextFlow Tower
+    if (!laboratory.NextFlowTowerEnabled) {
+      throw new MissingNextFlowTowerAccessError();
     }
 
     // Retrieve Seqera Cloud / NextFlow Tower AccessToken from SSM

--- a/packages/back-end/src/app/controllers/nf-tower/workflow/read-workflow.lambda.ts
+++ b/packages/back-end/src/app/controllers/nf-tower/workflow/read-workflow.lambda.ts
@@ -5,6 +5,7 @@ import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/src
 import {
   LaboratoryAccessTokenUnavailableError,
   LaboratoryNotFoundError,
+  MissingNextFlowTowerAccessError,
   RequiredIdNotFoundError,
   UnauthorizedAccessError,
 } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
@@ -60,6 +61,11 @@ export const handler: Handler = async (
       )
     ) {
       throw new UnauthorizedAccessError();
+    }
+
+    // Laboratory requires access to NextFlow Tower
+    if (!laboratory.NextFlowTowerEnabled) {
+      throw new MissingNextFlowTowerAccessError();
     }
 
     // Retrieve Seqera Cloud / NextFlow Tower AccessToken from SSM

--- a/packages/shared-lib/src/app/constants/errorMessages.ts
+++ b/packages/shared-lib/src/app/constants/errorMessages.ts
@@ -26,6 +26,8 @@ export const ERROR_CODES: ErrorMessages = {
   'EG-312': 'Removing user from laboratory failed',
   'EG-313': 'Laboratory User not found',
   'EG-314': 'Laboratory Bucket not found',
+  'EG-315': 'Laboratory does not have AWS HealthOmics enabled',
+  'EG-316': 'Laboratory does not have Seqera Cloud / NextFlow Tower enabled',
   'EG-401': 'User already exists',
   'EG-402': 'User deletion failed',
   'EG-403': 'User not found',

--- a/packages/shared-lib/src/app/types/easy-genomics/errors.ts
+++ b/packages/shared-lib/src/app/types/easy-genomics/errors.ts
@@ -24,6 +24,8 @@ export type ErrorCodeKeys =
   | 'EG-312'
   | 'EG-313'
   | 'EG-314'
+  | 'EG-315'
+  | 'EG-316'
   | 'EG-401'
   | 'EG-402'
   | 'EG-403'

--- a/packages/shared-lib/src/app/utils/HttpError.ts
+++ b/packages/shared-lib/src/app/utils/HttpError.ts
@@ -351,6 +351,28 @@ export class LaboratoryBucketNotFoundError extends HttpError {
   }
 }
 
+/**
+ * Laboratory does not have access to AWS Health Omics
+ *
+ * @param messageOpt - optional additional message
+ */
+export class MissingAWSHealthOmicsAccessError extends HttpError {
+  constructor(messageOpt?: string) {
+    super('Laboratory does not have AWS HealthOmics enabled', 403, 'EG-315', messageOpt);
+  }
+}
+
+/**
+ * Laboratory does not have access to NextFlow Tower / Seqera Cloud
+ *
+ * @param messageOpt - optional additional message
+ */
+export class MissingNextFlowTowerAccessError extends HttpError {
+  constructor(messageOpt?: string) {
+    super('Laboratory does not have Seqera Cloud / NextFlow Tower enabled', 403, 'EG-316', messageOpt);
+  }
+}
+
 // User Errors
 
 /**


### PR DESCRIPTION
## Title*
Throw discrete error messages for when a laboratory lacks NextFlow Tower of AWS HealthOmics access

## Type of Change*
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Throw error (EG-315) for AWS HealthOmics endpoints for laboratories that are not allowed to use AWS HealthOmics.
Throw error (EG-316) for NextFlow Tower endpoints for laboratories that are not allowed to use NextFlow Tower.

## Testing*
Labs can be enabled/disabled for both HealthOmics and NextFlow, but UI will likely prevent any actions, so will likely need to use postman to call the API endpoints directly.

## Impact
Nextflow endpoints are now locked down to only labs enabled for nextflow.
AWS HealthOmics endpoints already had these protections, but just threw a standard not authorized error, where as now they throw a specific error.

## Checklist*
- [ ] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [ ] Code has been commented in particularly hard-to-understand areas.