### PR TITLE
feat(EG-711): persistent file uploads

### DIFF
--- a/packages/front-end/src/app/components/EGRunFormUploadData.vue
+++ b/packages/front-end/src/app/components/EGRunFormUploadData.vue
@@ -18,7 +18,7 @@
 
   type UploadStatus = 'idle' | 'uploading' | 'success' | 'failed';
 
-  type FilePair = {
+  export type FilePair = {
     sampleId: string; // Common start of the file name for each of the file pair e.g. GOL2051A67473_S133_L002 when uploading the pair of files GOL2051A67473_S133_L002_R1_001.fastq.gz and GOL2051A67473_S133_L002_R2_001.fastq.gz
     r1File?: FileDetails;
     r2File?: FileDetails;
@@ -57,7 +57,15 @@
 
   const chooseFilesButton = ref<HTMLButtonElement | null>(null);
 
-  const filePairs = ref<FilePair[]>([]);
+  const filePairs = computed<FilePair[]>(() => {
+    // initialize files if not present
+    if (props.wipRun.files === undefined) {
+      props.wipRun.files = [];
+    }
+
+    return props.wipRun.files;
+  });
+
   const files = computed<FileDetails[]>(() => {
     const files = [];
     for (const filePair of filePairs.value) {
@@ -537,7 +545,7 @@
 
   const removeFile = (file: { sampleId: string; fileName: string }) => {
     // Remove the filePair containing the file
-    filePairs.value = filePairs.value.filter((pair) => {
+    props.wipRun.files = filePairs.value.filter((pair) => {
       if (pair.r1File?.name === file.fileName || pair.r2File?.name === file.fileName) {
         return false;
       }

--- a/packages/front-end/src/app/components/EGRunFormUploadData.vue
+++ b/packages/front-end/src/app/components/EGRunFormUploadData.vue
@@ -47,12 +47,10 @@
 
   const emit = defineEmits(['next-step', 'previous-step', 'step-validated']);
   const props = defineProps<{
-    sampleSheetS3Url: string;
     labId: string;
     labName: string;
     pipelineOrWorkflowName: string;
-    runName: string;
-    transactionId: string;
+    wipRun: WipSeqeraRunData & WipOmicsRunData; // will be one of these types, and officially can have any common fields
     wipRunUpdateFunction: Function;
     wipRunTempId: string;
   }>();
@@ -330,7 +328,7 @@
   async function getSampleSheetCsv(uploadedFilePairs: UploadedFilePairInfo[]): Promise<SampleSheetResponse> {
     const request: SampleSheetRequest = {
       LaboratoryId: props.labId,
-      TransactionId: props.transactionId || '',
+      TransactionId: props.wipRun.transactionId || '',
       UploadedFilePairs: uploadedFilePairs,
     };
     const response = await $api.uploads.getSampleSheetCsv(request);
@@ -340,7 +338,7 @@
   async function getUploadFilesManifest(files: FileDetails[]): Promise<FileUploadManifest> {
     const request: FileUploadRequest = {
       LaboratoryId: props.labId,
-      TransactionId: props.transactionId || '',
+      TransactionId: props.wipRun.transactionId || '',
       Files: files.map((file) => ({ Name: file.name, Size: file.size })),
     };
 
@@ -691,12 +689,12 @@
     </div>
 
     <EGS3SampleSheetBar
-      v-if="props.sampleSheetS3Url"
-      :url="props.sampleSheetS3Url"
+      v-if="props.wipRun.sampleSheetS3Url"
+      :url="props.wipRun.sampleSheetS3Url"
       :lab-id="props.labId"
       :lab-name="props.labName"
       :pipeline-or-workflow-name="props.pipelineOrWorkflowName"
-      :run-name="props.runName"
+      :run-name="props.wipRun.runName"
     />
 
     <div class="flex justify-end pt-4">
@@ -705,7 +703,14 @@
         variant="secondary"
         class="mr-2"
         label="Download sample sheet"
-        @click="downloadSampleSheet(props.labId, props.sampleSheetS3Url, props.pipelineOrWorkflowName, props.runName)"
+        @click="
+          downloadSampleSheet(
+            props.labId,
+            props.wipRun.sampleSheetS3Url,
+            props.pipelineOrWorkflowName,
+            props.wipRun.runName,
+          )
+        "
       />
       <EGButton
         @click="startUploadProcess"

--- a/packages/front-end/src/app/components/EGRunFormUploadData.vue
+++ b/packages/front-end/src/app/components/EGRunFormUploadData.vue
@@ -142,6 +142,7 @@
   // Add a computed property to check if all file pairs are complete and all files are successfully uploaded
   const areAllFilesUploaded = computed(() => filesNotUploaded.value.length === 0);
 
+  // reset files error states
   function clearErrorsFromFiles(files: FileDetails[]) {
     files.forEach((file) => {
       file.error = undefined;
@@ -149,6 +150,7 @@
     });
   }
 
+  // set progress to 0 - this makes the computed uploadStatus get set to 'uploading'
   function initializeProgressForFiles(files: FileDetails[]) {
     files.forEach((file) => {
       file.progress = 0;
@@ -278,9 +280,7 @@
   }
 
   async function startUploadProcess() {
-    // reset files error states
     clearErrorsFromFiles(filesNotUploaded.value);
-    // set progress to 0 - this makes the computed uploadStatus get set to 'uploading'
     initializeProgressForFiles(filesNotUploaded.value);
 
     const uploadManifest = await getUploadFilesManifest(filesNotUploaded.value);
@@ -534,9 +534,7 @@
       throw new Error(`no fileToRetry found with name '${fileSelector.fileName}'`);
     }
 
-    // reset files error states
     clearErrorsFromFiles([fileToRetry]);
-    // set progress to 0 - this makes the computed uploadStatus get set to 'uploading'
     initializeProgressForFiles([fileToRetry]);
 
     try {

--- a/packages/front-end/src/app/components/EGRunFormUploadData.vue
+++ b/packages/front-end/src/app/components/EGRunFormUploadData.vue
@@ -281,10 +281,15 @@
     // get sample sheet info
     const sampleSheetResponse: SampleSheetResponse = await getSampleSheetCsv(uploadedFilePairs);
     // save to wip run
+    const { S3Url, Bucket, Path } = sampleSheetResponse.SampleSheetInfo;
     props.wipRunUpdateFunction(props.wipRunTempId, {
-      sampleSheetS3Url: sampleSheetResponse.SampleSheetInfo.S3Url,
-      s3Bucket: sampleSheetResponse.SampleSheetInfo.Bucket,
-      s3Path: sampleSheetResponse.SampleSheetInfo.Path,
+      sampleSheetS3Url: S3Url,
+      s3Bucket: Bucket,
+      s3Path: Path,
+      params: {
+        input: S3Url,
+        outdir: `s3://${Bucket}/${Path}/results`,
+      },
     });
   }
 

--- a/packages/front-end/src/app/components/EGRunPipelineFormEditParameters.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineFormEditParameters.vue
@@ -6,22 +6,21 @@
   const props = defineProps<{
     schema: object;
     params: object;
-    pipelineId: string;
-    labId: string;
-    labName: string;
-    pipelineOrWorkflowName: string;
-    runName: string;
+    seqeraRunTempId: string;
   }>();
 
   const emit = defineEmits(['next-step', 'previous-step', 'step-validated']);
-  const $route = useRoute();
-
-  const seqeraRunTempId = $route.query.seqeraRunTempId as string;
-
   const activeSection = ref<string | null>(null);
   const runStore = useRunStore();
+  const labsStore = useLabsStore();
+  const seqeraPipelinesStore = useSeqeraPipelinesStore();
 
-  const wipSeqeraRun = computed<WipSeqeraRunData | undefined>(() => runStore.wipSeqeraRuns[seqeraRunTempId]);
+  const wipSeqeraRun = computed<WipSeqeraRunData | undefined>(() => runStore.wipSeqeraRuns[props.seqeraRunTempId]);
+
+  const labName = computed<string | null>(() => labsStore.labs[wipSeqeraRun.value?.laboratoryId || '']?.Name || null);
+  const pipelineName = computed<string | null>(
+    () => seqeraPipelinesStore.pipelines[wipSeqeraRun.value?.pipelineId || '']?.name || null,
+  );
 
   const localProps = reactive({
     schema: props.schema,
@@ -82,7 +81,7 @@
     () => localProps.params,
     (val) => {
       if (val) {
-        runStore.updateWipSeqeraRun(seqeraRunTempId, { params: val });
+        runStore.updateWipSeqeraRun(props.seqeraRunTempId, { params: val });
       }
     },
     { deep: true },
@@ -92,11 +91,11 @@
 <template>
   <EGS3SampleSheetBar
     v-if="wipSeqeraRun?.sampleSheetS3Url"
-    :url="wipSeqeraRun?.sampleSheetS3Url"
-    :lab-id="props.labId"
-    :lab-name="props.labName"
-    :pipeline-or-workflow-name="props.pipelineOrWorkflowName"
-    :run-name="props.runName"
+    :url="wipSeqeraRun.sampleSheetS3Url"
+    :lab-id="wipSeqeraRun.laboratoryId"
+    :lab-name="labName"
+    :pipeline-or-workflow-name="pipelineName"
+    :run-name="wipSeqeraRun.runName"
   />
 
   <div class="flex">

--- a/packages/front-end/src/app/components/EGRunPipelineFormEditParameters.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineFormEditParameters.vue
@@ -22,7 +22,6 @@
   const runStore = useRunStore();
 
   const wipSeqeraRun = computed<WipSeqeraRunData | undefined>(() => runStore.wipSeqeraRuns[seqeraRunTempId]);
-  const sampleSheetS3Url = wipSeqeraRun.value?.sampleSheetS3Url;
 
   function generatedParamFields(): { input?: string; outdir?: string } {
     const r: any = {};
@@ -104,7 +103,8 @@
 
 <template>
   <EGS3SampleSheetBar
-    :url="sampleSheetS3Url"
+    v-if="wipSeqeraRun?.sampleSheetS3Url"
+    :url="wipSeqeraRun?.sampleSheetS3Url"
     :lab-id="props.labId"
     :lab-name="props.labName"
     :pipeline-or-workflow-name="props.pipelineOrWorkflowName"

--- a/packages/front-end/src/app/components/EGRunPipelineFormEditParameters.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineFormEditParameters.vue
@@ -23,21 +23,9 @@
 
   const wipSeqeraRun = computed<WipSeqeraRunData | undefined>(() => runStore.wipSeqeraRuns[seqeraRunTempId]);
 
-  function generatedParamFields(): { input?: string; outdir?: string } {
-    const r: any = {};
-    if (!!wipSeqeraRun.value?.sampleSheetS3Url) r.input = wipSeqeraRun.value?.sampleSheetS3Url;
-    if (!!wipSeqeraRun.value?.s3Bucket && !!wipSeqeraRun.value?.s3Path)
-      r.outdir = `s3://${wipSeqeraRun.value?.s3Bucket}/${wipSeqeraRun.value?.s3Path}/results`;
-
-    return r;
-  }
-
   const localProps = reactive({
     schema: props.schema,
-    params: {
-      ...props.params,
-      ...generatedParamFields(),
-    },
+    params: props.params,
   });
 
   const schemaDefinitions = computed(() => props.schema.$defs || props.schema.definitions);

--- a/packages/front-end/src/app/components/EGRunPipelineStepper.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineStepper.vue
@@ -198,7 +198,7 @@
           <!-- Upload Data -->
           <template v-if="items[selectedIndex].key === 'upload'">
             <EGRunFormUploadData
-              :sample-sheet-s3-url="wipSeqeraRun.sampleSheetS3Url"
+              :sample-sheet-s3-url="wipSeqeraRun?.sampleSheetS3Url"
               :lab-id="labId"
               :lab-name="labName"
               :pipeline-or-workflow-name="pipeline.name"

--- a/packages/front-end/src/app/components/EGRunPipelineStepper.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineStepper.vue
@@ -213,13 +213,9 @@
           <!-- Edit Parameters -->
           <template v-if="items[selectedIndex].key === 'parameters'">
             <EGRunPipelineFormEditParameters
-              :lab-id="labId"
-              :lab-name="labName"
-              :pipeline-or-workflow-name="pipeline.name"
-              :run-name="wipSeqeraRun.runName"
               :params="params"
               :schema="schema"
-              :pipeline-id="pipelineId"
+              :seqera-run-temp-id="seqeraRunTempId"
               @next-step="() => nextStep('review')"
               @previous-step="previousStep"
             />

--- a/packages/front-end/src/app/components/EGRunPipelineStepper.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineStepper.vue
@@ -198,12 +198,10 @@
           <!-- Upload Data -->
           <template v-if="items[selectedIndex].key === 'upload'">
             <EGRunFormUploadData
-              :sample-sheet-s3-url="wipSeqeraRun?.sampleSheetS3Url"
               :lab-id="labId"
               :lab-name="labName"
               :pipeline-or-workflow-name="pipeline.name"
-              :run-name="wipSeqeraRun.runName"
-              :transaction-id="wipSeqeraRun.transactionId"
+              :wip-run="wipSeqeraRun"
               :wip-run-update-function="runStore.updateWipSeqeraRun"
               :wip-run-temp-id="seqeraRunTempId"
               @next-step="() => nextStep('parameters')"

--- a/packages/front-end/src/app/components/EGRunWorkflowFormEditParameters.vue
+++ b/packages/front-end/src/app/components/EGRunWorkflowFormEditParameters.vue
@@ -5,18 +5,21 @@
   const props = defineProps<{
     schema: object;
     params: object;
-
-    sampleSheetS3Url: string;
-    s3Bucket: string;
-    s3Path: string;
     omicsRunTempId: string;
   }>();
 
   const emit = defineEmits(['next-step', 'previous-step', 'step-validated']);
 
   const runStore = useRunStore();
+  const labsStore = useLabsStore();
+  const omicsWorklowsStore = useOmicsWorkflowsStore();
 
   const wipOmicsRun = computed<WipOmicsRunData | undefined>(() => runStore.wipOmicsRuns[props.omicsRunTempId]);
+
+  const labName = computed<string | null>(() => labsStore.labs[wipOmicsRun.value?.laboratoryId || '']?.Name || null);
+  const workflowName = computed<string | null>(
+    () => omicsWorklowsStore.workflows[wipOmicsRun.value?.workflowId || '']?.name || null,
+  );
 
   type SchemaItem = {
     name: string;

--- a/packages/front-end/src/app/components/EGRunWorkflowFormEditParameters.vue
+++ b/packages/front-end/src/app/components/EGRunWorkflowFormEditParameters.vue
@@ -44,23 +44,12 @@
     Object.keys(props.schema).map((fieldName) => [fieldName, '']),
   );
 
-  function generatedParamFields(): { input?: string; outdir?: string } {
-    const r: any = {};
-    if (!!wipOmicsRun.value?.sampleSheetS3Url) r.input = wipOmicsRun.value?.sampleSheetS3Url;
-    if (!!wipOmicsRun.value?.s3Bucket && !!wipOmicsRun.value?.s3Path)
-      r.outdir = `s3://${wipOmicsRun.value?.s3Bucket}/${wipOmicsRun.value?.s3Path}/results`;
-
-    return r;
-  }
-
   const localProps = reactive({
     schema: props.schema,
     params: {
       // initialize all fields with empty string as default
       ...paramDefaults,
-      // initialize input and output values with default values
-      ...generatedParamFields(),
-      // finally overwrite with any existing values
+      // overwrite with any existing values
       ...props.params,
     },
   });

--- a/packages/front-end/src/app/components/EGRunWorkflowFormEditParameters.vue
+++ b/packages/front-end/src/app/components/EGRunWorkflowFormEditParameters.vue
@@ -74,6 +74,15 @@
 </script>
 
 <template>
+  <EGS3SampleSheetBar
+    v-if="wipOmicsRun?.sampleSheetS3Url"
+    :url="wipOmicsRun.sampleSheetS3Url"
+    :lab-id="wipOmicsRun.laboratoryId"
+    :lab-name="labName"
+    :pipeline-or-workflow-name="workflowName"
+    :run-name="wipOmicsRun.runName"
+  />
+
   <div class="flex">
     <div class="mr-4 w-1/4">
       <EGCard>

--- a/packages/front-end/src/app/components/EGRunWorkflowStepper.vue
+++ b/packages/front-end/src/app/components/EGRunWorkflowStepper.vue
@@ -199,10 +199,8 @@
           <template v-if="items[selectedIndex].key === 'upload'">
             <EGRunFormUploadData
               :lab-id="labId"
-              :sample-sheet-s3-url="wipOmicsRun.sampleSheetS3Url"
               :pipeline-or-workflow-name="workflow.name"
-              :run-name="wipOmicsRun.runName"
-              :transaction-id="wipOmicsRun.transactionId"
+              :wip-run="wipOmicsRun"
               :wip-run-update-function="runStore.updateWipOmicsRun"
               :wip-run-temp-id="omicsRunTempId"
               @next-step="() => nextStep('parameters')"

--- a/packages/front-end/src/app/components/EGRunWorkflowStepper.vue
+++ b/packages/front-end/src/app/components/EGRunWorkflowStepper.vue
@@ -7,6 +7,7 @@
     schema: Record<string, WorkflowParameter>;
     params: object;
     workflowId: string;
+    labName: string;
   }>();
 
   const $route = useRoute();
@@ -199,6 +200,7 @@
           <template v-if="items[selectedIndex].key === 'upload'">
             <EGRunFormUploadData
               :lab-id="labId"
+              :lab-name="labName"
               :pipeline-or-workflow-name="workflow.name"
               :wip-run="wipOmicsRun"
               :wip-run-update-function="runStore.updateWipOmicsRun"
@@ -214,9 +216,6 @@
             <EGRunWorkflowFormEditParameters
               :params="params"
               :schema="schema"
-              :sample-sheet-s3-url="wipOmicsRun.sampleSheetS3Url"
-              :s3-bucket="wipOmicsRun.s3Bucket"
-              :s3-path="wipOmicsRun.s3Path"
               :omics-run-temp-id="omicsRunTempId"
               @next-step="() => nextStep('review')"
               @previous-step="previousStep"
@@ -230,10 +229,10 @@
               :params="wipOmicsRun?.params"
               :lab-id="labId"
               :omics-run-temp-id="omicsRunTempId"
-              :s3-bucket="wipOmicsRun.s3Bucket"
-              :s3-path="wipOmicsRun.s3Path"
-              :run-name="wipOmicsRun.runName"
-              :transaction-id="wipOmicsRun.transactionId"
+              :s3-bucket="wipOmicsRun?.s3Bucket"
+              :s3-path="wipOmicsRun?.s3Path"
+              :run-name="wipOmicsRun?.runName"
+              :transaction-id="wipOmicsRun?.transactionId"
               :workflow-id="props.workflowId"
               :workflow-name="workflow.name"
               @submit-launch-request="handleSubmitLaunchRequest()"

--- a/packages/front-end/src/app/pages/labs/[labId]/run-workflow/[workflowId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/run-workflow/[workflowId].vue
@@ -14,11 +14,22 @@
   const omicsWorkflowsStore = useOmicsWorkflowsStore();
   const uiStore = useUiStore();
 
+  const labId = $route.params.labId as string;
+
+  // check permissions to be on this page
+  if (!useUserStore().canViewLab(labId)) {
+    $router.push('/labs');
+  }
+
+  // set a new omicsRunTempId if not provided
+  if (!$route.query.omicsRunTempId) {
+    $router.push({ query: { omicsRunTempId: uuidv4() } });
+  }
+
   const omicsRunTempId = computed<string>(() => $route.query.omicsRunTempId as string);
 
   const wipOmicsRun = computed<WipOmicsRunData | undefined>(() => runStore.wipOmicsRuns[omicsRunTempId.value]);
 
-  const labId = $route.params.labId as string;
   const workflowId = $route.params.workflowId as string;
 
   const workflow = computed<ReadWorkflow | null>(() => omicsWorkflowsStore.workflows[workflowId]);
@@ -32,11 +43,6 @@
   const schema = computed<Record<string, WorkflowParameter> | null>(() => workflow.value?.parameterTemplate ?? null);
 
   const resetStepperKey = ref(0);
-
-  // check permissions to be on this page
-  if (!useUserStore().canViewLab(labId)) {
-    $router.push('/labs');
-  }
 
   const loading = computed<boolean>(() => uiStore.isRequestPending('loadOmicsWorkflow'));
 

--- a/packages/front-end/src/app/pages/labs/[labId]/run-workflow/[workflowId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/run-workflow/[workflowId].vue
@@ -144,6 +144,7 @@
       @reset-run-pipeline="resetRunPipeline()"
       :key="resetStepperKey"
       :workflow-id="workflowId"
+      :lab-name="labName"
     />
 
     <EGDialog

--- a/packages/front-end/src/app/stores/run.ts
+++ b/packages/front-end/src/app/stores/run.ts
@@ -4,6 +4,7 @@ import { RunListItem as OmicsRun } from '@aws-sdk/client-omics';
 import { Workflow as SeqeraRun } from '@easy-genomics/shared-lib/lib/app/types/nf-tower/nextflow-tower-api';
 import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory-run';
 import { defineStore } from 'pinia';
+import { FilePair } from '@FE/components/EGRunFormUploadData.vue';
 
 /*
 The WIP run is a construct for storing all of the data for a pipeline run that's being configured but hasn't been
@@ -19,6 +20,7 @@ export interface WipSeqeraRunData {
   sampleSheetS3Url?: string;
   s3Bucket?: string;
   s3Path?: string;
+  files?: FilePair[];
 }
 
 export interface WipOmicsRunData {
@@ -31,6 +33,7 @@ export interface WipOmicsRunData {
   sampleSheetS3Url?: string;
   s3Bucket?: string;
   s3Path?: string;
+  files?: FilePair[];
 }
 
 interface RunState {
@@ -153,7 +156,7 @@ const useRunStore = defineStore('runStore', {
     },
 
     updateWipSeqeraRun(tempId: string, updates: Partial<WipSeqeraRunData>): void {
-            const existingWipRun = this.wipSeqeraRuns[tempId] || {};
+      const existingWipRun = this.wipSeqeraRuns[tempId] || {};
       const existingParams = existingWipRun.params || {};
       this.wipSeqeraRuns[tempId] = {
         ...existingWipRun,

--- a/packages/front-end/src/app/stores/run.ts
+++ b/packages/front-end/src/app/stores/run.ts
@@ -153,10 +153,19 @@ const useRunStore = defineStore('runStore', {
     },
 
     updateWipSeqeraRun(tempId: string, updates: Partial<WipSeqeraRunData>): void {
+            const existingWipRun = this.wipSeqeraRuns[tempId] || {};
+      const existingParams = existingWipRun.params || {};
       this.wipSeqeraRuns[tempId] = {
-        ...(this.wipSeqeraRuns[tempId] || {}),
+        ...existingWipRun,
         ...updates,
       };
+      // need to merge params separately because they're nested
+      if (updates.params) {
+        this.wipSeqeraRuns[tempId].params = {
+          ...existingParams,
+          ...updates.params,
+        };
+      }
     },
 
     // Omics Runs
@@ -196,10 +205,19 @@ const useRunStore = defineStore('runStore', {
     },
 
     updateWipOmicsRun(tempId: string, updates: Partial<WipOmicsRunData>): void {
+      const existingWipRun = this.wipOmicsRuns[tempId] || {};
+      const existingParams = existingWipRun.params || {};
       this.wipOmicsRuns[tempId] = {
-        ...(this.wipOmicsRuns[tempId] || {}),
+        ...existingWipRun,
         ...updates,
       };
+      // need to merge params separately because they're nested
+      if (updates.params) {
+        this.wipOmicsRuns[tempId].params = {
+          ...existingParams,
+          ...updates.params,
+        };
+      }
     },
   },
 


### PR DESCRIPTION
## Title*

Implement persistent file uploads, and some related fixes/refactors

## Type of Change*
- [X] New feature
- [X] Bug fix
- [ ] Documentation update
- [X] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Features
- File upload persistence - file upload information for a wip run is now stored/read/written directly from the wip run data, so no state is lost when switching between steps

Fixes
- if Omics `/run-workflow/...` route is reached without an omicsTempId in query param, it will generate one automatically
- a console error log when sample sheet wasn't present
- hide sample sheet bar when info isn't present yet
- input/outdir params are generated on file upload success

Refactors
- wip run update functions merge params instead of overwriting `params` object

## Testing*

Dev tested - seems solid as far as I can tell, but any undetected problems should shake out

## Impact

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.