### PR TITLE
feat(EG-875): add AWS HealthOmics create-run-execution API

### DIFF
--- a/packages/back-end/src/app/controllers/aws-healthomics/run/cancel-run-execution.lambda.ts
+++ b/packages/back-end/src/app/controllers/aws-healthomics/run/cancel-run-execution.lambda.ts
@@ -20,7 +20,7 @@ const laboratoryService = new LaboratoryService();
 const omicsService = new OmicsService();
 
 /**
- * This PUT /aws-healthomics/run/cancel-run/:{RunId}?laboratoryId={LaboratoryId}
+ * This PUT /aws-healthomics/run/cancel-run-execution/:{RunId}?laboratoryId={LaboratoryId}
  * API queries the same region's AWS HealthOmics service to cancel a specific
  * Run, and it expects:
  *  - Required Path Parameter:

--- a/packages/back-end/src/app/controllers/aws-healthomics/run/create-run-execution.lambda.ts
+++ b/packages/back-end/src/app/controllers/aws-healthomics/run/create-run-execution.lambda.ts
@@ -1,0 +1,89 @@
+import { StartRunCommandInput } from '@aws-sdk/client-omics';
+import { CreateRunRequestSchema } from '@easy-genomics/shared-lib/lib/app/schema/aws-healthomics/aws-healthomics-api';
+import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/lib/app/utils/common';
+import {
+  InvalidRequestError,
+  LaboratoryNotFoundError,
+  RequiredIdNotFoundError,
+  UnauthorizedAccessError,
+} from '@easy-genomics/shared-lib/lib/app/utils/HttpError';
+import { CreateRunRequest } from '@easy-genomics/shared-lib/src/app/types/aws-healthomics/aws-healthomics-api';
+import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
+import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
+import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
+import { OmicsService } from '@BE/services/omics-service';
+import {
+  validateLaboratoryManagerAccess,
+  validateLaboratoryTechnicianAccess,
+  validateOrganizationAdminAccess,
+} from '@BE/utils/auth-utils';
+
+const laboratoryService = new LaboratoryService();
+const omicsService = new OmicsService();
+
+/**
+ * This POST /aws-healthomics/run/create-run-execution?laboratoryId={LaboratoryId}
+ * API issues the command to the same region's AWS HealthOmics service to create
+ * a new Workflow Run, and it expects:
+ *  - Required Query Parameter:
+ *    - 'laboratoryId': to retrieve the Laboratory to verify access to AWS HealthOmics
+ *  - JSON payload defining the input parameters for starting a Workflow Run
+ *    - workflowId
+ *    - requestId (transactionId)
+ *    - name
+ *    - parameters (JSON document defining the inputs for the Workflow including the sample-sheet)
+ *
+ * @param event
+ */
+export const handler: Handler = async (
+  event: APIGatewayProxyWithCognitoAuthorizerEvent,
+): Promise<APIGatewayProxyResult> => {
+  console.log('EVENT: \n' + JSON.stringify(event, null, 2));
+  try {
+    // Post Request Body
+    const request: CreateRunRequest = event.isBase64Encoded ? JSON.parse(atob(event.body!)) : JSON.parse(event.body!);
+    // Data validation safety check
+    if (!CreateRunRequestSchema.safeParse(request).success) throw new InvalidRequestError();
+
+    // Get required query parameter
+    const laboratoryId: string = event.queryStringParameters?.laboratoryId || '';
+    if (laboratoryId === '') throw new RequiredIdNotFoundError('laboratoryId');
+
+    const laboratory: Laboratory = await laboratoryService.queryByLaboratoryId(laboratoryId);
+
+    if (!laboratory) {
+      throw new LaboratoryNotFoundError();
+    }
+
+    if (!laboratory.AwsHealthOmicsEnabled) {
+      throw new UnauthorizedAccessError('Laboratory does not have AWS HealthOmics enabled');
+    }
+
+    // Only available for Org Admins or Laboratory Managers and Technicians
+    if (
+      !(
+        validateOrganizationAdminAccess(event, laboratory.OrganizationId) ||
+        validateLaboratoryManagerAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId) ||
+        validateLaboratoryTechnicianAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId)
+      )
+    ) {
+      throw new UnauthorizedAccessError();
+    }
+
+    const parameters = JSON.parse(request.parameters.toString());
+    const response = await omicsService.startRun(<StartRunCommandInput>{
+      ...request,
+      parameters: {
+        ...parameters,
+        outdir: '/mnt/workflow/pubdir', // AWS HealthOmics requires explicitly setting 'outdir' = '/mnt/workflow/pubdir' for internal output
+      },
+      outputUri: parameters.outdir, // AWS HealthOmics requires setting outputUri for copying 'outdir' output to the final destination
+      workflowType: 'PRIVATE',
+      roleArn: `arn:aws:iam::${process.env.ACCOUNT_ID}:role/${process.env.NAME_PREFIX}-easy-genomics-healthomics-workflow-run-role`,
+    });
+    return buildResponse(200, JSON.stringify(response), event);
+  } catch (err: any) {
+    console.error(err);
+    return buildErrorResponse(err, event);
+  }
+};

--- a/packages/back-end/src/infra/stacks/aws-healthomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/aws-healthomics-nested-stack.ts
@@ -165,8 +165,8 @@ export class AwsHealthOmicsNestedStack extends NestedStack {
         effect: Effect.ALLOW,
       }),
     ]);
