### PR TITLE
fix(EG-897): improve LaboratoryRun type def & zod schema properties

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/create-laboratory-run.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/create-laboratory-run.lambda.ts
@@ -1,10 +1,9 @@
-import crypto from 'crypto';
 import {
   AddLaboratoryRun,
   AddLaboratoryRunSchema,
-  ReadLaboratoryRun,
 } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/laboratory-run';
 import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
+import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory-run';
 import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/src/app/utils/common';
 import {
   InvalidRequestError,
@@ -53,35 +52,23 @@ export const handler: Handler = async (
       throw new LaboratoryNotFoundError();
     }
 
-    const runId: string = crypto.randomUUID().toLowerCase();
-
-    const laboratoryRun = await laboratoryRunService
-      .add({
-        RunId: runId,
-        OrganizationId: laboratory.OrganizationId,
+    const response = await laboratoryRunService
+      .add(<LaboratoryRun>{
         LaboratoryId: laboratory.LaboratoryId,
-        Status: 'Active',
-        Type: request.Type,
-        S3Input: request.S3Input,
-        S3Output: request.S3Output,
-        Settings: JSON.stringify(request.Settings ? request.Settings : {}),
-        WorkflowName: request.WorkflowName,
+        RunId: request.RunId,
         UserId: currentUserId,
+        OrganizationId: laboratory.OrganizationId,
+        Type: request.Type,
+        Status: 'Created',
+        Title: request.Title,
+        WorkflowName: request.WorkflowName,
+        Settings: JSON.stringify(request.Settings),
         CreatedAt: new Date().toISOString(),
         CreatedBy: currentUserId,
-        ModifiedAt: new Date().toISOString(),
-        ModifiedBy: currentUserId,
       })
       .catch((error: any) => {
         throw error;
       });
-
-    // Return Laboratory Run with settings object
-    const response: ReadLaboratoryRun = {
-      ...laboratoryRun,
-      Settings: JSON.parse(laboratoryRun.Settings || '{}'),
-    };
-
     return buildResponse(200, JSON.stringify(response), event);
   } catch (err: any) {
     console.error(err);

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/update-laboratory-run.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/update-laboratory-run.lambda.ts
@@ -1,7 +1,6 @@
 import {
   EditLaboratoryRun,
   EditLaboratoryRunSchema,
-  ReadLaboratoryRun,
 } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/laboratory-run';
 import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory-run';
 import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/src/app/utils/common';
@@ -53,23 +52,13 @@ export const handler: Handler = async (
       throw new UnauthorizedAccessError();
     }
 
-    const updatedLaboratoryRun = await laboratoryRunService
-      .update({
-        ...existing,
-        ...request,
-        Settings: request.Settings ? JSON.stringify(request.Settings) : existing.Settings,
-        ModifiedAt: new Date().toISOString(),
-        ModifiedBy: currentUserId,
-      })
-      .catch((error: any) => {
-        throw error;
-      });
-
-    // Return Laboratory Run with settings object
-    const response: ReadLaboratoryRun = {
-      ...updatedLaboratoryRun,
-      Settings: JSON.parse(updatedLaboratoryRun.Settings || '{}'),
-    };
+    const response: LaboratoryRun = await laboratoryRunService.update({
+      ...existing,
+      ...request,
+      Settings: JSON.stringify(request.Settings),
+      ModifiedAt: new Date().toISOString(),
+      ModifiedBy: currentUserId,
+    });
 
     return buildResponse(200, JSON.stringify(response), event);
   } catch (err: any) {

--- a/packages/shared-lib/src/app/schema/easy-genomics/laboratory-run.ts
+++ b/packages/shared-lib/src/app/schema/easy-genomics/laboratory-run.ts
@@ -15,6 +15,7 @@ export const LaboratoryRunSchema = z
     Status: z.string(),
     Title: z.string().optional(),
     WorkflowName: z.string().optional(),
+    ExternalRunId: z.string().optional(),
     S3Input: z.string().optional(),
     S3Output: z.string().optional(),
     Settings: z.string().optional(), // JSON as a string
@@ -35,6 +36,7 @@ export const ReadLaboratoryRunSchema = z
     Status: z.string(),
     Title: z.string().optional(),
     WorkflowName: z.string().optional(),
+    ExternalRunId: z.string().optional(),
     S3Input: z.string().optional(),
     S3Output: z.string().optional(),
     Settings: z.record(z.string(), jsonSchema).optional(), // JSON
@@ -49,6 +51,7 @@ export type ReadLaboratoryRun = z.infer<typeof ReadLaboratoryRunSchema>;
 export const AddLaboratoryRunSchema = z
   .object({
     LaboratoryId: z.string().uuid(),
+    RunId: z.string().uuid(),
     OrganizationId: z.string().uuid(),
     Type: z.enum(['AWS HealthOmics', 'Seqera Cloud']),
     Status: z.string(),
@@ -69,6 +72,7 @@ export const EditLaboratoryRunSchema = z
     Status: z.string(),
     Settings: z.record(z.string(), jsonSchema).optional(),
     WorkflowName: z.string().optional(),
+    ExternalRunId: z.string().optional(),
     S3Input: z.string().optional(),
     S3Output: z.string().optional(),
   })

--- a/packages/shared-lib/src/app/schema/easy-genomics/laboratory-run.ts
+++ b/packages/shared-lib/src/app/schema/easy-genomics/laboratory-run.ts
@@ -66,8 +66,6 @@ export type AddLaboratoryRun = z.infer<typeof AddLaboratoryRunSchema>;
 
 export const EditLaboratoryRunSchema = z
   .object({
-    LaboratoryId: z.string().uuid(),
-    RunId: z.string().uuid(),
     Title: z.string().optional(),
     Status: z.string(),
     Settings: z.string().optional(), // JSON string

--- a/packages/shared-lib/src/app/schema/easy-genomics/laboratory-run.ts
+++ b/packages/shared-lib/src/app/schema/easy-genomics/laboratory-run.ts
@@ -18,7 +18,7 @@ export const LaboratoryRunSchema = z
     ExternalRunId: z.string().optional(),
     S3Input: z.string().optional(),
     S3Output: z.string().optional(),
-    Settings: z.string().optional(), // JSON as a string
+    Settings: z.string().optional(), // JSON string
     CreatedAt: z.string().optional(),
     CreatedBy: z.string().optional(),
     ModifiedAt: z.string().optional(),
@@ -39,7 +39,7 @@ export const ReadLaboratoryRunSchema = z
     ExternalRunId: z.string().optional(),
     S3Input: z.string().optional(),
     S3Output: z.string().optional(),
-    Settings: z.record(z.string(), jsonSchema).optional(), // JSON
+    Settings: z.string().optional(), // JSON string
     CreatedAt: z.string().optional(),
     CreatedBy: z.string().optional(),
     ModifiedAt: z.string().optional(),
@@ -59,7 +59,7 @@ export const AddLaboratoryRunSchema = z
     WorkflowName: z.string().optional(),
     S3Input: z.string().optional(),
     S3Output: z.string().optional(),
-    Settings: z.record(z.string(), jsonSchema).optional(), // JSON
+    Settings: z.string().optional(), // JSON string
   })
   .strict();
 export type AddLaboratoryRun = z.infer<typeof AddLaboratoryRunSchema>;
@@ -70,7 +70,7 @@ export const EditLaboratoryRunSchema = z
     RunId: z.string().uuid(),
     Title: z.string().optional(),
     Status: z.string(),
-    Settings: z.record(z.string(), jsonSchema).optional(),
+    Settings: z.string().optional(), // JSON string
     WorkflowName: z.string().optional(),
     ExternalRunId: z.string().optional(),
     S3Input: z.string().optional(),

--- a/packages/shared-lib/src/app/schema/easy-genomics/laboratory-run.ts
+++ b/packages/shared-lib/src/app/schema/easy-genomics/laboratory-run.ts
@@ -76,17 +76,3 @@ export const EditLaboratoryRunSchema = z
   })
   .strict();
 export type EditLaboratoryRun = z.infer<typeof EditLaboratoryRunSchema>;
-
-export const RemoveLaboratoryRunSchema = z
-  .object({
-    LaboratoryId: z.string().uuid(),
-    RunId: z.string().uuid(),
-  })
-  .strict();
-
-export const RequestLaboratoryRunSchema = z
-  .object({
-    LaboratoryId: z.string().uuid(),
-    RunId: z.string().uuid(),
-  })
-  .strict();

--- a/packages/shared-lib/src/app/types/easy-genomics/laboratory-run.d.ts
+++ b/packages/shared-lib/src/app/types/easy-genomics/laboratory-run.d.ts
@@ -18,7 +18,7 @@
  *   ExternalRunId?: <string>,
  *   S3Input?: <string>,
  *   S3Output?: <string>,
- *   Settings?: <string>, // JSON
+ *   Settings?: <string>, // JSON string
  *   CreatedAt?: <string>,
  *   CreatedBy?: <string>,
  *   ModifiedAt?: <string>,
@@ -39,5 +39,5 @@ export interface LaboratoryRun extends BaseAttributes {
   ExternalRunId?: string;
   S3Input?: string;
   S3Output?: string;
-  Settings?: string; // JSON
+  Settings?: string; // JSON string
 }

--- a/packages/shared-lib/src/app/types/easy-genomics/laboratory-run.d.ts
+++ b/packages/shared-lib/src/app/types/easy-genomics/laboratory-run.d.ts
@@ -15,6 +15,7 @@
  *   Status: <string>,
  *   Title?: <string>,
  *   WorkflowName?: <string>,
+ *   ExternalRunId?: <string>,
  *   S3Input?: <string>,
  *   S3Output?: <string>,
  *   Settings?: <string>, // JSON
@@ -35,6 +36,7 @@ export interface LaboratoryRun extends BaseAttributes {
   Status: string;
   Title?: string;
   WorkflowName?: string;
+  ExternalRunId?: string;
   S3Input?: string;
   S3Output?: string;
   Settings?: string; // JSON


### PR DESCRIPTION
## Title*
Update the LaboratoryRun type def & zod schema properties to properly support create, read, and update LaboratoryRun records.

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [X] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
 - Update LaboratoryRun type def & zod schemas to add missing ExternalRunId property to store the Id generated by launching a Seqera Pipeline Run / AWS HealthOmics Workflow Run.
 - Simplify the LaboratoryRun's Settings property to a string that will store a stringified JSON object.
 - Simplify the HTTP POST `/easy-genomics/laboratory/run/create-laboratory-run` API implementation
 - Simplify the HTTP PUT `/easy-genomics/laboratory/run/update-laboratory-run/{:id}` API implementation
 - Removed unused LaboratoryRun Read and Delete Zod Schemas

## Testing*
See JIRA ticket for testing instructions.

## Impact
The improvements in this PR will enable the FE Stepper changes in EG-888 to correctly create a LaboratoryRun record and update it to correctly track the necessary LaboratoryRun details to support improved FileManager access to the Run's results on S3.

## Additional Information
None.

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.