### PR TITLE
fix(EG-911): undefined forEach error when no seqera run s3 contents available

### DIFF
--- a/packages/front-end/src/app/components/EGFileExplorer.vue
+++ b/packages/front-end/src/app/components/EGFileExplorer.vue
@@ -85,7 +85,7 @@
 
   function transformS3Data(s3Contents: S3Response, s3prefix: string) {
     const map: MapType = {};
-    s3Contents.Contents.forEach((item: S3Object) => {
+    s3Contents?.Contents?.forEach((item: S3Object) => {
       if (item.Key.startsWith(s3prefix)) {
         const parts = item.Key.slice(s3prefix.length).split('/').filter(Boolean);
         parts.reduce((acc: MapType, part: string, index: number) => {

--- a/packages/front-end/src/app/pages/labs/[labId]/seqera-run/[seqeraRunId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/seqera-run/[seqeraRunId].vue
@@ -14,7 +14,7 @@
   const seqeraRunId = $route.params.seqeraRunId as string;
 
   const seqeraRunReports = ref([]);
-  const s3Contents = ref<S3Response>(null);
+  const s3Contents = ref<S3Response | null>(null);
   const tabIndex = ref(0);
 
   // Permission Check


### PR DESCRIPTION
## Title*

Fix console error when run has no S3 contents

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

When S3 content fetch for a Seqera Run's results returned nothing, a console error would appear alerting to an `(undefined).forEach(...)`.

Adding null conditional operators to skip the `forEach` action avoids the error, and the S3 results widget simply reports "No files or folders found".

## Testing*

Manual before and after testing to confirm this was the cause and solution to this particular error.

## Impact

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.