### PR TITLE
fix(EG-909): generate correct paths for Seqera S3 downloads

### DIFF
--- a/packages/front-end/src/app/components/EGFileExplorer.vue
+++ b/packages/front-end/src/app/components/EGFileExplorer.vue
@@ -4,8 +4,8 @@
   import { useRunStore } from '@FE/stores';
   import { format } from 'date-fns';
   import {
-    S3Response,
     S3Object,
+    S3Response,
   } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/file/request-list-bucket-objects';
 
   interface MapType {
@@ -158,8 +158,10 @@
               ? handleS3Download(
                   props.labId,
                   row.name,
-                  useRunStore().seqeraRuns[props.labId][props.seqeraRunId].workDir.replace(/\/work$/, ''),
-                  row.size,
+                  getSeqeraS3downloadPath(
+                    useRunStore().seqeraRuns[props.labId][props.seqeraRunId].workDir,
+                    fsPath.value,
+                  ),
                 )
               : downloadFolder(),
         },
@@ -167,6 +169,33 @@
     ];
     return items;
   };
+
+  /**
+   * Get the S3 download path from a Seqera
+   * @param workDir
+   * @param fsPath
+   */
+  function getSeqeraS3downloadPath(workDir, fsPath) {
+    const parts = workDir.split('/');
+    parts.splice(-2); // Remove last two segments
+    return parts.join('/') + fsPath;
+  }
+
+  /**
+   * Get the filesystem path based on the breadcrumb structure
+   * @returns {string} file path
+   */
+  const fsPath = computed(() => {
+    if (!breadcrumbs.value?.length) return '/';
+
+    // Map each breadcrumb name and join with forward slashes
+    // Skip "All Files" since it's the root level display name
+    const pathSegments = breadcrumbs.value.map((crumb) => crumb.name).filter((name) => name !== 'All Files');
+
+    // If there are no segments after filtering (only "All Files" existed),
+    // return root slash, otherwise join segments with slashes
+    return pathSegments.length ? `/${pathSegments.join('/')}` : '/';
+  });
 
   // Watchers to ensure data reactivity
   watch(currentPath, () => {});


### PR DESCRIPTION
## Title*
Fixes Seqera S3 file downloads in nested folders.

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
S3 directory structure was not being computed correctly at time of download, meaning the download path would always point back to the root folder. This also meant files inside nested directories could not be downloaded.

## Testing*
Manually tested successfully downloading files several levels deep in the folder structure, including duplicate named files.

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.