### PR TITLE
feat(EG-931): remove single file if failed upload

### DIFF
--- a/packages/front-end/src/app/components/EGRunFormUploadData.vue
+++ b/packages/front-end/src/app/components/EGRunFormUploadData.vue
@@ -244,15 +244,12 @@
    * @param newFile
    */
   function checkIsFileDuplicate(newFile: File): boolean {
-    // Only check files that are currently in file pairs
-    const existingFiles = filePairs.value.flatMap((pair) => {
-      const files = [];
-      if (pair.r1File) files.push(pair.r1File);
-      if (pair.r2File) files.push(pair.r2File);
-      return files;
-    });
+    // Only check files from complete pairs (where both R1 and R2 exist)
+    const filesInCompletePairs = filePairs.value
+      .filter((pair) => pair.r1File && pair.r2File)
+      .flatMap((pair) => [pair.r1File!, pair.r2File!]);
 
-    return existingFiles.some((fileDetails: FileDetails) => fileDetails.name === newFile.name);
+    return filesInCompletePairs.some((fileDetails) => fileDetails.name === newFile.name);
   }
 
   function getFileDetails(file: File): FileDetails {

--- a/packages/front-end/src/app/components/EGRunFormUploadData.vue
+++ b/packages/front-end/src/app/components/EGRunFormUploadData.vue
@@ -136,13 +136,6 @@
     const hasUnmatched = haveUnmatchedFiles.value;
     const isUploading = uploadStatus.value === 'uploading';
 
-    console.log('Upload button disabled because:', {
-      noInternet,
-      noFiles,
-      hasUnmatched,
-      isUploading,
-    });
-
     return noInternet || noFiles || hasUnmatched || isUploading;
   });
 

--- a/packages/front-end/src/app/components/EGRunFormUploadData.vue
+++ b/packages/front-end/src/app/components/EGRunFormUploadData.vue
@@ -128,7 +128,7 @@
     return files;
   });
 
