### PR TITLE
feat(EG-923): add User DefaultOrganization setting support

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -11,9 +11,9 @@ import {
   TypescriptConfigOptions,
 } from 'projen/lib/javascript';
 import { pathsToModuleNameMapper } from 'ts-jest';
+import { ApacheLicense } from './projenrc/apache-license';
 import { setupProjectFolders } from './projenrc/easy-genomics-project-setup';
 import { GithubActionsCICDRelease } from './projenrc/github-actions-cicd-release';
-import { ApacheLicense } from './projenrc/apache-license';
 import { Husky } from './projenrc/husky';
 import { Nx } from './projenrc/nx';
 import { PnpmWorkspace } from './projenrc/pnpm';
@@ -109,9 +109,11 @@ const jestOptions: JestOptions = {
   jestConfig: {
     // Add all the special paths to let Jest resolve them properly
     moduleNameMapper: {
-      ...pathsToModuleNameMapper(tsConfigOptions.compilerOptions?.paths!, {
-        prefix: '<rootDir>/',
-      }),
+      ...(tsConfigOptions.compilerOptions?.paths
+        ? pathsToModuleNameMapper(tsConfigOptions.compilerOptions?.paths, {
+            prefix: '<rootDir>/',
+          })
+        : {}),
     },
     coveragePathIgnorePatterns: ['/node_modules/'],
   },

--- a/packages/back-end/src/app/controllers/auth/process-pre-token-generation.lambda.ts
+++ b/packages/back-end/src/app/controllers/auth/process-pre-token-generation.lambda.ts
@@ -30,6 +30,7 @@ export const handler: Handler = async (
           ['FirstName']: user.FirstName || '',
           ['LastName']: user.LastName || '',
           ['Status']: user.Status,
+          ['DefaultOrganization']: user.DefaultOrganization || '', // User chosen Default Organization
           ['OrganizationAccess']: JSON.stringify(user.OrganizationAccess),
         },
       },

--- a/packages/back-end/src/app/controllers/easy-genomics/user/update-user-default-organization-request.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/user/update-user-default-organization-request.lambda.ts
@@ -1,0 +1,82 @@
+import {
+  UpdateUserDefaultOrganization,
+  UpdateUserDefaultOrganizationSchema,
+} from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/user';
+import { OrganizationUser } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/organization-user';
+import { User } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/user';
+import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/src/app/utils/common';
+import {
+  InvalidRequestError,
+  RequiredIdNotFoundError,
+  UnauthorizedAccessError,
+} from '@easy-genomics/shared-lib/src/app/utils/HttpError';
+import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
+import { OrganizationUserService } from '@BE/services/easy-genomics/organization-user-service';
+import { UserService } from '@BE/services/easy-genomics/user-service';
+
+const organizationUserService = new OrganizationUserService();
+const userService = new UserService();
+
+export const handler: Handler = async (
+  event: APIGatewayProxyWithCognitoAuthorizerEvent,
+): Promise<APIGatewayProxyResult> => {
+  console.log('EVENT: \n' + JSON.stringify(event, null, 2));
+  try {
+    // Get Path Parameter
+    const id: string = event.pathParameters?.id || '';
+    if (id === '') throw new RequiredIdNotFoundError();
+
+    const userId = event.requestContext.authorizer.claims['cognito:username'];
+    if (id !== userId) {
+      throw new UnauthorizedAccessError();
+    }
+
+    // Only the current User can change their own User details
+    const existing: User | undefined = (
+      await userService.queryByEmail(event.requestContext.authorizer.claims.email)
+    ).shift();
+
+    if (!existing) {
+      throw new UnauthorizedAccessError();
+    }
+
+    // Put Request Body
+    const request: UpdateUserDefaultOrganization = event.isBase64Encoded
+      ? JSON.parse(atob(event.body!))
+      : JSON.parse(event.body!);
+    // Data validation safety check
+    if (!UpdateUserDefaultOrganizationSchema.safeParse(request).success) {
+      throw new InvalidRequestError();
+    }
+
+    const defaultOrganization: string = request.DefaultOrganization ? request.DefaultOrganization : '';
+    if (defaultOrganization !== '') {
+      // Do not allow updating DefaultOrganization if it is the same
+      if (existing.DefaultOrganization === defaultOrganization) {
+        throw new InvalidRequestError(`Organization '${existing.DefaultOrganization}' is already set as default`);
+      }
+
+      // Do not allow updating DefaultOrganization if the User does not have an existing OrganizationUser access
+      const organizationUsers: OrganizationUser[] = await organizationUserService.queryByUserId(existing.UserId);
+      if (!organizationUsers.find((_: OrganizationUser) => _.OrganizationId === defaultOrganization)) {
+        throw new UnauthorizedAccessError(`Organization '${defaultOrganization}' cannot be set as default`);
+      }
+    }
+
+    // Update existing User record in Easy-Genomics User table to change DefaultOrganization setting
+    const response: User = await userService.update(
+      {
+        ...existing,
+        DefaultOrganization: defaultOrganization,
+        ModifiedAt: new Date().toISOString(),
+        ModifiedBy: userId,
+      },
+      existing,
+    );
+
+    return buildResponse(200, JSON.stringify(response), event);
+  } catch (err: any) {
+    console.error(err);
+    return buildErrorResponse(err, event);
+  }
+};

