### PR TITLE
fix(EG-885): replace || with ?? to prevent present false value from defaulting to fallback value

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/create-laboratory.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/create-laboratory.lambda.ts
@@ -64,8 +64,8 @@ export const handler: Handler = async (
         Description: request.Description,
         Status: 'Active',
         S3Bucket: request.S3Bucket, // S3 Bucket Full Name
-        AwsHealthOmicsEnabled: request.AwsHealthOmicsEnabled || organization.AwsHealthOmicsEnabled || false,
-        NextFlowTowerEnabled: request.NextFlowTowerEnabled || organization.NextFlowTowerEnabled || false,
+        AwsHealthOmicsEnabled: request.AwsHealthOmicsEnabled ?? organization.AwsHealthOmicsEnabled ?? false,
+        NextFlowTowerEnabled: request.NextFlowTowerEnabled ?? organization.NextFlowTowerEnabled ?? false,
         NextFlowTowerWorkspaceId: request.NextFlowTowerWorkspaceId,
         CreatedAt: new Date().toISOString(),
         CreatedBy: currentUserId,


### PR DESCRIPTION
## Title*

Fix `NextFlowIntegrationEnabled = false` being overwritten to `true` on lab creation

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

When creating a lab, if `NextFlowIntegrationEnabled` was `false`, it was being changed to `true`.

The source of this error is this line:

```
NextFlowTowerEnabled: request.NextFlowTowerEnabled || organization.NextFlowTowerEnabled || false,
```

The logical intent of this line is "use `request` value if present, else use `organization` value, else `false`". 

However, the logical OR `||` uses the value on the right if the value on the left is `false`, causing the `organization` value to be used when the `request` value is `false`. (This will have also been happening to `AwsOmicsIntegrationEnabled`, but apparently the `organization` value for that was also `false`, so the behaviour was as expected.) 

The right operator is the null coalesce `??`, which will use the `request` value if supplied (either `true` or `false`), and only default to the `organization` value if the `request` value is not present (`undefined`).

```
NextFlowTowerEnabled: request.NextFlowTowerEnabled ?? organization.NextFlowTowerEnabled ?? false,
```

## Testing*

Manual before/after testing with Postman.

## Impact

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.