### PR TITLE
fix(EG-897): fix update-laboratory-run API when Settings is omitted

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/update-laboratory-run.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/update-laboratory-run.lambda.ts
@@ -57,10 +57,12 @@ export const handler: Handler = async (
       throw new UnauthorizedAccessError();
     }
 
+    const settings: string | undefined = request.Settings ? JSON.stringify(request.Settings) : existing.Settings;
+
     const response: LaboratoryRun = await laboratoryRunService.update({
       ...existing,
       ...request,
-      Settings: JSON.stringify(request.Settings),
+      Settings: settings,
       ModifiedAt: new Date().toISOString(),
       ModifiedBy: currentUserId,
     });


### PR DESCRIPTION
## Title*
Fix `/easy-genomics/laboratory/run/update-laboratory-run` API to allow updating without Settings property defined.

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Fix `/easy-genomics/laboratory/run/update-laboratory-run` API to allow updating without Settings property defined.

## Testing*
See associated JIRA ticket for testing instructions.

## Impact
None.

## Additional Information
None.

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.