### PR TITLE
fix(EG-899): aws-healthomics iam policy enhancements

### DIFF
--- a/packages/back-end/src/infra/constructs/iam-construct.ts
+++ b/packages/back-end/src/infra/constructs/iam-construct.ts
@@ -97,6 +97,17 @@ export class IamConstruct extends Construct {
     return role;
   }
 
+  /**
+   * This function allows IAM policy to be defined in the appropriate nested stack
+   * and added to this construct's roles map collection for easy retrieval.
+   *
+   * @param name
+   * @param policy
+   */
+  public addPolicy(name: string, policy: Policy) {
+    this.policies.set(name, policy);
+  }
+
   public getPolicy(name: string): Policy {
     const policy: Policy | undefined = this.policies.get(name);
     if (!policy) {

--- a/packages/shared-lib/src/app/schema/aws-healthomics/aws-healthomics-api.ts
+++ b/packages/shared-lib/src/app/schema/aws-healthomics/aws-healthomics-api.ts
@@ -13,7 +13,6 @@ import { z } from 'zod';
 export const CreateRunRequestSchema = z
   .object({
     workflowId: z.string(),
-    requestId: z.string(), // Easy Genomics TransactionId
     name: z.string(),
     parameters: z.string(),
     roleArn: z.string().optional(), // 'easy-genomics-healthomics-workflow-run-role'
@@ -25,6 +24,7 @@ export const CreateRunRequestSchema = z
     priority: z.number().optional(),
     storageCapacity: z.number().optional(),
     logLevel: z.enum(['ALL', 'ERROR', 'FATAL', 'OFF']).optional(),
+    requestId: z.string().optional(), // unique id to prevent multiple runs
     retentionMode: z.enum(['RETAIN', 'REMOVE']).optional(),
     storageType: z.enum(['STATIC', 'DYNAMIC']).optional(),
     workflowOwnerId: z.string().optional(),


### PR DESCRIPTION
## Title*
fix(EG-899): aws-healthomics iam policy enhancements

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [X] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Refactor the aws-healthomics-nested-stack IAM policy definitions support running AWS HealthOmics Workflows and improve understandability / maintainability.

Also corrected the CreateRunRequestSchema definition to make `requestId` an optional property as per the SDK definition. It was originally planned to set the EasyGenomics transactionId / runId value for this property for it to be used by AWS HealthOmics instead of generating a new random ID. But the AWS HealthOmics SDK does not return this value in its responses, so this Easy Genomics cannot leverage this property.

## Testing*
See associated JIRA ticket for testing instructions.

## Impact
None.

## Additional Information
None.

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.