### PR TITLE
feat: update laboratory run status for nf tower workflow runs

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.ts
@@ -1,3 +1,4 @@
+import { GetRunCommandInput } from '@aws-sdk/client-omics';
 import { GetParameterCommandOutput, ParameterNotFound } from '@aws-sdk/client-ssm';
 import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
 import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory-run';
@@ -10,9 +11,10 @@ import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/src
 import { LaboratoryAccessTokenUnavailableError } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
 import { APIGatewayProxyResult, Handler, SQSRecord } from 'aws-lambda';
 import { SQSEvent } from 'aws-lambda/trigger/sqs';
-import { v4 as uuidv4 } from 'uuid';
+//import { v4 as uuidv4 } from 'uuid';
 import { LaboratoryRunService } from '@BE/services/easy-genomics/laboratory-run-service';
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
+import { OmicsService } from '@BE/services/omics-service';
 import { SnsService } from '@BE/services/sns-service';
 import { SsmService } from '@BE/services/ssm-service';
 import { getNextFlowApiQueryParameters, httpRequest, REST_API_METHOD } from '@BE/utils/rest-api-utils';
@@ -21,6 +23,7 @@ const laboratoryService = new LaboratoryService();
 const laboratoryRunService = new LaboratoryRunService();
 const ssmService = new SsmService();
 const snsService = new SnsService();
+const omicsService = new OmicsService();
 
 export const handler: Handler = async (event: SQSEvent): Promise<APIGatewayProxyResult> => {
   console.log('EVENT: \n' + JSON.stringify(event, null, 2));
@@ -33,7 +36,7 @@ export const handler: Handler = async (event: SQSEvent): Promise<APIGatewayProxy
       switch (snsEvent.Type) {
         case 'LaboratoryRun':
           const laboratoryRun: LaboratoryRun = <LaboratoryRun>JSON.parse(JSON.stringify(snsEvent.Record));
-          await processLaboratoryRunStatusCheckEvent(snsEvent.Operation, laboratoryRun);
+          await processStatusCheckEvent(snsEvent.Operation, laboratoryRun);
           break;
         default:
           console.error(`Unsupported SNS Processing Event Type: ${snsEvent.Type}`);
@@ -47,41 +50,24 @@ export const handler: Handler = async (event: SQSEvent): Promise<APIGatewayProxy
   }
 };
 
