### PR TITLE
feat(EG-905): add HTTP GET '/aws-healthomics/workflow/list-shared-workflows' API

### DIFF
--- a/packages/back-end/src/app/controllers/aws-healthomics/workflow/list-shared-workflows.lambda.ts
+++ b/packages/back-end/src/app/controllers/aws-healthomics/workflow/list-shared-workflows.lambda.ts
@@ -1,0 +1,77 @@
+import { ListSharesCommandInput } from '@aws-sdk/client-omics';
+import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/lib/app/utils/common';
+import {
+  LaboratoryNotFoundError,
+  RequiredIdNotFoundError,
+  UnauthorizedAccessError,
+} from '@easy-genomics/shared-lib/lib/app/utils/HttpError';
+import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
+import { MissingAWSHealthOmicsAccessError } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
+import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
+import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
+import { OmicsService } from '@BE/services/omics-service';
+import {
+  validateLaboratoryManagerAccess,
+  validateLaboratoryTechnicianAccess,
+  validateOrganizationAdminAccess,
+} from '@BE/utils/auth-utils';
+import { AwsHealthOmicsQueryParameters, getAwsHealthOmicsApiQueryParameters } from '@BE/utils/rest-api-utils';
+
+const laboratoryService = new LaboratoryService();
+const omicsService = new OmicsService();
+
+/**
+ * This GET /aws-healthomics/workflow/list-shared-workflows?laboratoryId={LaboratoryId}
+ * API queries the same region's AWS HealthOmics service to retrieve a list of
+ * Shared Workflows, and it expects:
+ *  - Required Query Parameter:
+ *    - 'laboratoryId': to retrieve the Laboratory to verify access to AWS HealthOmics
+ *  - Optional Query Parameters:
+ *    - 'maxResults': pagination number of results
+ *    - 'nextToken': pagination results offset index
+ *    - 'name': string to search by the Workflow name attribute
+ *
+ * @param event
+ */
+export const handler: Handler = async (
+  event: APIGatewayProxyWithCognitoAuthorizerEvent,
+): Promise<APIGatewayProxyResult> => {
+  console.log('EVENT: \n' + JSON.stringify(event, null, 2));
+  try {
+    // Get required query parameter
+    const laboratoryId: string = event.queryStringParameters?.laboratoryId || '';
+    if (laboratoryId === '') throw new RequiredIdNotFoundError('laboratoryId');
+
+    const laboratory: Laboratory = await laboratoryService.queryByLaboratoryId(laboratoryId);
+
+    if (!laboratory) {
+      throw new LaboratoryNotFoundError();
+    }
+
+    // Only available for Org Admins or Laboratory Managers and Technicians
+    if (
+      !(
+        validateOrganizationAdminAccess(event, laboratory.OrganizationId) ||
+        validateLaboratoryManagerAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId) ||
+        validateLaboratoryTechnicianAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId)
+      )
+    ) {
+      throw new UnauthorizedAccessError();
+    }
+
+    // Requires AWS Health Omics access
+    if (!laboratory.AwsHealthOmicsEnabled) {
+      throw new MissingAWSHealthOmicsAccessError();
+    }
+
+    const queryParameters: AwsHealthOmicsQueryParameters = getAwsHealthOmicsApiQueryParameters(event);
+    const response = await omicsService.listSharedWorkflows(<ListSharesCommandInput>{
+      resourceOwner: 'OTHER',
+      ...queryParameters,
+    });
+    return buildResponse(200, JSON.stringify(response), event);
+  } catch (err: any) {
+    console.error(err);
+    return buildErrorResponse(err, event);
+  }
+};

--- a/packages/back-end/src/app/services/omics-service.ts
+++ b/packages/back-end/src/app/services/omics-service.ts
@@ -14,6 +14,9 @@ import {
   ListWorkflowsCommand,
   ListWorkflowsCommandInput,
   ListWorkflowsCommandOutput,
+  ListSharesCommand,
+  ListSharesCommandInput,
+  ListSharesCommandOutput,
   OmicsClient,
   OmicsServiceException,
   StartRunCommand,
@@ -27,6 +30,7 @@ export enum OmicsCommand {
   GET_WORKFLOW = 'get-workflow',
   LIST_RUNS = 'list-runs',
   LIST_WORKFLOWS = 'list-workflows',
+  LIST_SHARED_WORKFLOWS = 'list-shared-workflows',
   START_RUN = 'start-run',
 }
 
@@ -65,6 +69,15 @@ export class OmicsService {
     return this.omicsRequest<ListWorkflowsCommandInput, ListWorkflowsCommandOutput>(
       OmicsCommand.LIST_WORKFLOWS,
       listWorkflowsCommandInput,
+    );
+  };
+
+  public listSharedWorkflows = async (
+    listSharesCommandInput: ListSharesCommandInput,
+  ): Promise<ListSharesCommandOutput> => {
+    return this.omicsRequest<ListSharesCommandInput, ListSharesCommandOutput>(
+      OmicsCommand.LIST_SHARED_WORKFLOWS,
+      listSharesCommandInput,
     );
   };
 
@@ -107,6 +120,8 @@ export class OmicsService {
         return new ListRunsCommand(data);
       case OmicsCommand.LIST_WORKFLOWS:
         return new ListWorkflowsCommand(data);
+      case OmicsCommand.LIST_SHARED_WORKFLOWS:
+        return new ListSharesCommand(data);
       case OmicsCommand.START_RUN:
         return new StartRunCommand(data);
       default:

--- a/packages/back-end/src/infra/stacks/aws-healthomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/aws-healthomics-nested-stack.ts
@@ -119,6 +119,22 @@ export class AwsHealthOmicsNestedStack extends NestedStack {
       }),
     ]);
 
+    // /aws-healthomics/workflow/list-shared-workflows
+    this.iam.addPolicyStatements('/aws-healthomics/workflow/list-shared-workflows', [
+      new PolicyStatement({
+        resources: [
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table`,
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table/index/*`,
+        ],
+        actions: ['dynamodb:Query'],
+      }),
+      new PolicyStatement({
+        resources: [`arn:aws:omics:${this.props.env.region!}:${this.props.env.account!}:/shares`],
+        actions: ['omics:ListShares'],
+        effect: Effect.ALLOW,
+      }),
+    ]);
+
     // /aws-healthomics/workflow/read-private-workflow
     this.iam.addPolicyStatements('/aws-healthomics/workflow/read-private-workflow', [
       new PolicyStatement({


### PR DESCRIPTION
## Title*
Add HTTP GET `'/aws-healthomics/workflow/list-shared-workflows'` API endpoint.

## Type of Change*
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
This PR adds a new API endpoint to retrieve a list of available shared Workflows from 'OTHER' parties.

It is better to have a separate API endpoint to return the list of shared Workflows instead of modifying the existing `'/aws-healthomics/workflow/list-private-workflows'` API endpoint as it would make it harder to maintain into the future since the data responses is different, and the existing pagination/filtering querying behaviour would be compromised.

## Testing*
Refer to JIRA ticket for the testing acceptance criteria.

## Impact
If shared Workflows is a required functionality that Easy Genomics needs to support, then this API will be ready to meet this requirement, and will require the FE to be enhanced to incorporate this API's returned shared Workflow data.

## Additional Information
None

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.