### PR TITLE
fix(EG-889): fix LabRun File Manager downloads

### DIFF
--- a/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
@@ -1100,12 +1100,12 @@ export class EasyGenomicsNestedStack extends NestedStack {
       }),
       new PolicyStatement({
         resources: ['arn:aws:s3:::*'],
-        actions: ['s3:GetBucketLocation'],
+        actions: ['s3:GetBucketLocation', 's3:ListBucket'],
         effect: Effect.ALLOW,
       }),
       new PolicyStatement({
         resources: ['arn:aws:s3:::*/*'],
-        actions: ['s3:GetObject', 's3:ListBucket'], // Required to generate pre-signed S3 Urls for downloading with GetObject request
+        actions: ['s3:GetObject'], // Required to generate pre-signed S3 Urls for downloading with GetObject request
         effect: Effect.ALLOW,
       }),
     ]);

--- a/packages/front-end/src/app/stores/lab-runs.ts
+++ b/packages/front-end/src/app/stores/lab-runs.ts
@@ -22,11 +22,6 @@ const useLabRunsStore = defineStore('labRunsStore', {
       (labId: string): LaboratoryRun[] =>
         state.labRunIdsByLab[labId]?.map((labRunId) => state.labRuns[labRunId]) || [],
 
-    labRunById:
-      (state: LabRunsStoreState) =>
-      (labRunId: string): LaboratoryRun | null =>
-        Object.values(state.labRuns).find((labRun) => labRun.RunId === labRunId) ?? null,
-
     labRunByExternalId:
       (state: LabRunsStoreState) =>
       (externalId: string): LaboratoryRun | null =>

--- a/packages/front-end/src/app/stores/lab-runs.ts
+++ b/packages/front-end/src/app/stores/lab-runs.ts
@@ -22,6 +22,11 @@ const useLabRunsStore = defineStore('labRunsStore', {
       (labId: string): LaboratoryRun[] =>
         state.labRunIdsByLab[labId]?.map((labRunId) => state.labRuns[labRunId]) || [],
 
+    labRunById:
+      (state: LabRunsStoreState) =>
+      (labRunId: string): LaboratoryRun | null =>
+        Object.values(state.labRuns).find((labRun) => labRun.RunId === labRunId) ?? null,
+
     labRunByExternalId:
       (state: LabRunsStoreState) =>
       (externalId: string): LaboratoryRun | null =>


### PR DESCRIPTION
## Title*
Fix LabRun File Manager downloads

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [x] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
There were two main errors causing errors with LaboratoryRun file downloads.
1. The IAM permissions for listing s3 buckets was incorrect
   - This required a minor correction

2. The EGFileExplorer (aka File Manager) implementation was still referencing the Seqera List Runs API store and `workDir` to generate the S3 Path for file downloads.
   - The File Manager implementation was simplified to use the LaboratoryRun's `InputS3Url` to obtain the S3Bucket and S3Prefix information to then generate the S3ObjectPath for the presigned S3 file download request.
   - With the `InputS3Url` information it also allows the File Manager to immediately display the S3 contents within the LaboratoryRun's `transactionId` S3 path.

## Testing*
See associated JIRA ticket for testing instructions.

## Impact
None.

## Additional Information
None.

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.