### PR TITLE
fix(EG-954): remove org user not working for org admin

### DIFF
--- a/packages/back-end/src/app/services/easy-genomics/platform-user-service.ts
+++ b/packages/back-end/src/app/services/easy-genomics/platform-user-service.ts
@@ -242,7 +242,7 @@ export class PlatformUserService extends DynamoDBService {
             ExpressionAttributeNames: {
               '#UserId': 'UserId',
             },
-            Item: marshall(user),
+            Item: marshall(user, { removeUndefinedValues: true }),
           },
         },
         {

--- a/packages/front-end/src/app/components/EGHeader.vue
+++ b/packages/front-end/src/app/components/EGHeader.vue
@@ -146,7 +146,7 @@
             Labs
           </ULink>
           <ULink
-            v-if="userStore.canManageOrgs()"
+            v-if="userStore.canManageAnyOrgs()"
             :to="orgsPath"
             inactive-class="text-body"
             active-class="text-primary-dark bg-primary-muted"

--- a/packages/front-end/src/app/components/EGOrgView.vue
+++ b/packages/front-end/src/app/components/EGOrgView.vue
@@ -13,6 +13,7 @@
   const props = defineProps<{
     orgId: string;
     superuser?: boolean;
+    orgAdmin?: boolean;
   }>();
 
   const { $api } = useNuxtApp();
@@ -93,7 +94,7 @@
       ],
     ];
 
-    if (props.superuser) {
+    if (props.superuser || props.orgAdmin) {
       items.push([
         {
           label: 'Remove From Org',

--- a/packages/front-end/src/app/components/EGOrgView.vue
+++ b/packages/front-end/src/app/components/EGOrgView.vue
@@ -28,9 +28,9 @@
   const isLoading = computed<boolean>(() => useUiStore().anyRequestPending(['fetchOrgData', 'editOrg']));
 
   // Dynamic remove user dialog values
-  const isOpen = ref(false);
-  const primaryMessage = ref('');
-  const selectedUserId = ref('');
+  const isRemoveUserModalOpen = ref(false);
+  const removeUserModalPrimaryMessage = ref('');
+  const userToRemoveId = ref('');
   const isRemovingUser = ref(false);
 
   // Table-related refs and computed props
@@ -99,9 +99,9 @@
           label: 'Remove From Org',
           class: 'text-alert-danger-dark',
           click: () => {
-            selectedUserId.value = user.UserId;
-            primaryMessage.value = `Are you sure you want to remove ${user.displayName} from ${org.value.Name}?`;
-            isOpen.value = true;
+            userToRemoveId.value = user.UserId;
+            removeUserModalPrimaryMessage.value = `Are you sure you want to remove ${user.displayName} from ${org.value.Name}?`;
+            isRemoveUserModalOpen.value = true;
           },
         },
       ]);
@@ -135,18 +135,18 @@
   });
 
   async function handleRemoveOrgUser() {
-    isOpen.value = false;
+    isRemoveUserModalOpen.value = false;
     isRemovingUser.value = true;
 
-    const userToRemove = orgUsersDetailsData.value.find((user) => user.UserId === selectedUserId.value);
+    const userToRemove = orgUsersDetailsData.value.find((user) => user.UserId === userToRemoveId.value);
     const displayName = userToRemove?.displayName;
 
     try {
-      if (!selectedUserId.value) {
-        throw new Error('No selectedUserId');
+      if (!userToRemoveId.value) {
+        throw new Error('No userToRemoveId');
       }
 
-      const res: DeletedResponse = await $api.orgs.removeUser(props.orgId, selectedUserId.value);
+      const res: DeletedResponse = await $api.orgs.removeUser(props.orgId, userToRemoveId.value);
 
       if (res?.Status === 'Success') {
         useToastStore().success(`${displayName} has been removed from ${org.value.Name}`);
@@ -158,8 +158,8 @@
       useToastStore().error(`Failed to remove ${displayName} from  ${org.value.Name}`);
       throw error;
     } finally {
-      selectedUserId.value = '';
-      isOpen.value = false;
+      userToRemoveId.value = '';
+      isRemoveUserModalOpen.value = false;
       isRemovingUser.value = false;
     }
   }
@@ -352,18 +352,8 @@
           cancelLabel="Cancel"
           :cancelVariant="ButtonVariantEnum.enum.secondary"
           @action-triggered="handleRemoveOrgUser"
-          :primaryMessage="primaryMessage"
-          v-model="isOpen"
-        />
-
-        <EGDialog
-          actionLabel="Remove User"
-          :actionVariant="ButtonVariantEnum.enum.destructive"
-          cancelLabel="Cancel"
-          :cancelVariant="ButtonVariantEnum.enum.secondary"
-          @action-triggered="handleRemoveOrgUser"
-          :primaryMessage="primaryMessage"
-          v-model="isOpen"
+          :primaryMessage="removeUserModalPrimaryMessage"
+          v-model="isRemoveUserModalOpen"
         />
 
         <EGTable

--- a/packages/front-end/src/app/pages/orgs/[orgId]/edit-user/[userId].vue
+++ b/packages/front-end/src/app/pages/orgs/[orgId]/edit-user/[userId].vue
@@ -2,13 +2,16 @@
   const $router = useRouter();
   const $route = useRoute();
 
-  if (!useUserStore().canManageOrgs()) {
+  const orgId = $route.params.orgId as string;
+  const userId = $route.params.userId as string;
+
+  if (!useUserStore().canManageOrg(orgId)) {
     $router.push({ path: '/' });
   }
 </script>
 
 <template>
-  <EGUserAccess :org-id="$route.params.orgId" :user-id="$route.params.userId" />
+  <EGUserAccess :org-id="orgId" :user-id="userId" />
 </template>
 
 <style scoped></style>

--- a/packages/front-end/src/app/pages/orgs/[orgId]/index.vue
+++ b/packages/front-end/src/app/pages/orgs/[orgId]/index.vue
@@ -2,13 +2,15 @@
   const $router = useRouter();
   const $route = useRoute();
 
-  if (!useUserStore().canManageOrgs()) {
+  const userStore = useUserStore();
+
+  const orgId = $route.params.orgId as string;
+
+  if (!userStore.canManageOrg(orgId)) {
     $router.push({ path: '/' });
   }
-
-  const orgId = $route.params.orgId;
 </script>
 
 <template>
-  <EGOrgView :org-id="orgId" />
+  <EGOrgView :org-id="orgId" :org-admin="userStore.isOrgAdminForOrg(orgId)" />
 </template>

--- a/packages/front-end/src/app/pages/orgs/index.vue
+++ b/packages/front-end/src/app/pages/orgs/index.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
   const $router = useRouter();
 
-  if (!useUserStore().canManageOrgs()) {
+  if (!useUserStore().canManageAnyOrgs()) {
     $router.push({ path: '/' });
   }
 </script>


### PR DESCRIPTION
## Title*

Fix org admin permissions not allowing some org-level user management functions

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Org admins couldn't remove users from orgs previously, plus weren't able to view org pages in some circumstances. These are fixed now.

## Testing*

e2e tests full pass ✅ 

Demonstration:

https://github.com/user-attachments/assets/9daca1a7-64a4-44fd-abed-fb5af721aa62


## Impact

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.