### PR TITLE
fix(EG-888): store FE transactionId as LaboratoryRun runId

### DIFF
--- a/packages/back-end/src/app/controllers/nf-tower/workflow/create-workflow-execution.lambda.ts
+++ b/packages/back-end/src/app/controllers/nf-tower/workflow/create-workflow-execution.lambda.ts
@@ -119,7 +119,10 @@ export const handler: Handler = async (
     console.log('Create workflow launch response from Next Flow Tower API:', nfTowerResponse);
 
     // Create laboratory run
-    const runId: string = crypto.randomUUID().toLowerCase();
+    const runId: string | undefined = createWorkflowLaunchRequest.launch?.id;
+    if (!runId) {
+      throw new RequiredIdNotFoundError('Seqera Pipeline Run Launch Id (Transaction Id) missing');
+    }
 
     const response = await laboratoryRunService
       .add({

--- a/packages/front-end/src/app/components/EGRunPipelineFormReviewPipeline.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineFormReviewPipeline.vue
@@ -44,6 +44,7 @@
       const workDir: string = `s3://${wipSeqeraRun.value?.s3Bucket}/${wipSeqeraRun.value?.s3Path}/work`;
       const launchRequest: CreateWorkflowLaunchRequest = {
         launch: {
+          id: wipSeqeraRun?.transactionId, // Specify Easy Genomics' generated random Transaction ID for Seqera Pipeline Run Launch ID
           computeEnvId: launchDetails.launch?.computeEnv?.id,
           runName: wipSeqeraRun.value?.userPipelineRunName,
           pipeline: launchDetails.launch?.pipeline,


### PR DESCRIPTION
## Title*

Store FE transactionId as LaboratoryRun runId

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Update FE Stepper to specify the `transactionId` for the Seqera Pipeline Launch Run `id` so it can be passed from the FE to the BE `/nf-tower/workflow/create-workflow-execution` API, which then can use the supplied `id` to store in the LaboratoryRun record's `runId`.

## Testing*
The same `transactionId` used in the S3 Path where files are uploaded to / output written to should be stored in the LaboratoryRun table's runId field.

## Impact

## Additional Information

## Checklist*
- [ ] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [ ] Code adheres to the coding and style guidelines of the project.
- [ ] Code has been commented in particularly hard-to-understand areas.