### PR TITLE
fix(EG-974): replace non-specific error message on expired invite accept with specific error

### DIFF
--- a/packages/front-end/src/app/pages/accept-invitation.vue
+++ b/packages/front-end/src/app/pages/accept-invitation.vue
@@ -110,7 +110,7 @@
       await signIn(email, password);
       handleSuccess();
     } catch (error: any) {
-      if (error.message === `Request error: ${ERROR_MESSAGES.invitationAlreadyActivated}`) {
+      if (error.message === `Request error: Unauthorized access: ${ERROR_MESSAGES.invitationAlreadyActivated}`) {
         await router.push({ path: `/signin`, query: { email: state.value.email } });
         useToastStore().error(VALIDATION_MESSAGES.inviteAcceptedOrExpired);
       } else {


### PR DESCRIPTION
## Title*

On sign up from expired/already accepted invite link; replace non-specific error message with specific error message

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Replaces "Something went wrong" message with "Your invite link has been accepted or expired".

![image](https://github.com/user-attachments/assets/24093b7c-25c8-4bec-acc1-9c9a1ee3c9e2)

## Testing*

Manually tested, e2e tests do not cover this

## Impact

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.