### PR TITLE
fix(EG-901): lab selected tab breaking after details update changes list of tabs

### DIFF
--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -228,10 +228,14 @@
     await fetchLaboratoryRuns();
   });
 
-  // set tabIndex according to query param
-  onMounted(() => {
+  function setTabIndexFromQuery() {
     const queryTabMatchIndex = tabItems.value.findIndex((tab) => tab.label === props.initialTab);
     tabIndex.value = queryTabMatchIndex !== -1 ? queryTabMatchIndex : 0;
+  }
+
+  onMounted(() => {
+    // set tabIndex according to query param
+    setTabIndexFromQuery();
 
     if (intervalId) {
       clearTimeout(intervalId);
@@ -487,6 +491,13 @@
 
     await getSeqeraRuns();
     await getOmicsRuns();
+  }
+
+  async function handleDetailsUpdated() {
+    await loadLabData();
+
+    // the tabs can change after details are updated from adding/removing a compute integration, so update tab index
+    setTimeout(setTabIndexFromQuery, 100); // there's a slight delay to get around a race condition
   }
 
   watch(lab, async (lab) => {
@@ -756,7 +767,7 @@
         </EGTable>
       </div>
       <div v-else-if="item.key === 'details'" class="space-y-3">
-        <EGFormLabDetails @updated="loadLabData" />
+        <EGFormLabDetails @updated="handleDetailsUpdated" />
       </div>
     </template>
   </UTabs>


### PR DESCRIPTION
## Title*

Fix lab view selected tab breaking after updating lab details to add/remove a compute integration

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

When editing a lab to add/remove a compute integration, the list of tabs on the page gets changed. The tab index remained the same and there were visual bugs.

This patch makes the page recalculate the right tab index after lab details are updated.

## Testing*

Manual testing

## Impact

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.