### PR TITLE
feat(EG-986): add network offline modal

### DIFF
--- a/packages/front-end/src/app/app.vue
+++ b/packages/front-end/src/app/app.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
   import tailwindConfig from '../../tailwind.config.js';
+  import { useNetwork } from '@vueuse/core';
 
   const primaryColHex = tailwindConfig.theme.extend.colors.primary;
   const { ENV_TYPE } = useRuntimeConfig().public;
+  const { isOnline } = useNetwork();
 </script>
 
 <template>
   <NuxtLoadingIndicator :color="primaryColHex" />
+  <EGOfflineModal :model-value="!isOnline" />
   <NuxtLayout :key="useUiStore().remountAppKey">
     <NuxtPage />
     <EGBuildInfo v-if="ENV_TYPE !== 'prod'" />

--- a/packages/front-end/src/app/assets/icons/spinner.svg
+++ b/packages/front-end/src/app/assets/icons/spinner.svg
@@ -1,4 +1,4 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle opacity="0.25" cx="12" cy="12" r="9" stroke="#12181F" stroke-width="3"/>
+<circle opacity="0.25" cx="12" cy="12" r="9" stroke="currentColor" stroke-width="3"/>
 <path d="M5.63604 18.364C4.37737 17.1053 3.5202 15.5016 3.17294 13.7558C2.82567 12.01 3.0039 10.2004 3.68509 8.55585C4.36628 6.91131 5.51983 5.50571 6.99987 4.51677C8.47991 3.52784 10.22 3 12 3" stroke="#12181F" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/packages/front-end/src/app/components/EGDialog.vue
+++ b/packages/front-end/src/app/components/EGDialog.vue
@@ -21,6 +21,8 @@
 
   const delaying = ref<boolean>(false);
 
+  const canCancel = computed(() => props.cancelLabel);
+
   function handleClick() {
     delaying.value = true;
 
@@ -32,7 +34,17 @@
 </script>
 
 <template>
-  <UModal :modelValue="modelValue" @update:modelValue="(value) => emit('update:modelValue', value)" prevent-close>
+  <UModal
+    :ui="{
+      overlay: {
+        base: 'fixed inset-0 transition-opacity backdrop-blur-[5px]',
+        background: 'bg-gray-800/30',
+      },
+    }"
+    :modelValue="modelValue"
+    @update:modelValue="(value) => emit('update:modelValue', value)"
+    prevent-close
+  >
     <UCard>
       <template #header>
         <div class="flex flex-col">
@@ -40,6 +52,7 @@
             <EGText tag="h3" class="mb-6">{{ primaryMessage }}</EGText>
             <div>
               <UButton
+                v-if="canCancel"
                 @click="handleCancel"
                 icon="i-heroicons-x-mark"
                 class="hover:bg-background-dark-grey ml-2"

--- a/packages/front-end/src/app/components/EGLoadingSpinner.vue
+++ b/packages/front-end/src/app/components/EGLoadingSpinner.vue
@@ -1,13 +1,44 @@
 <template>
-  <img src="@/assets/icons/spinner.svg" class="spinner" />
+  <div :class="['spinner-container', sizeClass]">
+    <svg class="spinner" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <circle opacity="0.25" cx="12" cy="12" r="9" :stroke="spinnerColor" stroke-width="3" />
+      <path
+        d="M5.63604 18.364C4.37737 17.1053 3.5202 15.5016 3.17294 13.7558C2.82567 12.01 3.0039 10.2004 3.68509 8.55585C4.36628 6.91131 5.51983 5.50571 6.99987 4.51677C8.47991 3.52784 10.22 3 12 3"
+        :stroke="spinnerColor"
+        stroke-width="3"
+        stroke-linecap="round"
+      />
+    </svg>
+  </div>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+  type SpinnerVariant = 'default' | 'dark';
+
+  const props = withDefaults(
+    defineProps<{
+      sizeClass?: string;
+      variant?: SpinnerVariant;
+    }>(),
+    {
+      sizeClass: 'w-8 h-8',
+      variant: 'default',
+    },
+  );
+
+  const spinnerColor = computed(() => {
+    switch (props.variant) {
+      case 'dark':
+        return '#323840';
+      case 'default':
+      default:
+        return '#5524e0';
+    }
+  });
+</script>
 
 <style scoped>
   .spinner {
-    width: 24px;
-    height: 24px;
     animation: spin 1s linear infinite;
   }
 

--- a/packages/front-end/src/app/components/EGModal.vue
+++ b/packages/front-end/src/app/components/EGModal.vue
@@ -10,7 +10,6 @@
     {
       title: '',
       message: '',
-      canDismiss: true,
       preventClose: false,
     },
   );
@@ -21,7 +20,15 @@
 </script>
 
 <template>
-  <UModal prevent-close>
+  <UModal
+    prevent-close
+    :ui="{
+      overlay: {
+        base: 'fixed inset-0 transition-opacity backdrop-blur-[5px]',
+        background: 'bg-gray-800/30',
+      },
+    }"
+  >
     <UCard>
       <div class="space-y-2">
         <EGText tag="h3" v-if="title" class="mb-8">{{ title }}</EGText>

