### PR TITLE
fix(EG-982): view lab run

### DIFF
--- a/packages/front-end/src/app/composables/useFileDownload.ts
+++ b/packages/front-end/src/app/composables/useFileDownload.ts
@@ -72,7 +72,6 @@ export default function useFileDownload() {
   return {
     handleS3Download,
     downloadFolder,
-    getSignedCsvContent,
     isSupportedFileType,
   };
 }


### PR DESCRIPTION
## Title*
Remove `getSignedCsvContent` export from recently deleted function to prevent app from crashing when viewing a lab run.

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Testing*
Manually tested viewing a submitted run.

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.