### PR TITLE
feat(EG-848): handle click invite email while signed in as superuser

### DIFF
--- a/packages/front-end/src/app/components/EGHeader.vue
+++ b/packages/front-end/src/app/components/EGHeader.vue
@@ -14,7 +14,7 @@
   const userStore = useUserStore();
   const orgsStore = useOrgsStore();
 
-  const { signOut } = useAuth();
+  const { signOutAndRedirect } = useAuth();
   const $router = useRouter();
   const labsPath = '/labs';
   const orgsPath = '/orgs';
@@ -64,7 +64,7 @@
       {
         label: 'Sign Out',
         class: 'p-4 text-primary underline',
-        click: signOut,
+        click: signOutAndRedirect,
       },
     ]);
 

--- a/packages/front-end/src/app/composables/useAuth.ts
+++ b/packages/front-end/src/app/composables/useAuth.ts
@@ -79,12 +79,16 @@ export default function useAuth() {
     try {
       await Auth.signOut();
       useUserStore().reset();
-      await navigateTo('/signin');
-      useToastStore().success('You have been signed out.');
     } catch (error) {
       console.error('Error occurred during sign out.', error);
       throw error;
     }
+  }
+
+  async function signOutAndRedirect() {
+    await signOut();
+    useToastStore().success('You have been signed out.');
+    await navigateTo('/signin');
   }
 
   return {
@@ -93,5 +97,6 @@ export default function useAuth() {
     isAuthed,
     signIn,
     signOut,
+    signOutAndRedirect,
   };
 }

--- a/packages/front-end/src/app/middleware/auth.global.ts
+++ b/packages/front-end/src/app/middleware/auth.global.ts
@@ -8,8 +8,8 @@ const baseURL = window.location.origin;
 export default defineNuxtRouteMiddleware(async (to) => {
   const url = new URL(to.fullPath, baseURL);
 
-  // If the URL contains an email query parameter (incoming from /accept-invite) do not redirect
-  if (url.search.startsWith('?email=')) {
+  // If the URL contains an email query parameter (incoming from /accept-invitation) do not redirect
+  if (url.pathname === '/accept-invitation' && url.search.startsWith('?email=')) {
     return;
   }
 
@@ -17,7 +17,7 @@ export default defineNuxtRouteMiddleware(async (to) => {
   if (url.pathname === '/accept-invitation') {
     const token = url.searchParams.get('invite');
 
-    // If the 'accept-password' query parameter is missing or empty, redirect to '/'
+    // If the 'invite' query parameter is missing or empty, redirect to '/'
     if (!token) {
       return navigateTo('/signin');
     }
@@ -52,6 +52,15 @@ export default defineNuxtRouteMiddleware(async (to) => {
         return navigateTo('/signin');
       }
     }
+  }
+
+  /*
+   * @description Handles case where invite link is clicked while signed in as superuser: sign out, then continue
+   */
+  if (useUserStore().isSuperuser && url.pathname === '/accept-invitation') {
+    const { signOut } = useAuth();
+    await signOut();
+    return;
   }
 
   /**


### PR DESCRIPTION
## Title*

Handle click invite email while signed in as superuser

## Type of Change*
- [X] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [X] UI/UX improvement

## Description

Previously, when an accept invite link was clicked while signed in as superuser, it resulted in a 404.

Now, the (super)user gets signed out, and the invitation accepting continues as normal.

## Testing*

Manual testing

## Impact

## Additional Information

I made a couple fixes to the route middleware where I inferred something was wrong

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.