### PR TITLE
fix(EG-890): prevent autocomplete on personal access token input

### DIFF
--- a/packages/front-end/src/app/components/EGFormLabDetails.vue
+++ b/packages/front-end/src/app/components/EGFormLabDetails.vue
@@ -417,7 +417,7 @@
           v-if="formMode === LabDetailsFormModeEnum.enum.Create"
           v-model="state.NextFlowTowerAccessToken"
           :password="true"
-          :autocomplete="AutoCompleteOptionsEnum.enum.Off"
+          :autocomplete="AutoCompleteOptionsEnum.enum.NewPassword"
           :disabled="!isEditing || isSubmittingFormData"
         />
         <!-- Next Flow Tower Access Token: Edit  Mode -->


### PR DESCRIPTION
## Title*
Prevent autocomplete on personal access token input field

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Browsers (at least chrome and firefox) are ignoring the "off" autocomplete when creating a new lab and autofilling in the username and password into the personal access token and workspace id fields. This change sets the autocomplete to "new-password" which the bowsers seem to accept and not autofill with details.

## Testing*
Can be tested by creating a new lab

## Impact
Removes the annoyance of browsers autofilling fields that are not usernames and passwords

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [ ] Code has been commented in particularly hard-to-understand areas.