### PR TITLE
fix: sys-admin invite user test failing due to change of user list format

### DIFF
--- a/packages/front-end/tests/e2e/sys-admin/Organizations_System_Admin.spec.e2e.ts
+++ b/packages/front-end/tests/e2e/sys-admin/Organizations_System_Admin.spec.e2e.ts
@@ -96,7 +96,6 @@ test('03 - Invite a user to an Org Successfully', async ({ page, baseURL }) => {
     await page.waitForTimeout(2000);
     const cell = page.getByRole('cell', {
       name: envConfig.testInviteEmail,
-      exact: true,
     });
     await expect(cell).toBeVisible();
   }


### PR DESCRIPTION
## Title*

Fix the failing sys-admin e2e test due to change of user list format

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Removes the exact match requirement from the user email field, because after the user display component consolidation it now also shows the user name

## Testing*

e2e tests pass now

## Impact

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.