-  const showDropzone = computed(() => uploadStatus.value !== 'uploading');
+  const isDropzoneEnabled = computed(() => uploadStatus.value !== 'uploading');
 
   const isUploadButtonDisabled = computed(() => {
     const noInternet = !isOnline.value;
@@ -658,7 +658,11 @@
       <li>5GB max size per individual file</li>
     </ul>
     <UDivider class="py-4" />
-    <div class="py-4" @drop.prevent="handleDroppedFiles" v-if="showDropzone">
+    <div
+      class="py-4"
+      @drop.prevent="handleDroppedFiles"
+      :class="{ 'pointer-events-none opacity-50': !isDropzoneEnabled }"
+    >
       <div
         id="dropzone"
         @dragenter.prevent="toggleDropzoneActive"
@@ -694,6 +698,7 @@
               multiple
             />
             <EGButton
+              :disabled="!isDropzoneEnabled"
               :class="cn('visible ml-4', { 'invisible': isDropzoneActive })"
               @click="chooseFiles"
               label="Choose Files"
@@ -785,7 +790,6 @@
       :lab-name="props.labName"
       :pipeline-or-workflow-name="props.pipelineOrWorkflowName"
       :run-name="props.wipRun.runName"
-      :class="{ 'pointer-events-none opacity-50': uploadStatus === 'uploading' }"
     />
 
     <div class="flex justify-end pt-4">

--- a/packages/front-end/src/app/components/EGRunFormUploadData.vue
+++ b/packages/front-end/src/app/components/EGRunFormUploadData.vue
@@ -130,14 +130,21 @@
 
   const showDropzone = computed(() => uploadStatus.value !== 'uploading');
 
-  const isUploadButtonDisabled = computed(
-    // reasons why uploading might be disabled
-    () =>
-      !isOnline.value || // no internet connection
-      filesNotUploaded.value.length === 0 || // nothing to upload
-      haveUnmatchedFiles.value || // there's an unmatched file
-      uploadStatus.value === 'uploading', // uploading is currently going
-  );
+  const isUploadButtonDisabled = computed(() => {
+    const noInternet = !isOnline.value;
+    const noFiles = filesNotUploaded.value.length === 0;
+    const hasUnmatched = haveUnmatchedFiles.value;
+    const isUploading = uploadStatus.value === 'uploading';
+
+    console.log('Upload button disabled because:', {
+      noInternet,
+      noFiles,
+      hasUnmatched,
+      isUploading,
+    });
+
+    return noInternet || noFiles || hasUnmatched || isUploading;
+  });
 
   // Add a computed property to check if all file pairs are complete and all files are successfully uploaded
   const areAllFilesUploaded = computed(() => filesNotUploaded.value.length === 0);
@@ -232,8 +239,20 @@
     addFileToFilePairs(fileDetails);
   }
 
+  /**
+   * Check if a file is already in the file pairs
+   * @param newFile
+   */
   function checkIsFileDuplicate(newFile: File): boolean {
-    return files.value.some((fileDetails: FileDetails) => fileDetails.name === newFile.name);
+    // Only check files that are currently in file pairs
+    const existingFiles = filePairs.value.flatMap((pair) => {
+      const files = [];
+      if (pair.r1File) files.push(pair.r1File);
+      if (pair.r2File) files.push(pair.r2File);
+      return files;
+    });
+
+    return existingFiles.some((fileDetails: FileDetails) => fileDetails.name === newFile.name);
   }
 
   function getFileDetails(file: File): FileDetails {
@@ -461,6 +480,9 @@
     }
 
     const controller = new AbortController();
+    // Store the controller
+    uploadControllers.value[fileDetails.name] = controller;
+
     const timeoutId = setTimeout(() => {
       controller.abort();
     }, UPLOAD_TIMEOUT);
@@ -499,10 +521,14 @@
 
       clearTimeout(timeoutId);
       unwatch();
+      // Remove the controller after successful upload
+      delete uploadControllers.value[fileDetails.name];
       return response.data;
     } catch (error: any) {
       clearTimeout(timeoutId);
       unwatch();
+      // Remove the controller after failed upload
+      delete uploadControllers.value[fileDetails.name];
 
       if (error.name === 'AbortError' || error.message === 'Network Error' || !isOnline.value) {
         fileDetails.error = 'Network connection lost. Upload aborted.';
@@ -555,13 +581,42 @@
   };
 
   const removeFile = (file: { sampleId: string; fileName: string }) => {
-    // Remove the filePair containing the file
-    props.wipRun.files = filePairs.value.filter((pair) => {
-      if (pair.r1File?.name === file.fileName || pair.r2File?.name === file.fileName) {
-        return false;
+    // Find the file pair containing the file
+    const filePair = filePairs.value.find((pair) => pair.sampleId === file.sampleId);
+
+    if (filePair) {
+      // Remove only the specific file (r1 or r2) that matches the filename
+      if (filePair.r1File?.name === file.fileName) {
+        filePair.r1File = undefined;
+      } else if (filePair.r2File?.name === file.fileName) {
+        filePair.r2File = undefined;
       }
-      return true;
+
+      // If both files are now undefined, remove the entire pair
+      if (!filePair.r1File && !filePair.r2File) {
+        props.wipRun.files = filePairs.value.filter((pair) => pair.sampleId !== file.sampleId);
+      }
+    }
+  };
+
+  const canRetryUpload = (row: { sampleId: string; fileName: string; progress: number; error?: string }) => {
+    // If the file isn't in error state, can't retry
+    if (!row.error) return false;
+
+    // Find the matching pair for this file
+    const isPairedFile = filePairs.value.some((pair) => {
+      const isR1 = pair.r1File?.name === row.fileName;
+      const isR2 = pair.r2File?.name === row.fileName;
+
+      // If this is R1, check if R2 exists
+      if (isR1) return !!pair.r2File;
+      // If this is R2, check if R1 exists
+      if (isR2) return !!pair.r1File;
+
+      return false;
     });
+
+    return isPairedFile && isOnline.value;
   };
 
   watch(canProceedToNextStep, (val) => {
@@ -676,17 +731,21 @@
             <template v-if="row.error">
               <button
                 class="mr-2"
-                :class="[isOnline ? 'text-gray-900 hover:text-gray-700' : 'cursor-not-allowed text-gray-400']"
+                :class="[
+                  canRetryUpload(row) ? 'text-gray-900 hover:text-gray-700' : 'cursor-not-allowed text-gray-400',
+                ]"
                 @click="retryUpload(row)"
-                :disabled="!isOnline"
-                :title="isOnline ? 'Retry upload' : 'Cannot retry while offline'"
+                :disabled="!isOnline || !canRetryUpload(row)"
               >
                 <UIcon name="i-heroicons-arrow-path" size="20" />
               </button>
+
               <button
-                :disabled="!isOnline"
+                :disabled="!isOnline || uploadStatus === 'uploading'"
                 :class="[
-                  isOnline ? 'text-alert-danger hover:text-alert-danger-dark' : 'cursor-not-allowed text-gray-400',
+                  isOnline && uploadStatus !== 'uploading'
+                    ? 'text-alert-danger hover:text-alert-danger-dark'
+                    : 'cursor-not-allowed text-gray-400',
                 ]"
                 @click="removeFile(row)"
               >
@@ -709,11 +768,13 @@
 
     <EGS3SampleSheetBar
       v-if="props.wipRun.sampleSheetS3Url"
+      :disabled="uploadStatus === 'uploading'"
       :url="props.wipRun.sampleSheetS3Url"
       :lab-id="props.labId"
       :lab-name="props.labName"
       :pipeline-or-workflow-name="props.pipelineOrWorkflowName"
       :run-name="props.wipRun.runName"
+      :class="{ 'pointer-events-none opacity-50': uploadStatus === 'uploading' }"
     />
 
     <div class="flex justify-end pt-4">

--- a/packages/front-end/src/app/components/EGS3SampleSheetBar.vue
+++ b/packages/front-end/src/app/components/EGS3SampleSheetBar.vue
@@ -6,6 +6,7 @@
       pipelineOrWorkflowName: string;
       runName: string;
       labName: string;
+      disabled?: boolean;
     }>(),
     {
       url: '',
@@ -13,6 +14,7 @@
       pipelineOrWorkflowName: '',
       runName: '',
       labName: '',
+      disabled: false,
     },
   );
 
@@ -50,7 +52,10 @@
 
 <template>
   <EGText tag="h5" class="mb-2">Sample Sheet:</EGText>
-  <div class="border-r-1 bg-primary-muted mb-4 flex items-center justify-between rounded p-4">
+  <div
+    :class="[{ 'pointer-events-none opacity-50': disabled }]"
+    class="border-r-1 bg-primary-muted mb-4 flex items-center justify-between rounded p-4"
+  >
     <div
       class="text-primary hover:text-primary-900 relative cursor-pointer text-xs"
       @click="copyToClipboard"
@@ -59,7 +64,10 @@
       :aria-label="`Copy URL: ${url}`"
     >
       {{ url }}
-      <span :class="{ copied: true, show: isCopied }" role="status" aria-live="polite">Copied</span>
+      <div :class="{ copied: true, show: isCopied }" role="status" aria-live="polite" class="flex items-center gap-1">
+        Copied
+        <UIcon name="i-heroicons-check-20-solid" class="h-4 w-4 text-white" />
+      </div>
     </div>
 
     <div class="flex items-center gap-4" role="group" aria-label="URL Actions">

--- a/packages/front-end/src/app/components/EGS3SampleSheetBar.vue
+++ b/packages/front-end/src/app/components/EGS3SampleSheetBar.vue
@@ -51,48 +51,50 @@
 </script>
 
 <template>
-  <EGText tag="h5" class="mb-2">Sample Sheet:</EGText>
-  <div
-    :class="[{ 'pointer-events-none opacity-50': disabled }]"
-    class="border-r-1 bg-primary-muted mb-4 flex items-center justify-between rounded p-4"
-  >
+  <div class="sample-sheet-bar">
+    <EGText tag="h5" class="mb-2">Sample Sheet:</EGText>
     <div
-      class="text-primary hover:text-primary-900 relative cursor-pointer text-xs"
-      @click="copyToClipboard"
-      role="button"
-      tabindex="0"
-      :aria-label="`Copy URL: ${url}`"
+      :class="[{ 'pointer-events-none opacity-50': disabled }]"
+      class="border-r-1 bg-primary-muted mb-4 flex items-center justify-between rounded p-4"
     >
-      {{ url }}
-      <div :class="{ copied: true, show: isCopied }" role="status" aria-live="polite" class="flex items-center gap-1">
-        Copied
-        <UIcon name="i-heroicons-check-20-solid" class="h-4 w-4 text-white" />
+      <div
+        class="text-primary hover:text-primary-900 relative cursor-pointer text-xs"
+        @click="copyToClipboard"
+        role="button"
+        tabindex="0"
+        :aria-label="`Copy URL: ${url}`"
+      >
+        {{ url }}
+        <div :class="{ copied: true, show: isCopied }" role="status" aria-live="polite" class="flex items-center gap-1">
+          Copied
+          <UIcon name="i-heroicons-check-20-solid" class="h-4 w-4 text-white" />
+        </div>
       </div>
-    </div>
 
-    <div class="flex items-center gap-4" role="group" aria-label="URL Actions">
-      <button @click="openSampleSheet" class="cursor-pointer" aria-label="Open in new tab">
-        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="25" viewBox="0 0 24 25" fill="none">
-          <path
-            d="M20.2916 12.5C19.9004 12.5 19.5833 12.8171 19.5833 13.2084V19.5833H5.41674V5.41674H11.7916C12.1829 5.41674 12.5 5.09959 12.5 4.70837C12.5 4.31715 12.1829 4 11.7916 4H5.41674C4.63771 4 4 4.6375 4 5.41674V19.5835C4 20.3623 4.63771 21 5.41674 21H19.5833C20.3623 21 21 20.3623 21 19.5833V13.2084C21 12.8171 20.6829 12.5 20.2916 12.5Z"
-            fill="#5524E0"
-          />
-          <path
-            d="M20.2915 9.66663C20.6828 9.66669 21 9.34949 20.9999 8.95822L20.9994 4.70805C21 4.31726 20.6825 4 20.2917 4H16.0414C15.6503 4 15.3333 4.31705 15.3333 4.70816C15.3333 5.09926 15.6503 5.41631 16.0414 5.41631H18.5809L13.0008 10.9972C12.7242 11.2738 12.7242 11.7223 13.0008 11.999C13.2775 12.2757 13.726 12.2757 14.0027 11.9991L19.5833 6.41931V8.95831C19.5833 9.34946 19.9003 9.66657 20.2915 9.66663Z"
-            fill="#5524E0"
-          />
-        </svg>
-      </button>
-      <button @click="copyToClipboard" class="cursor-pointer" aria-label="Copy to clipboard">
-        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="25" viewBox="0 0 24 25" fill="none">
-          <path
-            fill-rule="evenodd"
-            clip-rule="evenodd"
-            d="M20 17.6207C20 18.047 19.6559 18.3923 19.2301 18.3923C18.8044 18.3923 18.4603 18.047 18.4603 17.6207V5.04317H8.94491C8.51915 5.04317 8.17504 4.69787 8.17504 4.27158C8.17504 3.84606 8.51915 3.5 8.94491 3.5H19.2301C19.6558 3.5 19.9999 3.8453 19.9999 4.27158L20 17.6207ZM8.17508 9.24168L6.63 10.7887H8.17508V9.24168ZM4.22967 11.0095C4.08317 11.1538 4 11.3509 4 11.5603V20.7284C4 21.1547 4.34411 21.5 4.76986 21.5H15.6221C16.0478 21.5 16.3934 21.1547 16.3934 20.7284V7.37916C16.3934 6.95288 16.0478 6.60758 15.6221 6.60758H8.94498C8.73516 6.60758 8.54136 6.69161 8.39639 6.83829L4.23045 11.0086L4.22967 11.0095ZM9.71485 8.1508V11.5604C9.71485 11.9867 9.37074 12.332 8.94498 12.332H5.53965V19.9569H14.8521V8.15086L9.71485 8.1508Z"
-            fill="#5524E0"
-          />
-        </svg>
-      </button>
+      <div class="flex items-center gap-4" role="group" aria-label="URL Actions">
+        <button @click="openSampleSheet" class="cursor-pointer" aria-label="Open in new tab">
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="25" viewBox="0 0 24 25" fill="none">
+            <path
+              d="M20.2916 12.5C19.9004 12.5 19.5833 12.8171 19.5833 13.2084V19.5833H5.41674V5.41674H11.7916C12.1829 5.41674 12.5 5.09959 12.5 4.70837C12.5 4.31715 12.1829 4 11.7916 4H5.41674C4.63771 4 4 4.6375 4 5.41674V19.5835C4 20.3623 4.63771 21 5.41674 21H19.5833C20.3623 21 21 20.3623 21 19.5833V13.2084C21 12.8171 20.6829 12.5 20.2916 12.5Z"
+              fill="#5524E0"
+            />
+            <path
+              d="M20.2915 9.66663C20.6828 9.66669 21 9.34949 20.9999 8.95822L20.9994 4.70805C21 4.31726 20.6825 4 20.2917 4H16.0414C15.6503 4 15.3333 4.31705 15.3333 4.70816C15.3333 5.09926 15.6503 5.41631 16.0414 5.41631H18.5809L13.0008 10.9972C12.7242 11.2738 12.7242 11.7223 13.0008 11.999C13.2775 12.2757 13.726 12.2757 14.0027 11.9991L19.5833 6.41931V8.95831C19.5833 9.34946 19.9003 9.66657 20.2915 9.66663Z"
+              fill="#5524E0"
+            />
+          </svg>
+        </button>
+        <button @click="copyToClipboard" class="cursor-pointer" aria-label="Copy to clipboard">
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="25" viewBox="0 0 24 25" fill="none">
+            <path
+              fill-rule="evenodd"
+              clip-rule="evenodd"
+              d="M20 17.6207C20 18.047 19.6559 18.3923 19.2301 18.3923C18.8044 18.3923 18.4603 18.047 18.4603 17.6207V5.04317H8.94491C8.51915 5.04317 8.17504 4.69787 8.17504 4.27158C8.17504 3.84606 8.51915 3.5 8.94491 3.5H19.2301C19.6558 3.5 19.9999 3.8453 19.9999 4.27158L20 17.6207ZM8.17508 9.24168L6.63 10.7887H8.17508V9.24168ZM4.22967 11.0095C4.08317 11.1538 4 11.3509 4 11.5603V20.7284C4 21.1547 4.34411 21.5 4.76986 21.5H15.6221C16.0478 21.5 16.3934 21.1547 16.3934 20.7284V7.37916C16.3934 6.95288 16.0478 6.60758 15.6221 6.60758H8.94498C8.73516 6.60758 8.54136 6.69161 8.39639 6.83829L4.23045 11.0086L4.22967 11.0095ZM9.71485 8.1508V11.5604C9.71485 11.9867 9.37074 12.332 8.94498 12.332H5.53965V19.9569H14.8521V8.15086L9.71485 8.1508Z"
+              fill="#5524E0"
+            />
+          </svg>
+        </button>
+      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Title*
Adds ability to remove a single file if failed during upload.

## Type of Change*
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [X] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [X] UI/UX improvement

## Description
**Key improvements**
- Prevents invalid operations
- Provides clear UI feedback
- Maintains data integrity
- Handles errors consistently

**UI elements during upload**
- Sample Sheet URL bar:
    - Disabled during uploads before renewed sample sheet is available
    - Returns to normal state after upload completes

- Retry button:
    - Properly enables when file is in error state
    - Checks for paired file existence
    - Validates network connectivity

**Remove buttons**
- Disabled during active uploads
- Maintains existing offline-state handling
- Disabled in two scenarios:
    1. When there's no internet connection
    2. During active file uploads

**Overall state management**
- Better handling of file pair states
- Improved validation during the upload process
- More consistent UI feedback during different states (uploading, offline, etc.)
- Enhanced property naming consistency:
    - Using `r1File/r2File` instead of `R1/R2`
    - Using `fileName` instead of `name`


## Testing*
Tested scenarios detailed above manually


## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.