--- a/packages/front-end/src/app/components/EGOfflineModal.vue
+++ b/packages/front-end/src/app/components/EGOfflineModal.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+  const props = defineProps<{
+    modelValue: any;
+  }>();
+</script>
+
+<template>
+  <UModal
+    :modelValue="modelValue"
+    @update:modelValue="(value) => emit('update:modelValue', value)"
+    prevent-close
+    :ui="{
+      overlay: {
+        base: 'fixed inset-0 transition-opacity backdrop-blur-[5px]',
+        background: 'bg-gray-800/30',
+      },
+    }"
+  >
+    <UCard>
+      <template #header>
+        <div class="flex flex-col">
+          <div>
+            <div class="mb-6 flex items-center justify-between">
+              <EGText tag="h3">Network connection lost</EGText>
+              <EGLoadingSpinner class="flex-end flex" />
+            </div>
+            <div>
+              <UButton
+                v-if="canCancel"
+                @click="handleCancel"
+                icon="i-heroicons-x-mark"
+                class="hover:bg-background-dark-grey ml-2"
+                color="black"
+                variant="ghost"
+                :ui="{ rounded: 'rounded-full' }"
+                :disabled="buttonsDisabled || delaying"
+              />
+            </div>
+          </div>
+          <EGText tag="p" class="mb-6">
+            Waiting for connection to be re-established. Please hold until you are back online.
+          </EGText>
+        </div>
+      </template>
+    </UCard>
+  </UModal>
+</template>

--- a/packages/front-end/src/app/components/EGOfflineModal.vue
+++ b/packages/front-end/src/app/components/EGOfflineModal.vue
@@ -19,23 +19,9 @@
     <UCard>
       <template #header>
         <div class="flex flex-col">
-          <div>
-            <div class="mb-6 flex items-center justify-between">
-              <EGText tag="h3">Network connection lost</EGText>
-              <EGLoadingSpinner class="flex-end flex" />
-            </div>
-            <div>
-              <UButton
-                v-if="canCancel"
-                @click="handleCancel"
-                icon="i-heroicons-x-mark"
-                class="hover:bg-background-dark-grey ml-2"
-                color="black"
-                variant="ghost"
-                :ui="{ rounded: 'rounded-full' }"
-                :disabled="buttonsDisabled || delaying"
-              />
-            </div>
+          <div class="mb-6 flex items-center justify-between">
+            <EGText tag="h3">Network connection lost</EGText>
+            <EGLoadingSpinner class="flex-end flex" />
           </div>
           <EGText tag="p" class="mb-6">
             Waiting for connection to be re-established. Please hold until you are back online.

--- a/packages/front-end/src/app/components/EGRunFormUploadData.vue
+++ b/packages/front-end/src/app/components/EGRunFormUploadData.vue
@@ -447,12 +447,8 @@
         .map((result) => (result.status === 'rejected' ? result.reason : result.value))
         .filter((error): error is UploadError => error !== null);
 
-      // Show network error toast only once if any file failed due to network
-      if (errors.some((error) => error.error === 'Network connection lost')) {
-        toastStore.error('Network error - please check your connection and try again');
-      }
       // Show other error toasts as needed
-      else if (errors.length > 0) {
+      if (errors.length > 0) {
         if (errors.length === 1) {
           toastStore.error(`Upload failed for ${errors[0].fileName}`);
         } else {

--- a/packages/front-end/src/app/pages/labs/[labId]/run-workflow/[workflowId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/run-workflow/[workflowId].vue
@@ -5,7 +5,6 @@
   import { ButtonVariantEnum } from '@FE/types/buttons';
   import { WorkflowParameter } from '@aws-sdk/client-omics';
   import { v4 as uuidv4 } from 'uuid';
-  import EGLoadingSpinner from '@FE/components/EGLoadingSpinner.vue';
 
   const { $api } = useNuxtApp();
   const $router = useRouter();


### PR DESCRIPTION
## Title*
Adds a global "network offline" modal to help prevent interactivity with the app.

## Type of Change*
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [X] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [X] UI/UX improvement

## Description
Implements a global network connectivity monitor with an automated modal dialog that appears when users lose internet connection. Key changes:

- Added non-dismissible modal that activates automatically on network loss
- Utilizes vueUse's `isOnline` reactive property to detect network state changes
- Prevents user interactions during offline state to avoid API call failures
- Standardized modal styling to match Figma designs and existing modal components
- Refactored loading spinner component to support multiple theme variants

The network status feature provides a more robust error prevention system while maintaining consistent UI/UX patterns across the application.

## Additional information

![image](https://github.com/user-attachments/assets/bf0eabab-aadb-4dd5-9670-def73bcc6959)


## Testing*
Network state was tested via both Chrome's dev tools network simulation as well as disabling the system Wifi.

## Impact
The modal is at the top level (`app.vue`) of the app so essentially will prevent any interaction with the app until connectivity is restored. 


## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.