### PR TITLE
refactor: update lab tabs and missing PAT message display logic

### DIFF
--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -39,7 +39,7 @@
   const labUsers = ref<LabUser[]>([]);
   const seqeraPipelines = ref<SeqeraPipeline[]>([]);
   const omicsWorkflows = ref<OmicsWorkflow[]>([]);
-  const canAddUsers = ref(false);
+  const canAddUsers = computed<boolean>(() => userStore.canAddLabUsers(props.labId));
   const showAddUserModule = ref(false);
   const searchOutput = ref('');
   const runToCancel = ref<GenericRun | null>(null);
@@ -515,8 +515,6 @@
       await Promise.all(promises);
       return;
     }
-
-    canAddUsers.value = userStore.canAddLabUsers(props.labId);
 
     if (lab.NextFlowTowerEnabled) {
       if (!lab.HasNextFlowTowerAccessToken) {


### PR DESCRIPTION
## Title*

Update the logic behind the PAT Missing modal message and lab view tabs displaying

## Type of Change*
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [X] UI/UX improvement

## Description

The logic to display the PAT Missing modal and the tabs in the lab view (namely the Lab Users tab) was implemented when Seqera was the only backend available. It doesn't make sense in some cases now that Omics is also a possible backend.

Specific changes:
- PAT Missing modal trigger logic
  - before: if Workspace ID or PAT missing
  - after: if Workspace ID or PAT missing AND Seqera integration enabled
- Lab Runs tab display
  - before: if Workspace ID and PAT present
  - after: if (Seqera integration enabled AND Workspace ID and PAT present) OR Omics integration enabled
- Lab Users tab display
  - before: if Workspace ID and PAT present
  - after: always

## Testing*

Manual testing

## Impact

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.