### PR TITLE
feat(EG-708): skip file upload

### DIFF
--- a/packages/front-end/src/app/components/EGRunPipelineFormEditParameters.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineFormEditParameters.vue
@@ -19,12 +19,20 @@
 
   const wipSeqeraRun = computed<WipSeqeraRunData | undefined>(() => runStore.wipSeqeraRuns[seqeraRunTempId]);
 
+  function generatedParamFields(): { input?: string; outdir?: string } {
+    const r: any = {};
+    if (!!wipSeqeraRun.value?.sampleSheetS3Url) r.input = wipSeqeraRun.value?.sampleSheetS3Url;
+    if (!!wipSeqeraRun.value?.s3Bucket && !!wipSeqeraRun.value?.s3Path)
+      r.outdir = `s3://${wipSeqeraRun.value?.s3Bucket}/${wipSeqeraRun.value?.s3Path}/results`;
+
+    return r;
+  }
+
   const localProps = reactive({
     schema: props.schema,
     params: {
       ...props.params,
-      input: wipSeqeraRun.value?.sampleSheetS3Url,
-      outdir: `s3://${wipSeqeraRun.value?.s3Bucket}/${wipSeqeraRun.value?.s3Path}/results`,
+      ...generatedParamFields(),
     },
   });
 


### PR DESCRIPTION
## Title*

Allow bypassing file upload 

## Type of Change*
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Changes include:

- File upload "Next Step" button changed to "Save & Continue" if files uploaded and "Skip" if not. Enabled in the Skip case, where was previously disabled.
- Generated `input` and `outdir` parameters now don't generate if S3 bucket/path info (obtained from successful file upload) aren't present

## Testing*

I've tested both pipelines and workflows with and without uploading files and it behaves as expected. 

## Impact

As the app could previously make the assumption that, post file upload step, there would be files uploaded, and this PR invalidates that assumption, there may be unanticipated effects, such as errors introduced in other parts of the run pipeline/workflow flow that relied on information from the file upload. We'll need to keep an eye out for these.

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.