-async function processLaboratoryRunStatusCheckEvent(operation: SnsProcessingOperation, laboratoryRun: LaboratoryRun) {
+async function processStatusCheckEvent(operation: SnsProcessingOperation, laboratoryRun: LaboratoryRun) {
   if (operation === 'UPDATE') {
     try {
       console.log('Processing LaboratoryRun Status Update: ', laboratoryRun);
       const existingRun: LaboratoryRun = await laboratoryRunService.queryByRunId(laboratoryRun.RunId);
-      const laboratory: Laboratory = await laboratoryService.queryByLaboratoryId(existingRun.LaboratoryId);
 
-      // Retrieve Seqera Cloud / NextFlow Tower AccessToken from SSM
-      const getParameterResponse: GetParameterCommandOutput = await ssmService
-        .getParameter({
-          Name: `/easy-genomics/organization/${laboratory.OrganizationId}/laboratory/${laboratory.LaboratoryId}/nf-access-token`,
-          WithDecryption: true,
-        })
-        .catch((error: any) => {
-          if (error instanceof ParameterNotFound) {
-            throw new LaboratoryAccessTokenUnavailableError();
-          } else {
-            throw error;
-          }
-        });
-
-      const accessToken: string | undefined = getParameterResponse.Parameter?.Value;
-      if (!accessToken) {
-        throw new LaboratoryAccessTokenUnavailableError();
+      if (!existingRun.ExternalRunId) {
+        console.log('Missing ExternalRunID from laboratory run: skipping');
+        return false;
       }
 
-      // Get Query Parameters for Seqera Cloud / NextFlow Tower APIs
-      const apiQueryParameters: string = getNextFlowApiQueryParameters(undefined, laboratory.NextFlowTowerWorkspaceId);
-      const response: DescribeWorkflowResponse = await httpRequest<DescribeWorkflowResponse>(
-        `${process.env.SEQERA_API_BASE_URL}/workflow/${existingRun.ExternalRunId}?${apiQueryParameters}`,
-        REST_API_METHOD.GET,
-        { Authorization: `Bearer ${accessToken}` },
-      );
+      let currentStatus = existingRun.Status;
 
-      const currentStatus = response.workflow?.status || 'UNKNOWN';
+      if (existingRun.Type === 'AWS HealthOmics') {
+        currentStatus = await getAWSHealthOmicsStatus(existingRun);
+      } else if (existingRun.Type === 'Seqera Cloud') {
+        currentStatus = await getSeqeraCloudStatus(existingRun);
+      }
 
       // Has status changed?
       if (existingRun.Status != currentStatus) {
@@ -96,7 +82,9 @@ async function processLaboratoryRunStatusCheckEvent(operation: SnsProcessingOper
       }
 
       // Do we need to queue up another check?
-      if (['FAILED', 'SUCCEEDED', 'CANCELLED'].includes(currentStatus)) {
+      // NOTE: we don't have unified Easy Genomics statuses yet, so the list of status here
+      //       is a mix of both Seqera and Omics
+      if (['FAILED', 'SUCCEEDED', 'CANCELLED', 'COMPLETED', 'DELETED'].includes(currentStatus)) {
         console.log('run finished with status:', currentStatus);
       } else {
         console.log('Queueing another status check:', currentStatus);
@@ -106,10 +94,10 @@ async function processLaboratoryRunStatusCheckEvent(operation: SnsProcessingOper
           Record: laboratoryRun,
         };
         await snsService.publish({
-          TopicArn: process.env.SNS_NF_TOWER_RUN_STATUS_CHECK_TOPIC,
+          TopicArn: process.env.SNS_LABORATORY_RUN_UPDATE_TOPIC,
           Message: JSON.stringify(record),
           MessageGroupId: `update-laboratory-run-${laboratoryRun.RunId}`,
-          MessageDeduplicationId: uuidv4(),
+          MessageDeduplicationId: laboratoryRun.RunId, //uuidv4(),
         });
       }
     } catch (err: any) {
@@ -123,14 +111,58 @@ async function processLaboratoryRunStatusCheckEvent(operation: SnsProcessingOper
         Record: laboratoryRun,
       };
       await snsService.publish({
-        TopicArn: process.env.SNS_NF_TOWER_RUN_STATUS_CHECK_TOPIC,
+        TopicArn: process.env.SNS_LABORATORY_RUN_UPDATE_TOPIC,
         Message: JSON.stringify(record),
         MessageGroupId: `update-laboratory-run-${laboratoryRun.RunId}`,
-        MessageDeduplicationId: uuidv4(),
+        MessageDeduplicationId: laboratoryRun.RunId, //uuidv4(),
       });
     }
   } else {
     console.error(`Unsupported SNS Processing Event Operation: ${operation}`);
   }
   return true;
+}
+
+async function getAWSHealthOmicsStatus(laboratoryRun: LaboratoryRun): Promise<string> {
+  console.log('Fetching AWS Health Omics status for run: ', laboratoryRun.RunId);
+
+  const response = await omicsService.getRun(<GetRunCommandInput>{
+    id: laboratoryRun.ExternalRunId,
+  });
+
+  return response.status || 'UNKNOWN';
+}
+
+async function getSeqeraCloudStatus(laboratoryRun: LaboratoryRun): Promise<string> {
+  console.log('Fetching NF Tower status for run: ', laboratoryRun.RunId);
+  const laboratory: Laboratory = await laboratoryService.queryByLaboratoryId(laboratoryRun.LaboratoryId);
+
+  // Retrieve Seqera Cloud / NextFlow Tower AccessToken from SSM
+  const getParameterResponse: GetParameterCommandOutput = await ssmService
+    .getParameter({
+      Name: `/easy-genomics/organization/${laboratory.OrganizationId}/laboratory/${laboratory.LaboratoryId}/nf-access-token`,
+      WithDecryption: true,
+    })
+    .catch((error: any) => {
+      if (error instanceof ParameterNotFound) {
+        throw new LaboratoryAccessTokenUnavailableError();
+      } else {
+        throw error;
+      }
+    });
+
+  const accessToken: string | undefined = getParameterResponse.Parameter?.Value;
+  if (!accessToken) {
+    throw new LaboratoryAccessTokenUnavailableError();
+  }
+
+  // Get Query Parameters for Seqera Cloud / NextFlow Tower APIs
+  const apiQueryParameters: string = getNextFlowApiQueryParameters(undefined, laboratory.NextFlowTowerWorkspaceId);
+  const response: DescribeWorkflowResponse = await httpRequest<DescribeWorkflowResponse>(
+    `${process.env.SEQERA_API_BASE_URL}/workflow/${laboratoryRun.ExternalRunId}?${apiQueryParameters}`,
+    REST_API_METHOD.GET,
+    { Authorization: `Bearer ${accessToken}` },
+  );
+
+  return response.workflow?.status || 'UNKNOWN';
 }

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/update-laboratory-run.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/update-laboratory-run.lambda.ts
@@ -3,6 +3,7 @@ import {
   EditLaboratoryRunSchema,
 } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/laboratory-run';
 import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory-run';
+import { SnsProcessingEvent } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/sns-processing-event';
 import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/src/app/utils/common';
 import {
   InvalidRequestError,
@@ -11,12 +12,16 @@ import {
   UnauthorizedAccessError,
 } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
 import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
+import { v4 as uuidv4 } from 'uuid';
 import { LaboratoryRunService } from '@BE/services/easy-genomics/laboratory-run-service';
+import { SnsService } from '@BE/services/sns-service';
 import {
   validateLaboratoryManagerAccess,
   validateLaboratoryTechnicianAccess,
   validateOrganizationAdminAccess,
 } from '@BE/utils/auth-utils';
+
+const snsService = new SnsService();
 
 const laboratoryRunService = new LaboratoryRunService();
 
@@ -65,6 +70,21 @@ export const handler: Handler = async (
       Settings: settings,
       ModifiedAt: new Date().toISOString(),
       ModifiedBy: currentUserId,
+    });
+
+    //TODO: check if it is an active request
+
+    // Queue up run status checks
+    const record: SnsProcessingEvent = {
+      Operation: 'UPDATE',
+      Type: 'LaboratoryRun',
+      Record: response,
+    };
+    await snsService.publish({
+      TopicArn: process.env.SNS_LABORATORY_RUN_UPDATE_TOPIC,
+      Message: JSON.stringify(record),
+      MessageGroupId: `update-laboratory-run-${response.RunId}`,
+      MessageDeduplicationId: uuidv4(),
     });
 
     return buildResponse(200, JSON.stringify(response), event);

--- a/packages/back-end/src/app/controllers/nf-tower/workflow/process-workflow-status-check.lambda.ts
+++ b/packages/back-end/src/app/controllers/nf-tower/workflow/process-workflow-status-check.lambda.ts
@@ -1,0 +1,136 @@
+import { GetParameterCommandOutput, ParameterNotFound } from '@aws-sdk/client-ssm';
+import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
+import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory-run';
+import {
+  SnsProcessingEvent,
+  SnsProcessingOperation,
+} from '@easy-genomics/shared-lib/src/app/types/easy-genomics/sns-processing-event';
+import { DescribeWorkflowResponse } from '@easy-genomics/shared-lib/src/app/types/nf-tower/nextflow-tower-api';
+import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/src/app/utils/common';
+import { LaboratoryAccessTokenUnavailableError } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
+import { APIGatewayProxyResult, Handler, SQSRecord } from 'aws-lambda';
+import { SQSEvent } from 'aws-lambda/trigger/sqs';
+import { v4 as uuidv4 } from 'uuid';
+import { LaboratoryRunService } from '@BE/services/easy-genomics/laboratory-run-service';
+import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
+import { SnsService } from '@BE/services/sns-service';
+import { SsmService } from '@BE/services/ssm-service';
+import { getNextFlowApiQueryParameters, httpRequest, REST_API_METHOD } from '@BE/utils/rest-api-utils';
+
+const laboratoryService = new LaboratoryService();
+const laboratoryRunService = new LaboratoryRunService();
+const ssmService = new SsmService();
+const snsService = new SnsService();
+
+export const handler: Handler = async (event: SQSEvent): Promise<APIGatewayProxyResult> => {
+  console.log('EVENT: \n' + JSON.stringify(event, null, 2));
+  try {
+    const sqsRecords: SQSRecord[] = event.Records;
+    for (const sqsRecord of sqsRecords) {
+      const body = JSON.parse(sqsRecord.body);
+      const snsEvent: SnsProcessingEvent = <SnsProcessingEvent>JSON.parse(body.Message);
+
+      switch (snsEvent.Type) {
+        case 'LaboratoryRun':
+          const laboratoryRun: LaboratoryRun = <LaboratoryRun>JSON.parse(JSON.stringify(snsEvent.Record));
+          await processLaboratoryRunStatusCheckEvent(snsEvent.Operation, laboratoryRun);
+          break;
+        default:
+          console.error(`Unsupported SNS Processing Event Type: ${snsEvent.Type}`);
+      }
+    }
+
+    return buildResponse(200, JSON.stringify({ Status: 'Success' }));
+  } catch (err: any) {
+    console.error(err);
+    return buildErrorResponse(err);
+  }
+};
+
+async function processLaboratoryRunStatusCheckEvent(operation: SnsProcessingOperation, laboratoryRun: LaboratoryRun) {
+  if (operation === 'UPDATE') {
+    try {
+      console.log('Processing LaboratoryRun Status Update: ', laboratoryRun);
+      const existingRun: LaboratoryRun = await laboratoryRunService.queryByRunId(laboratoryRun.RunId);
+      const laboratory: Laboratory = await laboratoryService.queryByLaboratoryId(existingRun.LaboratoryId);
+
+      // Retrieve Seqera Cloud / NextFlow Tower AccessToken from SSM
+      const getParameterResponse: GetParameterCommandOutput = await ssmService
+        .getParameter({
+          Name: `/easy-genomics/organization/${laboratory.OrganizationId}/laboratory/${laboratory.LaboratoryId}/nf-access-token`,
+          WithDecryption: true,
+        })
+        .catch((error: any) => {
+          if (error instanceof ParameterNotFound) {
+            throw new LaboratoryAccessTokenUnavailableError();
+          } else {
+            throw error;
+          }
+        });
+
+      const accessToken: string | undefined = getParameterResponse.Parameter?.Value;
+      if (!accessToken) {
+        throw new LaboratoryAccessTokenUnavailableError();
+      }
+
+      // Get Query Parameters for Seqera Cloud / NextFlow Tower APIs
+      const apiQueryParameters: string = getNextFlowApiQueryParameters(undefined, laboratory.NextFlowTowerWorkspaceId);
+      const response: DescribeWorkflowResponse = await httpRequest<DescribeWorkflowResponse>(
+        `${process.env.SEQERA_API_BASE_URL}/workflow/${existingRun.ExternalRunId}?${apiQueryParameters}`,
+        REST_API_METHOD.GET,
+        { Authorization: `Bearer ${accessToken}` },
+      );
+
+      const currentStatus = response.workflow?.status || 'UNKNOWN';
+
+      // Has status changed?
+      if (existingRun.Status != currentStatus) {
+        console.log('status change', existingRun.Status, currentStatus);
+
+        laboratoryRun = await laboratoryRunService.update({
+          ...existingRun,
+          Status: currentStatus,
+          ModifiedAt: new Date().toISOString(),
+          ModifiedBy: 'Status Check',
+        });
+      }
+
+      // Do we need to queue up another check?
+      if (['FAILED', 'SUCCEEDED', 'CANCELLED'].includes(currentStatus)) {
+        console.log('run finished with status:', currentStatus);
+      } else {
+        console.log('Queueing another status check:', currentStatus);
+        const record: SnsProcessingEvent = {
+          Operation: 'UPDATE',
+          Type: 'LaboratoryRun',
+          Record: laboratoryRun,
+        };
+        await snsService.publish({
+          TopicArn: process.env.SNS_NF_TOWER_RUN_STATUS_CHECK_TOPIC,
+          Message: JSON.stringify(record),
+          MessageGroupId: `update-laboratory-run-${laboratoryRun.RunId}`,
+          MessageDeduplicationId: uuidv4(),
+        });
+      }
+    } catch (err: any) {
+      console.error(err);
+
+      //TODO: should have something to prevent endless loops
+      console.log('Queueing another status check due to error checking status');
+      const record: SnsProcessingEvent = {
+        Operation: 'UPDATE',
+        Type: 'LaboratoryRun',
+        Record: laboratoryRun,
+      };
+      await snsService.publish({
+        TopicArn: process.env.SNS_NF_TOWER_RUN_STATUS_CHECK_TOPIC,
+        Message: JSON.stringify(record),
+        MessageGroupId: `update-laboratory-run-${laboratoryRun.RunId}`,
+        MessageDeduplicationId: uuidv4(),
+      });
+    }
+  } else {
+    console.error(`Unsupported SNS Processing Event Operation: ${operation}`);
+  }
+  return true;
+}

--- a/packages/back-end/src/app/utils/rest-api-utils.ts
+++ b/packages/back-end/src/app/utils/rest-api-utils.ts
@@ -72,18 +72,18 @@ export async function httpRequest<T>(
  * @param event
  * @param workspaceId
  */
-export function getNextFlowApiQueryParameters(event: APIGatewayProxyEvent, workspaceId?: string): string {
+export function getNextFlowApiQueryParameters(event?: APIGatewayProxyEvent, workspaceId?: string): string {
   const apiQueryParameters: URLSearchParams = new URLSearchParams();
 
-  const max: string | undefined = event.queryStringParameters?.max;
+  const max: string | undefined = event?.queryStringParameters?.max;
   if (max && parseInt(max) > 0) {
     apiQueryParameters.set('max', max);
   }
-  const offset: string | undefined = event.queryStringParameters?.offset;
+  const offset: string | undefined = event?.queryStringParameters?.offset;
   if (offset && parseInt(offset) > 0) {
     apiQueryParameters.set('offset', offset);
   }
-  const search: string | undefined = event.queryStringParameters?.search;
+  const search: string | undefined = event?.queryStringParameters?.search;
   if (search) {
     apiQueryParameters.set('search', search);
   }

--- a/packages/back-end/src/infra/stacks/nf-tower-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/nf-tower-nested-stack.ts
@@ -61,44 +61,6 @@ export class NFTowerNestedStack extends NestedStack {
         effect: Effect.ALLOW,
       }),
     ]);
-    this.iam.addPolicyStatements('laboratory-run-id-query-policy', [
-      new PolicyStatement({
-        resources: [
-          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-run-table`,
-          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-run-table/index/*`,
-        ],
-        actions: ['dynamodb:Query'],
-        effect: Effect.ALLOW,
-      }),
-    ]);
-    this.iam.addPolicyStatements('laboratory-run-create-policy', [
-      new PolicyStatement({
-        resources: [
-          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-run-table`,
-          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-run-table/index/*`,
-        ],
-        actions: ['dynamodb:PutItem'],
-        effect: Effect.ALLOW,
-      }),
-      new PolicyStatement({
-        resources: [
-          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-user-table`,
-          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-user-table/index/*`,
-        ],
-        actions: ['dynamodb:Query'],
-        effect: Effect.ALLOW,
-      }),
-    ]);
-    this.iam.addPolicyStatements('laboratory-run-update-policy', [
-      new PolicyStatement({
-        resources: [
-          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-run-table`,
-          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-run-table/index/*`,
-        ],
-        actions: ['dynamodb:UpdateItem'],
-        effect: Effect.ALLOW,
-      }),
-    ]);
 
     // /nf-tower/compute-env/list-compute-envs
     this.iam.addPolicyStatements('/nf-tower/compute-env/list-compute-envs', [
@@ -147,7 +109,6 @@ export class NFTowerNestedStack extends NestedStack {
     this.iam.addPolicyStatements('/nf-tower/workflow/create-workflow-execution', [
       ...this.iam.getPolicyStatements('laboratory-id-query-policy'),
       ...this.iam.getPolicyStatements('laboratory-get-ssm-access-token-policy'),
-      ...this.iam.getPolicyStatements('laboratory-run-create-policy'),
     ]);
     // /nf-tower/workflow/list-workflows
     this.iam.addPolicyStatements('/nf-tower/workflow/list-workflows', [

--- a/packages/back-end/src/infra/stacks/nf-tower-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/nf-tower-nested-stack.ts
@@ -1,44 +1,18 @@
-import { Duration, NestedStack } from 'aws-cdk-lib';
+import { NestedStack } from 'aws-cdk-lib';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
-import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
 import { Construct } from 'constructs';
 import { IamConstruct, IamConstructProps } from '../constructs/iam-construct';
 import { LambdaConstruct } from '../constructs/lambda-construct';
-import { SnsConstruct, TopicDetails, Topics } from '../constructs/sns-construct';
-import { QueueDetails, Queues, SqsConstruct } from '../constructs/sqs-construct';
 import { NFTowerNestedStackProps } from '../types/back-end-stack';
 
 export class NFTowerNestedStack extends NestedStack {
   props: NFTowerNestedStackProps;
   iam: IamConstruct;
   lambda: LambdaConstruct;
-  sns: SnsConstruct;
-  sqs: SqsConstruct;
 
   constructor(scope: Construct, id: string, props: NFTowerNestedStackProps) {
     super(scope, id);
     this.props = props;
-
-    this.sns = new SnsConstruct(this, `${this.props.constructNamespace}-sns`, {
-      namePrefix: this.props.namePrefix,
-      topics: <Topics>{
-        ['nf-tower-run-status-check-topic']: <TopicDetails>{ fifo: true },
-      },
-    });
-
-    this.sqs = new SqsConstruct(this, `${this.props.constructNamespace}-sqs`, {
-      namePrefix: this.props.namePrefix,
-      devEnv: this.props.devEnv,
-      queues: <Queues>{
-        ['nf-tower-run-status-check-queue']: <QueueDetails>{
-          fifo: true,
-          retentionPeriod: Duration.days(1),
-          visibilityTimeout: Duration.minutes(15),
-          deliveryDelay: Duration.minutes(5),
-          snsTopics: [this.sns.snsTopics.get('nf-tower-run-status-check-topic')],
-        },
-      },
-    });
 
     this.iam = new IamConstruct(this, `${this.props.constructNamespace}-iam`, {
       ...(<IamConstructProps>props), // Typecast to IamConstructProps
@@ -52,19 +26,6 @@ export class NFTowerNestedStack extends NestedStack {
       lambdaFunctionsNamespace: `${this.props.constructNamespace}`,
       lambdaFunctionsResources: {
         // Used for setting specific resources for a given Lambda function (e.g. environment settings, trigger events)
-        '/nf-tower/workflow/create-workflow-execution': {
-          environment: {
-            SNS_NF_TOWER_RUN_STATUS_CHECK_TOPIC:
-              this.sns.snsTopics.get('nf-tower-run-status-check-topic')?.topicArn || '',
-          },
-        },
-        '/nf-tower/workflow/process-workflow-status-check': {
-          events: [new SqsEventSource(this.sqs.sqsQueues.get('nf-tower-run-status-check-queue')!, { batchSize: 1 })],
-          environment: {
-            SNS_NF_TOWER_RUN_STATUS_CHECK_TOPIC:
-              this.sns.snsTopics.get('nf-tower-run-status-check-topic')?.topicArn || '',
-          },
-        },
       },
       environment: {
         // Defines the common environment settings for all lambda functions
@@ -187,11 +148,6 @@ export class NFTowerNestedStack extends NestedStack {
       ...this.iam.getPolicyStatements('laboratory-id-query-policy'),
       ...this.iam.getPolicyStatements('laboratory-get-ssm-access-token-policy'),
       ...this.iam.getPolicyStatements('laboratory-run-create-policy'),
-      new PolicyStatement({
-        resources: [`${this.sns.snsTopics.get('nf-tower-run-status-check-topic')?.topicArn || ''}`],
-        actions: ['sns:Publish'],
-        effect: Effect.ALLOW,
-      }),
     ]);
     // /nf-tower/workflow/list-workflows
     this.iam.addPolicyStatements('/nf-tower/workflow/list-workflows', [
@@ -217,18 +173,6 @@ export class NFTowerNestedStack extends NestedStack {
     this.iam.addPolicyStatements('/nf-tower/workflow/read-workflow-reports', [
       ...this.iam.getPolicyStatements('laboratory-id-query-policy'),
       ...this.iam.getPolicyStatements('laboratory-get-ssm-access-token-policy'),
-    ]);
-    // /nf-tower/workflow/process-workflow-status-check
-    this.iam.addPolicyStatements('/nf-tower/workflow/process-workflow-status-check', [
-      ...this.iam.getPolicyStatements('laboratory-id-query-policy'),
-      ...this.iam.getPolicyStatements('laboratory-get-ssm-access-token-policy'),
-      ...this.iam.getPolicyStatements('laboratory-run-id-query-policy'),
-      ...this.iam.getPolicyStatements('laboratory-run-update-policy'),
-      new PolicyStatement({
-        resources: [`${this.sns.snsTopics.get('nf-tower-run-status-check-topic')?.topicArn || ''}`],
-        actions: ['sns:Publish'],
-        effect: Effect.ALLOW,
-      }),
     ]);
   };
 }


### PR DESCRIPTION
## Title*
Update nf tower workflow run statuses via a delayed queue

## Type of Change*
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
After a NF Tower run is started, check the status of that run and update the laboratory run entry for that run every 5 minutes until the status is `Failed`, `Succeeded` or `Cancelled`. 

## Testing*
After creating a workflow run on NF Tower, there will be a laboratory run entry created for that run (the `ExternalRunId` value will match the workflowId return by NF Tower when starting the run). The status of that laboratory run will be `Pending` initially, but will be updated after 5 minutes to the status of the run in NF Tower. This may currently only be visible via the api in postman.

## Impact
We are now checking these statuses every 5 minutes for incomplete runs. For the expected loads in a production environment we do not expect to push any limits around Lambda invocations, but this will add to an overall load.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [ ] Code has been commented in particularly hard-to-understand areas.