### PR TITLE
feat(EG-908): switch org delay

### DIFF
--- a/packages/front-end/src/app/components/EGButton.vue
+++ b/packages/front-end/src/app/components/EGButton.vue
@@ -10,6 +10,7 @@
     iconRight?: boolean;
     disabled?: boolean;
     uButtonType?: string;
+    loading?: boolean;
   };
 
   withDefaults(defineProps<ButtonProps>(), {
@@ -20,6 +21,7 @@
     iconRight: true,
     disabled: false,
     uButtonType: undefined,
+    loading: false,
   });
 
   const buttonVariants = cva(
@@ -112,5 +114,6 @@
       },
     }"
     :type="uButtonType"
+    :loading="loading"
   />
 </template>

--- a/packages/front-end/src/app/components/EGDialog.vue
+++ b/packages/front-end/src/app/components/EGDialog.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
   import { ButtonVariantEnum, ButtonSizeEnum } from '@FE/types/buttons';
 
-  defineProps<{
+  const props = defineProps<{
     modelValue: any;
     primaryMessage?: string;
     secondaryMessage?: string;
@@ -10,12 +10,24 @@
     cancelLabel?: string;
     cancelVariant?: string;
     buttonsDisabled?: boolean;
+    triggerDelay?: number;
   }>();
 
   const emit = defineEmits(['action-triggered', 'update:modelValue']);
 
   function handleCancel() {
     emit('update:modelValue', false);
+  }
+
+  const delaying = ref<boolean>(false);
+
+  function handleClick() {
+    delaying.value = true;
+
+    setTimeout(() => {
+      delaying.value = false;
+      emit('action-triggered');
+    }, props.triggerDelay || 0);
   }
 </script>
 
@@ -34,6 +46,7 @@
                 color="black"
                 variant="ghost"
                 :ui="{ rounded: 'rounded-full' }"
+                :disabled="buttonsDisabled || delaying"
               />
             </div>
           </div>
@@ -47,15 +60,16 @@
                 :label="cancelLabel"
                 :variant="ButtonVariantEnum.enum.secondary"
                 :size="ButtonSizeEnum.enum.sm"
-                :disabled="buttonsDisabled"
+                :disabled="buttonsDisabled || delaying"
               />
             </div>
             <EGButton
-              @click="emit('action-triggered')"
+              @click="handleClick"
               :label="actionLabel"
               :size="ButtonSizeEnum.enum.sm"
               :variant="actionVariant"
-              :disabled="buttonsDisabled"
+              :disabled="buttonsDisabled || delaying"
+              :loading="delaying"
               autofocus
             />
           </div>

--- a/packages/front-end/src/app/components/EGHeader.vue
+++ b/packages/front-end/src/app/components/EGHeader.vue
@@ -160,6 +160,7 @@
     action-label="Continue"
     :action-variant="ButtonVariantEnum.enum.primary"
     @action-triggered="doSwitchOrg"
+    :trigger-delay="2000"
     primary-message="Are you sure you would like to switch organizations?"
     secondary-message="You are about to switch organisation accounts. Ensure all unsaved work is saved and reviewed before proceeding. Switching accounts may result in losing access to current session data or active tasks."
     v-model="switchOrgDialogOpen"


### PR DESCRIPTION
## Title*

Add an artificial delay on org switch to make it feel better

## Type of Change*
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [X] UI/UX improvement

## Description

Adds new features to EGButton (loading control) and EGDialog (artificial delay).

Then adds a 2 second delay to org switching.

https://github.com/user-attachments/assets/bbcd42e6-a9af-4cd5-98fd-72af877700db

## Testing*

Manually tested feature change, and tested that existing EGDialogs with no artificial delay behave as before.

## Impact

## Additional Information

## Checklist*
- [ ] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [ ] Code adheres to the coding and style guidelines of the project.
- [ ] Code has been commented in particularly hard-to-understand areas.