### PR TITLE
fix: frontend not sending through workflow name in run launch request

### DIFF
--- a/packages/front-end/src/app/components/EGRunPipelineFormReviewPipeline.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineFormReviewPipeline.vue
@@ -77,7 +77,7 @@
           'RunName': wipSeqeraRun.value?.userPipelineRunName,
           'Platform': 'Seqera Cloud', // TODO: Extend to support 'AWS HealthOmics',
           'Status': 'SUBMITTED',
-          'WorkflowName': pipeline?.name, // TODO: Extend to support AWS HealthOmics Workflow name
+          'WorkflowName': pipeline.value?.name, // TODO: Extend to support AWS HealthOmics Workflow name
           'ExternalRunId': res.workflowId,
           'InputS3Url': props.params.input.substring(0, props.params.input.lastIndexOf('/')),
           'OutputS3Url': props.params.outdir,


### PR DESCRIPTION
## Title*

Fix frontend not sending through workflow name in run launch request

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Just a forgotten `.value` on a `computed`.

## Testing*


## Impact
WorkflowName will start coming through on run start requests.

## Additional Information


## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.