### PR TITLE
refactor(EG-888): laboratory run store

### DIFF
--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -20,7 +20,6 @@
   } from '@easy-genomics/shared-lib/src/app/types/nf-tower/nextflow-tower-api';
   import { WorkflowListItem as OmicsWorkflow, RunListItem as OmicsRun } from '@aws-sdk/client-omics';
   import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory-run';
-  import useLabRunsStore from '@FE/stores/lab-runs';
 
   const props = defineProps<{
     superuser?: boolean;
@@ -40,7 +39,6 @@
 
   const orgId = labStore.labs[props.labId].OrganizationId;
   const labUsers = ref<LabUser[]>([]);
-  const labRuns = computed<LaboratoryRun[]>(() => labRunsStore.labRunsForLab(props.labId));
   const seqeraPipelines = ref<SeqeraPipeline[]>([]);
   const omicsWorkflows = ref<OmicsWorkflow[]>([]);
   const canAddUsers = computed<boolean>(() => userStore.canAddLabUsers(props.labId));
@@ -186,39 +184,17 @@
   ];
 
   function viewRunDetails(run: GenericRun) {
-    try {
-      const foundRun = getLabRunId(run.id);
-
-      if (!foundRun) {
-        throw new Error(`Run with ID ${run.id} not found.`);
-      }
-
-      $router.push({
-        path: `/labs/${props.labId}/${run.type}-run/${run.id}`,
-        query: { tab: 'Run Details', runId: foundRun.RunId },
-      });
-    } catch (error) {
-      console.error('Error in viewRunDetails:', error);
-      throw error;
-    }
+    $router.push({
+      path: `/labs/${props.labId}/${run.type}-run/${run.id}`,
+      query: { tab: 'Run Details' },
+    });
   }
 
   function viewRunResults(run: GenericRun) {
-    try {
-      const foundRun = getLabRunId(run.id);
-
-      if (!foundRun) {
-        throw new Error(`Run with ID ${run.id} not found.`);
-      }
-
-      $router.push({
-        path: `/labs/${props.labId}/${run.type}-run/${run.id}`,
-        query: { tab: 'Run Results', runId: foundRun.RunId },
-      });
-    } catch (error) {
-      console.error('Error in viewRunResults:', error);
-      throw error;
-    }
+    $router.push({
+      path: `/labs/${props.labId}/${run.type}-run/${run.id}`,
+      query: { tab: 'Run Results' },
+    });
   }
 
   function initCancelRun(run: GenericRun) {
@@ -249,7 +225,7 @@
    */
   onBeforeMount(async () => {
     await loadLabData();
-    await listLabRuns();
+    await fetchLaboratoryRuns();
   });
 
   // set tabIndex according to query param
@@ -398,16 +374,9 @@
     }
   }
 