--- a/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
@@ -744,6 +744,33 @@ export class EasyGenomicsNestedStack extends NestedStack {
         effect: Effect.ALLOW,
       }),
     ]);
+    // /easy-genomics/user/update-user-default-organization-request
+    this.iam.addPolicyStatements('/easy-genomics/user/update-user-default-organization-request', [
+      new PolicyStatement({
+        resources: [
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-user-table`,
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-user-table/index/*`,
+        ],
+        actions: ['dynamodb:GetItem', 'dynamodb:DeleteItem', 'dynamodb:Query', 'dynamodb:PutItem'],
+        effect: Effect.ALLOW,
+      }),
+      new PolicyStatement({
+        resources: [
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-organization-user-table`,
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-organization-user-table/index/*`,
+        ],
+        actions: ['dynamodb:Query'],
+        effect: Effect.ALLOW,
+      }),
+      new PolicyStatement({
+        resources: [
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-unique-reference-table`,
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-unique-reference-table/index/*`,
+        ],
+        actions: ['dynamodb:DeleteItem', 'dynamodb:PutItem'],
+        effect: Effect.ALLOW,
+      }),
+    ]);
     // /easy-genomics/user/delete-user-request
     this.iam.addPolicyStatements('/easy-genomics/user/delete-user-request', [
       new PolicyStatement({

--- a/packages/shared-lib/src/app/schema/easy-genomics/user.ts
+++ b/packages/shared-lib/src/app/schema/easy-genomics/user.ts
@@ -21,6 +21,7 @@ export const UserSchema = z
     FirstName: z.string().optional(),
     LastName: z.string().optional(),
     Status: z.enum(['Active', 'Inactive', 'Invited']),
+    DefaultOrganization: z.string().optional(),
     OrganizationAccess: OrganizationAccessSchema.optional(),
     CreatedAt: z.string().optional(),
     CreatedBy: z.string().optional(),
@@ -35,8 +36,10 @@ export const CreateUserSchema = z
     PreferredName: z.string().optional(),
     FirstName: z.string().optional(),
     LastName: z.string().optional(),
+    DefaultOrganization: z.string().optional(),
   })
   .strict();
+export type CreateUser = z.infer<typeof CreateUserSchema>;
 
 export const UpdateUserSchema = z
   .object({
@@ -45,3 +48,11 @@ export const UpdateUserSchema = z
     LastName: z.string().optional(),
   })
   .strict();
+export type UpdateUser = z.infer<typeof UpdateUserSchema>;
+
+export const UpdateUserDefaultOrganizationSchema = z
+  .object({
+    DefaultOrganization: z.string().optional(),
+  })
+  .strict();
+export type UpdateUserDefaultOrganization = z.infer<typeof UpdateUserDefaultOrganizationSchema>;

--- a/packages/shared-lib/src/app/types/easy-genomics/sample-data.ts
+++ b/packages/shared-lib/src/app/types/easy-genomics/sample-data.ts
@@ -36,6 +36,7 @@ export const orgAdminUser: User = {
   FirstName: 'Org',
   LastName: 'Admin',
   Status: 'Active',
+  DefaultOrganization: organizationId,
   OrganizationAccess: {
     [organizationId]: {
       Status: 'Active',
@@ -61,6 +62,7 @@ export const labManagerUser: User = {
   FirstName: 'Lab',
   LastName: 'Manager',
   Status: 'Active',
+  DefaultOrganization: organizationId,
   OrganizationAccess: {
     [organizationId]: {
       Status: 'Active',
@@ -102,6 +104,7 @@ export const labTechnicianUser: User = {
   FirstName: 'Lab',
   LastName: 'Technician',
   Status: 'Active',
+  DefaultOrganization: organizationId,
   OrganizationAccess: {
     [organizationId]: {
       Status: 'Active',

--- a/packages/shared-lib/src/app/types/easy-genomics/user.d.ts
+++ b/packages/shared-lib/src/app/types/easy-genomics/user.d.ts
@@ -15,6 +15,7 @@
  *   FirstName?: <string>,
  *   LastName?: <string>,
  *   Status: 'Active' | 'Inactive' | 'Invited',
+ *   DefaultOrganization?: <string>, // User chosen Default Organization
  *   OrganizationAccess?: <OrganizationAccess>,
  *   CreatedAt?: <string>,
  *   CreatedBy?: <string>,
@@ -31,6 +32,7 @@ export interface User extends BaseAttributes {
   FirstName?: string;
   LastName?: string;
   Status: UserStatus;
+  DefaultOrganization?: string; // User chosen Default Organization
   OrganizationAccess?: OrganizationAccess;
 }
 

--- a/projenrc/apache-license.ts
+++ b/projenrc/apache-license.ts
@@ -1,7 +1,7 @@
-import { Project, LicenseOptions, License, IResolver } from 'projen';
-import { TypeScriptProject } from 'projen/lib/typescript';
-import { AwsCdkTypeScriptApp } from 'projen/lib/awscdk';
 import * as fs from 'fs';
+import { Project, LicenseOptions, License } from 'projen';
+import { AwsCdkTypeScriptApp } from 'projen/lib/awscdk';
+import { TypeScriptProject } from 'projen/lib/typescript';
 
 /**
  * Apply the Apache 2.0 license with the correct copyright date and name
@@ -31,7 +31,7 @@ export class ApacheLicense extends License {
 
     this.apacheText = text;
   }
-  synthesizeContent(_: IResolver) {
+  synthesizeContent() {
     return this.apacheText;
   }
 }

--- a/projenrc/easy-genomics-project-setup.ts
+++ b/projenrc/easy-genomics-project-setup.ts
@@ -32,7 +32,7 @@ export function setupProjectFolders(project: Project) {
 function createProjectFolders(project: Project, projectFolder?: ProjectFolders.Structure[], folderPath: string = '') {
   const folder = projectFolder || [];
 
-  folder.map((s: ProjectFolders.Structure) => {
+  folder.forEach((s: ProjectFolders.Structure) => {
     if (s.name === 'README.md' && s.type === 'file') {
       createFolderReadMe(project, `${folderPath}/${s.name}`, s.content);
     } else {

--- a/projenrc/project-folders-structure.ts
+++ b/projenrc/project-folders-structure.ts
@@ -1,5 +1,6 @@
 import Structure = ProjectFolders.Structure;
 
+// eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace ProjectFolders {
   export interface Structure {
     name: string;


### PR DESCRIPTION
## Title*
Add support for a User to set their `DefaultOrganization` to allow for more consistency when logging into the platform when they have multiple Organization access.

## Type of Change*
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
This PR adds the HTTP PUT `/easy-genomics/user/update-user-default-organization-request/{UserId}` API to allow the current User to update their `DefaultOrganization` property in the DynamoDB `user` table with the JSON payload:

```
{
    "DefaultOrganization": "<Organization ID the User already has access to>"
}
```

The `DefaultOrganization` is returned in the JWT upon succestsful authentication against Cognito, so this is available for the FE to detect the User's chosen `DefaultOrganization` for their session (if they have not logged in / switched to an Organization before).

The logic in the `platform-user-service` has also been enhanced to also set, update, remove the `DefaultOrganization` upon user invitation when:
 - a new User is invited to an Organization (defaults to the Organization being invited to).
 - an existing User is invited to another Organization (if DefaultOrganization is not set, then defaults to the other Organization being invited to)
 - an existing User is removed from an Organization (defaults to the next available Organization the User has access to)

## Testing*
See associated JIRA ticket for testing instructions.

## Impact
None.

## Additional Information
The FE implementation will still need to:
 - display the current Organization Name in the FE so the current User is aware of which Organization they are currently accessing
 - call the HTTP PUT `/easy-genomics/user/update-user-default-organization-request/{UserId}` API to allow the current User to change their Default Organization if they wish to.
 
**NOTE:**
- If the `/easy-genomics/user/update-user-default-organization-request/{UserId}` is called to change the `DefaultOrganization` with the same value that is already existing will result in an InvalidRequest error.
- This API is not intended for use with the data-seeded test accounts (as their data seeded DynamoDB User Id does not match the generate Cognito User Id).

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.