### PR TITLE
feat(EG-873): combined runs table

### DIFF
--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -449,6 +449,9 @@
   }
 
   function viewRunOmicsWorkflow(workflow: OmicsRun) {
+    useToastStore().info('Running HealthOmics Workflows is not yet implemented');
+    return;
+
     const omicsRunTempId = uuidv4();
 
     runStore.updateWipOmicsRun(omicsRunTempId, {

--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -148,6 +148,7 @@
     { key: 'lastUpdated', label: 'Last Updated' },
     { key: 'status', label: 'Status' },
     { key: 'owner', label: 'Owner' },
+    { key: 'source', label: 'Source' },
     { key: 'actions', label: 'Actions' },
   ];
 
@@ -683,6 +684,10 @@
             <div class="text-body text-sm font-medium">{{ run.owner }}</div>
           </template>
 
+          <template #source-data="{ row: run }">
+            <div class="text-body text-sm font-medium capitalize">{{ run.type }}</div>
+          </template>
+
           <template #actions-data="{ row }">
             <div class="flex justify-end">
               <EGActionButton :items="runsActionItems(row)" class="ml-2" @click="$event.stopPropagation()" />
@@ -696,6 +701,7 @@
           </template>
         </EGTable>
       </div>
+
       <!-- Lab Users tab -->
       <div v-else-if="item.key === 'users'" class="space-y-3">
         <EGSearchInput

--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -41,10 +41,9 @@
   const canAddUsers = ref(false);
   const showAddUserModule = ref(false);
   const searchOutput = ref('');
+  const runToCancel = ref<GenericRun | null>(null);
   const isCancelSeqeraDialogOpen = ref<boolean>(false);
-  const seqeraRunToCancel = ref<SeqeraRun | null>(null);
   const isCancelOmicsDialogOpen = ref<boolean>(false);
-  const omicsRunToCancel = ref<OmicsRun | null>(null);
   const isOpen = ref(false);
   const primaryMessage = ref('');
   const userToRemove = ref();
@@ -57,6 +56,51 @@
 
   const seqeraRuns = computed<SeqeraRun[]>(() => runStore.seqeraRunsForLab(props.labId));
   const omicsRuns = computed<OmicsRun[]>(() => runStore.omicsRunsForLab(props.labId));
+
+  type GenericRun = {
+    type: 'seqera' | 'omics';
+    id: string;
+    name: string;
+    subName: string;
+    time: string;
+    status: string;
+    owner: string;
+  };
+
+  function seqeraToGeneric(seqeraRun: SeqeraRun): GenericRun {
+    return {
+      type: 'seqera',
+      id: seqeraRun.id!,
+      name: seqeraRun.runName,
+      subName: seqeraRun.projectName,
+      time: seqeraRun.lastUpdated?.replace(/\.\d\d\dZ/, 'Z') || '-',
+      status: seqeraRun.status || '-',
+      owner: seqeraRun.userName || '-',
+    };
+  }
+
+  function omicsToGeneric(omicsRun: OmicsRun): GenericRun {
+    return {
+      type: 'omics',
+      id: omicsRun.id!,
+      name: omicsRun.name || '-',
+      subName: '',
+      time: omicsRun.creationTime?.toString()?.replace(/\.\d\d\dZ/, 'Z') || '-',
+      status: omicsRun.status || '-',
+      owner: '-',
+    };
+  }
+
+  const combinedRuns = computed<GenericRun[]>(() => {
+    if (uiStore.anyRequestPending(['getSeqeraRuns', 'getOmicsRuns'])) {
+      return [];
+    }
+
+    return seqeraRuns.value
+      .map(seqeraToGeneric)
+      .concat(omicsRuns.value.map(omicsToGeneric))
+      .sort((a, b) => (a.time > b.time ? -1 : 1));
+  });
 
   const filteredTableData = computed(() => {
     let filteredLabUsers = labUsers.value;
@@ -83,69 +127,28 @@
   });
 
   const usersTableColumns = [
-    {
-      key: 'displayName',
-      label: 'Name',
-      sortable: true,
-      sort: useSort().stringSortCompare,
-    },
-    {
-      key: 'actions',
-      label: 'Lab Access',
-    },
+    { key: 'displayName', label: 'Name', sortable: true, sort: useSort().stringSortCompare },
+    { key: 'actions', label: 'Lab Access' },
   ];
 
   const seqeraPipelinesTableColumns = [
-    {
-      key: 'Name',
-      label: 'Name',
-    },
-    {
-      key: 'description',
-      label: 'Description',
-    },
-    {
-      key: 'actions',
-      label: 'Actions',
-    },
+    { key: 'Name', label: 'Name' },
+    { key: 'description', label: 'Description' },
+    { key: 'actions', label: 'Actions' },
   ];
 
   const omicsWorkflowsTableColumns = [
-    {
-      key: 'Name',
-      label: 'Name',
-    },
-    {
-      key: 'description',
-      label: 'Description',
-    },
-    {
-      key: 'actions',
-      label: 'Actions',
-    },
+    { key: 'Name', label: 'Name' },
+    { key: 'description', label: 'Description' },
+    { key: 'actions', label: 'Actions' },
   ];
 
   const runsTableColumns = [
-    {
-      key: 'runName',
-      label: 'Run Name',
-    },
-    {
-      key: 'lastUpdated',
-      label: 'Last Updated',
-    },
-    {
-      key: 'status',
-      label: 'Status',
-    },
-    {
-      key: 'owner',
-      label: 'Owner',
-    },
-    {
-      key: 'actions',
-      label: 'Actions',
-    },
+    { key: 'runName', label: 'Run Name' },
+    { key: 'lastUpdated', label: 'Last Updated' },
+    { key: 'status', label: 'Status' },
+    { key: 'owner', label: 'Owner' },
+    { key: 'actions', label: 'Actions' },
   ];
 
   const tabItems = computed<{ key: string; label: string }[]>(() => {
@@ -170,86 +173,39 @@
   });
 
   const seqeraPipelinesActionItems = (pipeline: any) => [
-    [
-      {
-        label: 'Run',
-        click: () => viewRunSeqeraPipeline(pipeline),
-      },
-    ],
+    [{ label: 'Run', click: () => viewRunSeqeraPipeline(pipeline) }],
   ];
 
   const omicsWorkflowsActionItems = (workflow: any) => [
-    [
-      {
-        label: 'Run',
-        click: () => viewRunOmicsWorkflow(workflow),
-      },
-    ],
+    [{ label: 'Run', click: () => viewRunOmicsWorkflow(workflow) }],
   ];
 
-  function seqeraRunsActionItems(row: SeqeraRun): object[] {
-    const buttons: object[][] = [
-      [
-        {
-          label: 'View Details',
-          click: () => viewSeqeraRunDetails(row),
-        },
-      ],
-      [
-        {
-          label: 'View Results',
-          click: () => {
-            $router.push({ path: `/labs/${props.labId}/seqera-run/${row.id}`, query: { tab: 'Run Results' } });
-          },
-        },
-      ],
-    ];
-
-    if (['SUBMITTED', 'RUNNING'].includes(row.status || '')) {
-      buttons.push([
-        {
-          label: 'Cancel Run',
-          click: () => {
-            seqeraRunToCancel.value = row;
-            isCancelSeqeraDialogOpen.value = true;
-          },
-          isHighlighted: true,
-        },
-      ]);
-    }
-
-    return buttons;
+  function viewRunDetails(run: GenericRun) {
+    $router.push({ path: `/labs/${props.labId}/${run.type}-run/${run.id}`, query: { tab: 'Run Details' } });
   }
 
-  function omicsRunsActionItems(row: OmicsRun): object[] {
+  function viewRunResults(run: GenericRun) {
+    $router.push({ path: `/labs/${props.labId}/${run.type}-run/${run.id}`, query: { tab: 'Run Results' } });
+  }
+
+  function initCancelRun(run: GenericRun) {
+    runToCancel.value = run;
+
+    if (run.type === 'seqera') {
+      isCancelSeqeraDialogOpen.value = true;
+    } else {
+      isCancelOmicsDialogOpen.value = true;
+    }
+  }
+
+  function runsActionItems(run: GenericRun): object[] {
     const buttons: object[][] = [
-      [
-        {
-          label: 'View Details',
-          click: () => viewOmicsRunDetails(row),
-        },
-      ],
-      [
-        {
-          label: 'View Results',
-          click: () => {
-            $router.push({ path: `/labs/${props.labId}/omics-run/${row.id}`, query: { tab: 'Run Results' } });
-          },
-        },
-      ],
+      [{ label: 'View Details', click: () => viewRunDetails(run) }],
+      [{ label: 'View Results', click: () => viewRunResults(run) }],
     ];
 
-    if (['SUBMITTED', 'RUNNING'].includes(row.status || '')) {
-      buttons.push([
-        {
-          label: 'Cancel Run',
-          click: () => {
-            omicsRunToCancel.value = row;
-            isCancelOmicsDialogOpen.value = true;
-          },
-          isHighlighted: true,
-        },
-      ]);
+    if (['SUBMITTED', 'RUNNING'].includes(run.status)) {
+      buttons.push([{ label: 'Cancel Run', click: () => initCancelRun(run), isHighlighted: true }]);
     }
 
     return buttons;
@@ -509,50 +465,33 @@
     });
   }
 
-  function viewSeqeraRunDetails(row: SeqeraRun) {
-    $router.push({ path: `/labs/${props.labId}/seqera-run/${row.id}`, query: { tab: 'Run Details' } });
-  }
+  async function handleCancelDialogAction() {
+    const runId = runToCancel.value?.id;
+    const runName = runToCancel.value?.name;
+    const runType = runToCancel.value?.type;
 
-  function viewOmicsRunDetails(row: OmicsRun) {
-    $router.push({ path: `/labs/${props.labId}/omics-run/${row.id}`, query: { tab: 'Run Details' } });
-  }
-
-  async function handleCancelSeqeraDialogAction() {
-    const runId = seqeraRunToCancel.value?.id;
-    const runName = seqeraRunToCancel.value?.runName;
-
-    if (!runId) {
-      throw new Error("seqeraRunToCancel runId should have a value but doesn't");
+    if (!runId || !runName || !runType) {
+      throw new Error('runToCancel is missing required information');
     }
 
-    uiStore.setRequestPending('cancelSeqeraRun');
-
     try {
-      await $api.seqeraRuns.cancelPipelineRun(props.labId, runId);
-      useToastStore().success(`${runName} has been successfully cancelled`);
+      if (runType === 'seqera') {
+        uiStore.setRequestPending('cancelSeqeraRun');
+        await $api.seqeraRuns.cancelPipelineRun(props.labId, runId);
+      } else {
+        uiStore.setRequestPending('cancelOmicsRun');
+        // await $api.omicsRuns.cancelPipelineRun(props.labId, runId); // TODO
+      }
     } catch (e) {
       useToastStore().error('Failed to cancel run');
     }
 
     isCancelSeqeraDialogOpen.value = false;
-    seqeraRunToCancel.value = null;
-    uiStore.setRequestComplete('cancelSeqeraRun');
-
-    await getSeqeraRuns();
-  }
-
-  async function handleCancelOmicsDialogAction() {
-    uiStore.setRequestPending('cancelOmicsRun');
-
-    const runId = omicsRunToCancel.value?.id;
-    const runName = omicsRunToCancel.value?.name;
-
-    console.log('you sure did cancel that omics run', runId, runName);
-
     isCancelOmicsDialogOpen.value = false;
-    omicsRunToCancel.value = null;
+    uiStore.setRequestComplete('cancelSeqeraRun');
     uiStore.setRequestComplete('cancelOmicsRun');
 
+    await getSeqeraRuns();
     await getOmicsRuns();
   }
 
@@ -720,76 +659,39 @@
       <!-- Runs tab -->
       <div v-else-if="item.key === 'runs'" class="space-y-3">
         <EGTable
-          :row-click-action="viewOmicsRunDetails"
-          :table-data="omicsRuns"
+          :row-click-action="viewRunDetails"
+          :table-data="combinedRuns"
           :columns="runsTableColumns"
-          :is-loading="useUiStore().anyRequestPending(['loadLabData', 'getOmicsRuns'])"
-          :show-pagination="!useUiStore().anyRequestPending(['loadLabData', 'getOmicsRuns'])"
+          :is-loading="useUiStore().anyRequestPending(['loadLabData', 'getSeqeraRuns', 'getOmicsRuns'])"
+          :show-pagination="!useUiStore().anyRequestPending(['loadLabData', 'getSeqeraRuns', 'getOmicsRuns'])"
         >
-          <template #runName-data="{ row: omicsRun }">
-            <div class="text-body text-sm font-medium">{{ omicsRun.name }}</div>
+          <template #runName-data="{ row: run }">
+            <div v-if="run.name" class="text-body text-sm font-medium">{{ run.name }}</div>
+            <div v-if="run.subName" class="text-muted text-xs font-normal">{{ run.subName }}</div>
           </template>
 
-          <template #lastUpdated-data="{ row: omicsRun }">
-            <div class="text-body text-sm font-medium">{{ getDate(omicsRun.creationTime) }}</div>
-            <div class="text-muted">{{ getTime(omicsRun.creationTime) }}</div>
+          <template #lastUpdated-data="{ row: run }">
+            <div class="text-body text-sm font-medium">{{ getDate(run.time) }}</div>
+            <div class="text-muted">{{ getTime(run.time) }}</div>
           </template>
 
-          <template #status-data="{ row: omicsRun }">
-            <EGStatusChip :status="omicsRun.status" />
+          <template #status-data="{ row: run }">
+            <EGStatusChip :status="run.status" />
           </template>
 
-          <template #owner-data="{ row: omicsRun }">
-            <div class="text-body text-sm font-medium">{{ omicsRun?.userName ?? '-' }}</div>
+          <template #owner-data="{ row: run }">
+            <div class="text-body text-sm font-medium">{{ run.owner }}</div>
           </template>
 
           <template #actions-data="{ row }">
             <div class="flex justify-end">
-              <EGActionButton :items="omicsRunsActionItems(row)" class="ml-2" @click="$event.stopPropagation()" />
+              <EGActionButton :items="runsActionItems(row)" class="ml-2" @click="$event.stopPropagation()" />
             </div>
           </template>
 
           <template #empty-state>
             <div class="text-muted flex h-24 items-center justify-center font-normal">
               There are no Omics Runs in your Lab
-            </div>
-          </template>
-        </EGTable>
-
-        <EGTable
-          :row-click-action="viewSeqeraRunDetails"
-          :table-data="seqeraRuns"
-          :columns="runsTableColumns"
-          :is-loading="useUiStore().anyRequestPending(['loadLabData', 'getSeqeraRuns'])"
-          :show-pagination="!useUiStore().anyRequestPending(['loadLabData', 'getSeqeraRuns'])"
-        >
-          <template #runName-data="{ row: seqeraRun }">
-            <div class="text-body text-sm font-medium">{{ seqeraRun.runName }}</div>
-            <div class="text-muted text-xs font-normal">{{ seqeraRun.projectName }}</div>
-          </template>
-
-          <template #lastUpdated-data="{ row: seqeraRun }">
-            <div class="text-body text-sm font-medium">{{ getDate(seqeraRun.lastUpdated) }}</div>
-            <div class="text-muted">{{ getTime(seqeraRun.lastUpdated) }}</div>
-          </template>
-
-          <template #status-data="{ row: seqeraRun }">
-            <EGStatusChip :status="seqeraRun.status" />
-          </template>
-
-          <template #owner-data="{ row: seqeraRun }">
-            <div class="text-body text-sm font-medium">{{ seqeraRun?.userName ?? '-' }}</div>
-          </template>
-
-          <template #actions-data="{ row }">
-            <div class="flex justify-end">
-              <EGActionButton :items="seqeraRunsActionItems(row)" class="ml-2" @click="$event.stopPropagation()" />
-            </div>
-          </template>
-
-          <template #empty-state>
-            <div class="text-muted flex h-24 items-center justify-center font-normal">
-              There are no Runs in your Lab
             </div>
           </template>
         </EGTable>
@@ -867,8 +769,8 @@
   <EGDialog
     action-label="Cancel Run"
     :action-variant="ButtonVariantEnum.enum.destructive"
-    @action-triggered="handleCancelSeqeraDialogAction"
-    :primary-message="`Are you sure you would like to cancel ${seqeraRunToCancel?.runName}?`"
+    @action-triggered="handleCancelDialogAction"
+    :primary-message="`Are you sure you would like to cancel ${runToCancel?.name}?`"
     secondary-message="This will stop any progress made."
     v-model="isCancelSeqeraDialogOpen"
     :buttons-disabled="uiStore.isRequestPending('cancelSeqeraRun')"
@@ -877,8 +779,8 @@
   <EGDialog
     action-label="Cancel Run"
     :action-variant="ButtonVariantEnum.enum.destructive"
-    @action-triggered="handleCancelOmicsDialogAction"
-    :primary-message="`Are you sure you would like to cancel ${omicsRunToCancel?.name}?`"
+    @action-triggered="handleCancelDialogAction"
+    :primary-message="`Are you sure you would like to cancel ${runToCancel?.name}?`"
     secondary-message="This will stop any progress made."
     v-model="isCancelOmicsDialogOpen"
     :buttons-disabled="uiStore.isRequestPending('cancelOmicsRun')"

--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -148,7 +148,6 @@
     { key: 'lastUpdated', label: 'Last Updated' },
     { key: 'status', label: 'Status' },
     { key: 'owner', label: 'Owner' },
-    { key: 'platform', label: 'Platform' },
     { key: 'actions', label: 'Actions' },
   ];
 
@@ -685,10 +684,6 @@
 
           <template #owner-data="{ row: run }">
             <div class="text-body text-sm font-medium">{{ run.owner }}</div>
-          </template>
-
-          <template #platform-data="{ row: run }">
-            <div class="text-body text-sm font-medium">{{ run.type === 'seqera' ? 'Seqera' : 'HealthOmics' }}</div>
           </template>
 
           <template #actions-data="{ row }">

--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -148,7 +148,7 @@
     { key: 'lastUpdated', label: 'Last Updated' },
     { key: 'status', label: 'Status' },
     { key: 'owner', label: 'Owner' },
-    { key: 'source', label: 'Source' },
+    { key: 'platform', label: 'Platform' },
     { key: 'actions', label: 'Actions' },
   ];
 
@@ -684,8 +684,8 @@
             <div class="text-body text-sm font-medium">{{ run.owner }}</div>
           </template>
 
-          <template #source-data="{ row: run }">
-            <div class="text-body text-sm font-medium capitalize">{{ run.type }}</div>
+          <template #platform-data="{ row: run }">
+            <div class="text-body text-sm font-medium">{{ run.type === 'seqera' ? 'Seqera' : 'HealthOmics' }}</div>
           </template>
 
           <template #actions-data="{ row }">

--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -437,7 +437,7 @@
       pipelineId,
       pipelineName,
       pipelineDescription: pipelineDescription || '',
-      transactionId: uuidv4(),
+      transactionId: seqeraRunTempId,
     });
 
     $router.push({
@@ -458,7 +458,7 @@
       laboratoryId: props.labId,
       workflowId: workflow.id,
       workflowName: workflow.name,
-      transactionId: uuidv4(),
+      transactionId: omicsRunTempId,
     });
 
     $router.push({

--- a/packages/front-end/src/app/composables/useFileDownload.ts
+++ b/packages/front-end/src/app/composables/useFileDownload.ts
@@ -10,7 +10,7 @@ export default function useFileDownload() {
 
     try {
       // Fetch the presigned URL from the API
-      const fileDownloadResponse: FileDownloadResponse = await $api.seqeraRuns.downloadS3file(labId, fileDownloadPath);
+      const fileDownloadResponse: FileDownloadResponse = await $api.file.downloadS3file(labId, fileDownloadPath);
 
       if (!fileDownloadResponse || !fileDownloadResponse.DownloadUrl) {
         console.error('Download URL is undefined or empty');

--- a/packages/front-end/src/app/pages/labs/[labId]/omics-run/[omicsRunId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/omics-run/[omicsRunId].vue
@@ -55,6 +55,10 @@
     tabIndex.value = queryTabMatchIndex !== -1 ? queryTabMatchIndex : 0;
   });
 
+  watch(tabIndex, (index) => {
+    if (index === 1) useToastStore().info('Viewing HealthOmics Run results is not yet implemented');
+  });
+
   // Note: the UTabs :ui attribute has to be defined locally in this file - if it is imported from another file,
   //  Tailwind won't pick up and include the classes used and styles will be missing.
   // To keep the tab styling consistent throughout the app, any changes made here need to be duplicated to all other
@@ -104,7 +108,7 @@
     "
   >
     <template #item="{ item }">
-      <div v-if="item.key === 'runResults'" class="space-y-3">Results go here</div>
+      <div v-if="item.key === 'runResults'" class="space-y-3"></div>
 
       <div v-if="item.key === 'runDetails'" class="space-y-3">
         <section

--- a/packages/front-end/src/app/pages/labs/[labId]/omics-run/[omicsRunId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/omics-run/[omicsRunId].vue
@@ -1,11 +1,8 @@
 <script setup lang="ts">
   import { getDate, getTime } from '@FE/utils/date-time';
-  import { Workflow as SeqeraRun } from '@easy-genomics/shared-lib/lib/app/types/nf-tower/nextflow-tower-api';
-  import { S3Response } from '@/packages/shared-lib/src/app/types/easy-genomics/file/request-list-bucket-objects';
   import { useRunStore } from '@FE/stores';
-  import { WorkflowListItem as OmicsWorkflow, RunListItem as OmicsRun } from '@aws-sdk/client-omics';
+  import { RunListItem as OmicsRun } from '@aws-sdk/client-omics';
 
-  const { $api } = useNuxtApp();
   const $router = useRouter();
   const $route = useRoute();
   const runStore = useRunStore();
@@ -32,19 +29,22 @@
 
   const omicsRun = computed<OmicsRun | null>(() => runStore.omicsRuns[labId][omicsRunId]);
 
+  // re: `as unknown as string` below: the schema for these time variables specifies `Date | undefined`, but we are
+  // receiving strings - this must be a mistake somewhere but for now we're casting them to the actual type
+
   const createdDateTime = computed(() => {
-    const createdDate = getDate(omicsRun.value?.creationTime?.toISOString());
-    const createdTime = getTime(omicsRun.value?.creationTime?.toISOString());
+    const createdDate = getDate(omicsRun.value?.creationTime as unknown as string);
+    const createdTime = getTime(omicsRun.value?.creationTime as unknown as string);
     return createdDate && createdTime ? `${createdTime} ⋅ ${createdDate}` : '—';
   });
   const startedDateTime = computed(() => {
-    const startedDate = getDate(omicsRun.value?.startTime?.toISOString());
-    const startedTime = getTime(omicsRun.value?.startTime?.toISOString());
+    const startedDate = getDate(omicsRun.value?.startTime as unknown as string);
+    const startedTime = getTime(omicsRun.value?.startTime as unknown as string);
     return startedDate && startedTime ? `${startedTime} ⋅ ${startedDate}` : '—';
   });
   const stoppedDateTime = computed(() => {
-    const stoppedDate = getDate(omicsRun.value?.stopTime?.toISOString());
-    const stoppedTime = getTime(omicsRun.value?.stopTime?.toISOString());
+    const stoppedDate = getDate(omicsRun.value?.stopTime as unknown as string);
+    const stoppedTime = getTime(omicsRun.value?.stopTime as unknown as string);
     return stoppedDate && stoppedTime ? `${stoppedTime} ⋅ ${stoppedDate}` : '—';
   });
 
@@ -117,15 +117,15 @@
             </div>
             <div class="flex border-b p-4 text-sm">
               <dt class="w-[200px] font-medium text-black">Creation Time</dt>
-              <dd class="text-muted text-left">{{ omicsRun.creationTime }}</dd>
+              <dd class="text-muted text-left">{{ createdDateTime }}</dd>
             </div>
             <div class="flex border-b p-4 text-sm">
               <dt class="w-[200px] font-medium text-black">Start Time</dt>
-              <dd class="text-muted text-left max-md:max-w-full">{{ omicsRun.startTime }}</dd>
+              <dd class="text-muted text-left max-md:max-w-full">{{ startedDateTime }}</dd>
             </div>
             <div class="flex p-4 text-sm">
               <dt class="w-[200px] font-medium text-black">Stop Time</dt>
-              <dd class="text-muted text-left max-md:max-w-full">{{ omicsRun.stopTime }}</dd>
+              <dd class="text-muted text-left max-md:max-w-full">{{ stoppedDateTime }}</dd>
             </div>
           </dl>
         </section>

--- a/packages/front-end/src/app/repository/modules/file.ts
+++ b/packages/front-end/src/app/repository/modules/file.ts
@@ -8,6 +8,7 @@ import {
   RequestListBucketObjects,
   S3Response,
 } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/file/request-list-bucket-objects';
+import { FileDownloadResponse } from '@easy-genomics/shared-lib/src/app/types/nf-tower/file/request-file-download';
 import HttpFactory from '@FE/repository/factory';
 import { validateApiResponse } from '@FE/utils/api-utils';
 
@@ -40,6 +41,30 @@ class FileModule extends HttpFactory {
     }
 
     validateApiResponse(S3ResponseSchema, res);
+    return res;
+  }
+
+  /**
+   * Get signed URL for downloading a file from S3 Bucket
+   * @param labId
+   * @param contentUri
+   */
+  async downloadS3file(labId: string, contentUri: string): Promise<FileDownloadResponse> {
+    const res: FileDownloadResponse | undefined = await this.call<FileDownloadResponse>(
+      'POST',
+      '/file/request-file-download-url',
+      {
+        LaboratoryId: labId,
+        S3Uri: contentUri,
+      },
+    );
+
+    if (!res) {
+      console.error('Error calling file download API');
+      throw new Error('Failed to perform file download');
+    }
+
+    validateApiResponse(FileDownloadUrlResponseSchema, res);
     return res;
   }
 }

--- a/packages/front-end/src/app/repository/modules/seqera-runs.ts
+++ b/packages/front-end/src/app/repository/modules/seqera-runs.ts
@@ -1,4 +1,3 @@
-import { FileDownloadUrlResponseSchema } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/file/request-file-download-url';
 import { FileDownloadResponseSchema } from '@easy-genomics/shared-lib/src/app/schema/nf-tower/file/request-file-download';
 import { FileDownloadResponse } from '@easy-genomics/shared-lib/src/app/types/nf-tower/file/request-file-download';
 import {
@@ -85,30 +84,6 @@ class SeqeraRunsModule extends HttpFactory {
     }
 
     validateApiResponse(FileDownloadResponseSchema, res);
-    return res;
-  }
-
-  /**
-   * Get signed URL for downloading a file from S3 Bucket
-   * @param labId
-   * @param contentUri
-   */
-  async downloadS3file(labId: string, contentUri: string): Promise<FileDownloadResponse> {
-    const res: FileDownloadResponse | undefined = await this.call<FileDownloadResponse>(
-      'POST',
-      '/file/request-file-download-url',
-      {
-        LaboratoryId: labId,
-        S3Uri: contentUri,
-      },
-    );
-
-    if (!res) {
-      console.error('Error calling file download API');
-      throw new Error('Failed to perform file download');
-    }
-
-    validateApiResponse(FileDownloadUrlResponseSchema, res);
     return res;
   }
 


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/ca5aa15a-983a-4bf2-ae84-529a698ceeea)


## Title*

Combine Seqera and Omics runs into the one table

## Type of Change*
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Basically, I created a new type `GenericRun` which contains the traits that are needed for handling runs, and convert `SeqeraRun`s and `OmicsRun`s into `GenericRun`s. Several paths that were previously handled separately for Seqera/Omics runs are now converged into one for `GenericRun`s.

## Testing*

e2e tests passed

## Impact

## Additional Information

Known issues:

- Omics runs don't display Owner because it's not provided to us
- Omics runs don't have a subtitle like Seqera runs' projectName subtitle

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.