-  async function listLabRuns(): Promise<LaboratoryRun[]> {
-    try {
-      await labRunsStore.loadLabRunsForLab(props.labId);
-    } catch (error) {
-      console.error('Error retrieving Lab runs', error);
-    }
-  }
-
-  function getLabRunId(runId: string): LaboratoryRun | undefined {
-    return labRuns.value.find((item) => item.ExternalRunId?.trim().toLowerCase() === runId.trim().toLowerCase());
+  // this anticipates these store values being needed on run click
+  async function fetchLaboratoryRuns(): Promise<void> {
+    await labRunsStore.loadLabRunsForLab(props.labId);
   }
 
   async function getSeqeraPipelines(): Promise<void> {

--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -20,6 +20,7 @@
   } from '@easy-genomics/shared-lib/src/app/types/nf-tower/nextflow-tower-api';
   import { WorkflowListItem as OmicsWorkflow, RunListItem as OmicsRun } from '@aws-sdk/client-omics';
   import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory-run';
+  import useLabRunsStore from '@FE/stores/lab-runs';
 
   const props = defineProps<{
     superuser?: boolean;
@@ -35,10 +36,11 @@
   const labStore = useLabsStore();
   const uiStore = useUiStore();
   const userStore = useUserStore();
+  const labRunsStore = useLabRunsStore();
 
   const orgId = labStore.labs[props.labId].OrganizationId;
   const labUsers = ref<LabUser[]>([]);
-  const labRuns = ref<LaboratoryRun[]>([]);
+  const labRuns = computed<LaboratoryRun[]>(() => labRunsStore.labRunsForLab(props.labId));
   const seqeraPipelines = ref<SeqeraPipeline[]>([]);
   const omicsWorkflows = ref<OmicsWorkflow[]>([]);
   const canAddUsers = computed<boolean>(() => userStore.canAddLabUsers(props.labId));
@@ -398,7 +400,7 @@
 
   async function listLabRuns(): Promise<LaboratoryRun[]> {
     try {
-      labRuns.value = await $api.labs.listLabRuns(props.labId);
+      await labRunsStore.loadLabRunsForLab(props.labId);
     } catch (error) {
       console.error('Error retrieving Lab runs', error);
     }

--- a/packages/front-end/src/app/stores/index.ts
+++ b/packages/front-end/src/app/stores/index.ts
@@ -1,3 +1,4 @@
+import useLaboratoryRunsStore from './lab-runs';
 import useLabsStore from './labs';
 import useOrgsStore from './orgs';
 import useRunStore from './run';
@@ -11,5 +12,15 @@ function resetStores() {
   useRunStore().reset();
   useUiStore().reset();
   useUserStore().reset();
+  useLaboratoryRunsStore().reset();
 }
-export { resetStores, useOrgsStore, useToastStore, useUserStore, useUiStore, useLabsStore, useRunStore };
+export {
+  resetStores,
+  useOrgsStore,
+  useToastStore,
+  useUserStore,
+  useUiStore,
+  useLabsStore,
+  useRunStore,
+  useLaboratoryRunsStore,
+};

--- a/packages/front-end/src/app/stores/index.ts
+++ b/packages/front-end/src/app/stores/index.ts
@@ -1,4 +1,4 @@
-import useLaboratoryRunsStore from './lab-runs';
+import useLabRunsStore from './lab-runs';
 import useLabsStore from './labs';
 import useOrgsStore from './orgs';
 import useRunStore from './run';
@@ -12,7 +12,7 @@ function resetStores() {
   useRunStore().reset();
   useUiStore().reset();
   useUserStore().reset();
-  useLaboratoryRunsStore().reset();
+  useLabRunsStore().reset();
 }
 export {
   resetStores,
@@ -22,5 +22,5 @@ export {
   useUiStore,
   useLabsStore,
   useRunStore,
-  useLaboratoryRunsStore,
+  useLabRunsStore,
 };

--- a/packages/front-end/src/app/stores/lab-runs.ts
+++ b/packages/front-end/src/app/stores/lab-runs.ts
@@ -1,0 +1,47 @@
+import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory-run';
+import { defineStore } from 'pinia';
+
+interface LabRunsStoreState {
+  // indexed by labId
+  labRuns: Record<string, LaboratoryRun>;
+  // ordered lists for lab runs by lab
+  labRunIdsByLab: Record<string, string[]>;
+}
+
+const initialState = (): LabRunsStoreState => ({
+  labRuns: {},
+  labRunIdsByLab: {},
+});
+
+const useLabRunsStore = defineStore('labRunsStore', {
+  state: initialState,
+
+  getters: {
+    labRunsForLab:
+      (state: LabRunsStoreState) =>
+      (labId: string): LaboratoryRun[] =>
+        state.labRunIdsByLab[labId]?.map((labRunId) => state.labRuns[labRunId]) || [],
+  },
+
+  actions: {
+    reset() {
+      Object.assign(this, initialState());
+    },
+
+    async loadLabRunsForLab(labId: string): Promise<void> {
+      const { $api } = useNuxtApp();
+
+      this.labRunIdsByLab[labId] = [];
+
+      const labRuns = await $api.labs.listLabRuns(labId);
+      for (const labRun of labRuns) {
+        this.labRuns[labRun.RunId] = labRun;
+        this.labRunIdsByLab[labId].push(labRun.RunId);
+      }
+    },
+  },
+
+  persist: true,
+});
+
+export default useLabRunsStore;

--- a/packages/front-end/src/app/stores/lab-runs.ts
+++ b/packages/front-end/src/app/stores/lab-runs.ts
@@ -21,6 +21,11 @@ const useLabRunsStore = defineStore('labRunsStore', {
       (state: LabRunsStoreState) =>
       (labId: string): LaboratoryRun[] =>
         state.labRunIdsByLab[labId]?.map((labRunId) => state.labRuns[labRunId]) || [],
+
+    labRunByExternalId:
+      (state: LabRunsStoreState) =>
+      (externalId: string): LaboratoryRun | null =>
+        Object.values(state.labRuns).find((labRun) => labRun.ExternalRunId === externalId) ?? null,
   },
 
   actions: {


### PR DESCRIPTION
## Title*

Add a laboratory runs cache store which enables the run pages to be independent of the lab page

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [X] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

- Add a laboratory run store
- Move seqeraRunId -> labRunId lookup logic from Lab (Run List) page to Run page to reduce coupling and enable direct loading of Run page without previous visit of Lab page

## Testing*

## Impact

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.