-    // /aws-healthomics/run/cancel-run
-    this.iam.addPolicyStatements('/aws-healthomics/run/cancel-run', [
+    // /aws-healthomics/run/cancel-run-execution
+    this.iam.addPolicyStatements('/aws-healthomics/run/cancel-run-execution', [
       new PolicyStatement({
         resources: [
           `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table`,

--- a/packages/back-end/src/infra/stacks/aws-healthomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/aws-healthomics-nested-stack.ts
@@ -180,5 +180,20 @@ export class AwsHealthOmicsNestedStack extends NestedStack {
         effect: Effect.ALLOW,
       }),
     ]);
+    // /aws-healthomics/run/create-run-execution
+    this.iam.addPolicyStatements('/aws-healthomics/run/create-run-execution', [
+      new PolicyStatement({
+        resources: [
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table`,
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table/index/*`,
+        ],
+        actions: ['dynamodb:Query'],
+      }),
+      new PolicyStatement({
+        resources: [`arn:aws:omics:${this.props.env.region!}:${this.props.env.account!}:run/*`],
+        actions: ['omics:StartRun'],
+        effect: Effect.ALLOW,
+      }),
+    ]);
   };
 }

--- a/packages/back-end/src/infra/stacks/aws-healthomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/aws-healthomics-nested-stack.ts
@@ -190,8 +190,18 @@ export class AwsHealthOmicsNestedStack extends NestedStack {
         actions: ['dynamodb:Query'],
       }),
       new PolicyStatement({
-        resources: [`arn:aws:omics:${this.props.env.region!}:${this.props.env.account!}:run/*`],
+        resources: [
+          `arn:aws:omics:${this.props.env.region!}:${this.props.env.account!}:run/*`,
+          `arn:aws:omics:${this.props.env.region!}:${this.props.env.account!}:workflow/*`,
+        ],
         actions: ['omics:StartRun'],
+        effect: Effect.ALLOW,
+      }),
+      new PolicyStatement({
+        resources: [
+          `arn:aws:iam::${this.props.env.account!}:role/${this.props.namePrefix}-easy-genomics-healthomics-workflow-run-role`,
+        ],
+        actions: ['iam:PassRole'],
         effect: Effect.ALLOW,
       }),
     ]);

--- a/packages/shared-lib/src/app/schema/aws-healthomics/aws-healthomics-api.ts
+++ b/packages/shared-lib/src/app/schema/aws-healthomics/aws-healthomics-api.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+/**
+ * The following Zod schema is a customized definition for Easy Genomics based
+ * upon the AWS HealthOmics StartRun interface:
+ *
+ * The fields marked as optional can be ignored or overridden by a supplied
+ * value if required.
+ *
+ * The roleArn is marked optional, so it can be overridden by the Easy Genomics
+ * implementation with the appropriate RoleArn value for the deployment.
+ */
+export const CreateRunRequestSchema = z
+  .object({
+    workflowId: z.string(),
+    requestId: z.string(), // Easy Genomics TransactionId
+    name: z.string(),
+    parameters: z.string(),
+    roleArn: z.string().optional(), // 'easy-genomics-healthomics-workflow-run-role'
+    workflowType: z.enum(['READY2RUN', 'PRIVATE']).optional(),
+    outputUri: z.string().optional(),
+    cacheId: z.string().optional(),
+    cacheBehavior: z.enum(['CACHE_ON_FAILURE', 'CACHE_ALWAYS']).optional(),
+    runGroupId: z.string().optional(),
+    priority: z.number().optional(),
+    storageCapacity: z.number().optional(),
+    logLevel: z.enum(['ALL', 'ERROR', 'FATAL', 'OFF']).optional(),
+    retentionMode: z.enum(['RETAIN', 'REMOVE']).optional(),
+    storageType: z.enum(['STATIC', 'DYNAMIC']).optional(),
+    workflowOwnerId: z.string().optional(),
+  })
+  .strict();

--- a/packages/shared-lib/src/app/types/aws-healthomics/aws-healthomics-api.ts
+++ b/packages/shared-lib/src/app/types/aws-healthomics/aws-healthomics-api.ts
@@ -1,4 +1,15 @@
-import { GetRunResponse, GetWorkflowResponse, ListWorkflowsResponse, ListRunsResponse } from '@aws-sdk/client-omics';
+import {
+  GetRunResponse,
+  GetWorkflowResponse,
+  ListWorkflowsResponse,
+  ListRunsResponse,
+  StartRunResponse,
+  StartRunRequest,
+} from '@aws-sdk/client-omics';
+
+export type CreateRun = StartRunResponse;
+
+export type CreateRunRequest = StartRunRequest;
 
 export type ListWorkflows = ListWorkflowsResponse;
 


### PR DESCRIPTION
## Title*
Add AWS HealthOmics create-run-execution API

## Type of Change*
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [X] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

- The existing HTTP PUT `/aws-healthomics/run/cancel-run` API was refactored to `/aws-healthomics/run/cancel-run-execution` for naming consistency.
- Added the HTTP POST `/aws-healthomics/run/create-run-execution` API and IAM policies to enable it to issue startRun commands to AWS HealthOmics.

## Testing*
Refer to the JIRA ticket for the QA acceptance criteria.

## Impact
None

## Additional Information
None

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [ X Code has been commented in particularly hard-to-understand areas.