### PR TITLE
feat(EG-929): dismiss green toasts with a click anywhere on the page

### DIFF
--- a/packages/front-end/src/app/components/EGToast.vue
+++ b/packages/front-end/src/app/components/EGToast.vue
@@ -7,6 +7,7 @@
       title: string;
       timeout?: number; // milliseconds
       variant?: ToastVariant;
+      callback?: Function;
     }>(),
     {
       timeout: 3000,
@@ -103,7 +104,21 @@
 </script>
 
 <template>
-  <UNotification :timeout="timeout" :id="id" :ui="variantUi" :title="title" :icon="variantUi.icon" />
+  <!-- invisible full screen overlay to pick up clicks and dismiss the green toast -->
+  <div
+    v-if="variant === 'success'"
+    class="z-99999 fixed bottom-px left-px right-px top-px"
+    @click.stop="callback"
+  ></div>
+
+  <UNotification
+    :timeout="timeout"
+    :id="id"
+    :ui="variantUi"
+    :title="title"
+    :icon="variantUi.icon"
+    :callback="callback"
+  />
 </template>
 
 <style scoped lang="scss">

--- a/packages/front-end/src/app/components/EGToasts.vue
+++ b/packages/front-end/src/app/components/EGToasts.vue
@@ -5,7 +5,7 @@
 
 <template>
   <div
-    class="pointer-events-none fixed bottom-auto left-0 right-0 z-[55] ml-auto mr-auto flex w-full max-w-lg flex-col justify-center break-all"
+    class="fixed bottom-auto left-0 right-0 z-[55] ml-auto mr-auto flex w-full max-w-lg flex-col justify-center break-all"
     role="region"
   >
     <div class="space-y-3 overflow-y-auto px-4 py-6 sm:px-6">


### PR DESCRIPTION
## Title*

Dismiss green toasts with a click anywhere on the screen

## Type of Change*
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Each green toast now renders an invisible full-screen div that will dismiss the toast on-click

## Testing*

## Impact

This change means that when there is 1 or more green toasts active, clicks anywhere on the page will go to dismissing them instead of interacting with page elements.

I have some concerns that this will be irritating for users but we'll see ourselves as we use the app in dev.

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.