### PR TITLE
fix(EG-976): grey default style for status pill

### DIFF
--- a/packages/front-end/src/app/components/EGStatusChip.vue
+++ b/packages/front-end/src/app/components/EGStatusChip.vue
@@ -68,7 +68,7 @@
   const getConfig = computed(() => {
     return {
       ...baseConfig,
-      variant: styleMap[props.status] || 'background-dark-grey text-body',
+      variant: styleMap[props.status] || { solid: 'bg-background-dark-grey text-body' },
     };
   });
 </script>


### PR DESCRIPTION
## Title*

Set the default style for run status pills to the basic grey background

## Type of Change*
- [X] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Previously, unexpected values for the status pill rendered no pill style. There was code to have a basic grey background as default but it wasn't working. This PR fixes it.

![image](https://github.com/user-attachments/assets/abb701ac-ba9c-4a54-b482-33b496cff020)

## Testing*

Visually inspected ✅ 

## Impact

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.