### PR TITLE
feat(EG-932): lab name in header

### DIFF
--- a/packages/front-end/src/app/components/EGHeader.vue
+++ b/packages/front-end/src/app/components/EGHeader.vue
@@ -210,12 +210,16 @@
 
                   <button
                     v-if="!userStore.isSuperuser && multipleOrgs"
-                    class="h-6 w-6 shrink-0 rounded-full border bg-white"
+                    class="ml-2 h-6 w-6 shrink-0 rounded-full border bg-white"
                     :class="defaultOrgButtonDynamicClasses(org.OrganizationId)"
                     :disabled="uiStore.isRequestPending('updateDefaultOrg')"
                     @click="async ($event) => await handleStarClick($event, org.OrganizationId)"
                   />
                 </div>
+              </div>
+
+              <div class="text-primary bg-primary-muted my-2 w-full rounded p-2 text-left text-xs">
+                Select the organisation that you would like to make your default organisation.
               </div>
             </template>
           </UDropdown>

--- a/packages/front-end/src/app/components/EGHeader.vue
+++ b/packages/front-end/src/app/components/EGHeader.vue
@@ -15,9 +15,11 @@
   const userStore = useUserStore();
   const orgsStore = useOrgsStore();
   const uiStore = useUiStore();
+  const labsStore = useLabsStore();
 
   const { signOutAndRedirect } = useAuth();
   const $router = useRouter();
+  const $route = useRoute();
   const labsPath = '/labs';
   const orgsPath = '/orgs';
 
@@ -115,6 +117,11 @@
       orgId === userStore.currentUserDetails.defaultOrgId && uiStore.isRequestPending('updateDefaultOrg'),
     'bg-background-grey': uiStore.isRequestPending('updateDefaultOrg'),
   });
+
+  const currentLabName = computed<string | null>(() => {
+    const currentLabId = $route.params.labId as string;
+    return labsStore.labs[currentLabId]?.Name ?? null;
+  });
 </script>
 
 <template>
@@ -123,8 +130,13 @@
       <template v-if="props.isAuthed">
         <img class="mr-2 min-w-[140px]" src="@/assets/images/easy-genomics-logo.svg" alt="EasyGenomics logo" />
 
-        <div class="text-muted text-lg" v-if="!!orgsStore.orgs[userStore.currentOrgId]?.Name">
-          {{ orgsStore.orgs[userStore.currentOrgId].Name }}
+        <div class="flex flex-col items-center">
+          <div class="text-body text-lg" v-if="!!orgsStore.orgs[userStore.currentOrgId]?.Name">
+            {{ orgsStore.orgs[userStore.currentOrgId].Name }}
+          </div>
+          <div class="text-muted" v-if="currentLabName">
+            {{ currentLabName }}
+          </div>
         </div>
 
         <div class="flex items-center gap-4">

--- a/packages/front-end/src/app/components/EGHeader.vue
+++ b/packages/front-end/src/app/components/EGHeader.vue
@@ -186,7 +186,7 @@
 
                 <button
                   v-if="!userStore.isSuperuser && multipleOrgs"
-                  class="h-6 w-6 rounded-full border bg-white"
+                  class="h-6 w-6 shrink-0 rounded-full border bg-white"
                   :class="defaultOrgButtonDynamicClasses(userStore.currentOrgId)"
                   :disabled="uiStore.isRequestPending('updateDefaultOrg')"
                   @click="async ($event) => await handleStarClick($event, userStore.currentOrgId)"
@@ -206,11 +206,11 @@
                   @click="() => selectSwitchToOrg(org.OrganizationId)"
                   class="flex w-full items-center justify-between py-3 text-left"
                 >
-                  <div class="font-medium">{{ org.Name }}</div>
+                  <div class="truncate-text font-medium">{{ org.Name }}</div>
 
                   <button
                     v-if="!userStore.isSuperuser && multipleOrgs"
-                    class="h-6 w-6 rounded-full border bg-white"
+                    class="h-6 w-6 shrink-0 rounded-full border bg-white"
                     :class="defaultOrgButtonDynamicClasses(org.OrganizationId)"
                     :disabled="uiStore.isRequestPending('updateDefaultOrg')"
                     @click="async ($event) => await handleStarClick($event, org.OrganizationId)"
@@ -257,5 +257,11 @@
 
   .border-6 {
     border-width: 6px;
+  }
+
+  .truncate-text {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 </style>


### PR DESCRIPTION
## Title*

Add the lab name to the header on pages that are specific to a lab. Also add a couple details I missed re: org switcher.

## Type of Change*
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Outside a specific lab: org name only

![image](https://github.com/user-attachments/assets/d9b87746-c6f6-4fc2-8f55-51b7f9c0da03)

Inside a lab-specific page: org name and lab name

![image](https://github.com/user-attachments/assets/cd2d5c45-9332-4cde-8c74-75fdcb04c491)

Features that I missed before about the org switcher:

- Truncate orgs with long names
- Purple help text

![image](https://github.com/user-attachments/assets/7604ce6e-7aa1-4c38-bff3-a23006bb09f0)

## Testing*

Manually tested

## Impact

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.