### PR TITLE
chore: suppress nag for required wildcard permission for access token

### DIFF
--- a/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
@@ -2,6 +2,7 @@ import { Duration, NestedStack } from 'aws-cdk-lib';
 import { AttributeType, Table } from 'aws-cdk-lib/aws-dynamodb';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
+import { NagSuppressions } from 'cdk-nag';
 import { Construct } from 'constructs';
 import { baseLSIAttributes, DynamoConstruct } from '../constructs/dynamodb-construct';
 import { IamConstruct, IamConstructProps } from '../constructs/iam-construct';
@@ -209,6 +210,21 @@ export class EasyGenomicsNestedStack extends NestedStack {
       awsHostedZoneId: this.props.awsHostedZoneId,
       emailSender: `no.reply@${this.props.appDomainName}`,
     });
+
+    // Nag Suppressions
+    NagSuppressions.addResourceSuppressions(
+      this,
+      [
+        {
+          id: 'AwsSolutions-IAM5',
+          reason: 'Need access to all organisation and laboratory nf token parameters',
+          appliesTo: [
+            `Resource::arn:aws:ssm:${this.props.env.region!}:${this.props.env.account!}:parameter/easy-genomics/organization/*/laboratory/*/nf-access-token`,
+          ], // optional
+        },
+      ],
+      true,
+    );
   }
 
   // Easy Genomics specific IAM policies

--- a/packages/back-end/src/infra/stacks/nf-tower-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/nf-tower-nested-stack.ts
@@ -1,5 +1,6 @@
 import { NestedStack } from 'aws-cdk-lib';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { NagSuppressions } from 'cdk-nag';
 import { Construct } from 'constructs';
 import { IamConstruct, IamConstructProps } from '../constructs/iam-construct';
 import { LambdaConstruct } from '../constructs/lambda-construct';
@@ -37,6 +38,20 @@ export class NFTowerNestedStack extends NestedStack {
         SEQERA_API_BASE_URL: this.props.seqeraApiBaseUrl,
       },
     });
+
+    NagSuppressions.addResourceSuppressions(
+      this,
+      [
+        {
+          id: 'AwsSolutions-IAM5',
+          reason: 'Need access to all organisation and laboratory nf token parameters',
+          appliesTo: [
+            `Resource::arn:aws:ssm:${this.props.env.region!}:${this.props.env.account!}:parameter/easy-genomics/organization/*/laboratory/*/nf-access-token`,
+          ], // optional
+        },
+      ],
+      true,
+    );
   }
 
   // NF-Tower specific IAM policies


### PR DESCRIPTION
## Title*
Suppress cdk nag for NF Tower Access Token wildcard permissions

## Type of Change*
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [x] Security patch
- [ ] UI/UX improvement

## Description
These wildcard permissions are required so that our lambdas can read the appropriate access token for each laboratory

## Testing*
NA

## Impact
Simply suppresses the nag, no change in functionality

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [ ] Code has been commented in particularly hard-to-understand areas.