### PR TITLE
feat(EG-1004): update the create-file-upload-sample-sheet API to support single read files

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/upload/create-file-upload-sample-sheet.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/upload/create-file-upload-sample-sheet.lambda.ts
@@ -41,7 +41,7 @@ export const handler: Handler = async (
     const requestParseResult = SampleSheetRequestSchema.safeParse(request);
     if (!requestParseResult.success) {
       requestParseResult.error.issues.forEach((issue) => console.error(issue));
-      throw new InvalidRequestError();
+      throw new InvalidRequestError('Invalid sample sheet request');
     }
 
     const laboratoryId: string = request.LaboratoryId;
@@ -50,7 +50,7 @@ export const handler: Handler = async (
 
     const s3Bucket: string | undefined = laboratory.S3Bucket;
     if (!s3Bucket) {
-      throw new Error(`Laboratory ${laboratoryId} S3 Bucket needs to be configured`);
+      throw new InvalidRequestError(`Laboratory ${laboratoryId} S3 Bucket needs to be configured`);
     }
 
     const s3Path: string = `${laboratory.OrganizationId}/${laboratory.LaboratoryId}/next-flow/${transactionId}`;
@@ -60,8 +60,12 @@ export const handler: Handler = async (
 
     // S3 Buckets in Region us-east-1 have a LocationConstraint of null.
     const s3Region: string = bucketLocation ? bucketLocation : 'us-east-1';
+    const sampleSheetType: string = getSampleSheetType(request);
 
-    const sampleSheetCsv: string = await generateSampleSheetCsv(request.UploadedFilePairs);
+    const sampleSheetCsv: string =
+      sampleSheetType === 'paired-read'
+        ? await generatePairedReadsSampleSheetCsv(request.UploadedFilePairs)
+        : await generateSingleReadSampleSheetCsv(request.UploadedFilePairs);
     const sampleSheetCsvChecksum: string = createHash('sha256').update(sampleSheetCsv).digest('hex');
 
     const result: PutObjectCommandOutput = await s3Service.putObject({
@@ -100,15 +104,98 @@ export const handler: Handler = async (
 };
 
 /**
- * Helper function to generate CSV Sample-Sheet from supplied array of
- * UploadedFilePairInfo definitions, which each consisting of R1 and R2 pairs.
+ * Helper function to get the type of sample-sheet request and will return either:
+ *  - 'single-read'
+ *  - 'paired-read'
+ *
+ * @param request
+ */
+function getSampleSheetType(request: SampleSheetRequest) {
+  // Check request has supplied a paired-read R1 & R2 sample sheet
+  const r1Info: boolean[] = request.UploadedFilePairs.map((row: UploadedFilePairInfo) => row.R1 != undefined);
+  const r2Info: boolean[] = request.UploadedFilePairs.map((row: UploadedFilePairInfo) => row.R2 != undefined);
+
+  // Check if R1 / R2 has any entries defined
+  const r1InfoDefined = r1Info.includes(true);
+  const r2InfoDefined = r2Info.includes(true);
+
+  const r1InfoAllValid = r1Info.every((r1Defined: boolean) => r1Defined === true);
+  const r2InfoAllValid = r2Info.every((r2Defined: boolean) => r2Defined === true);
+
+  if (r1InfoDefined && !r2InfoDefined) {
+    if (!r1InfoAllValid) {
+      throw new InvalidRequestError('Invalid single-read sample files supplied');
+    }
+
+    return 'single-read';
+  } else if (r1InfoDefined && r2InfoDefined) {
+    if (!r1InfoAllValid) {
+      throw new InvalidRequestError('Invalid paired-read R1 sample files supplied');
+    }
+    if (!r2InfoAllValid) {
+      throw new InvalidRequestError('Invalid paired-read R2 sample files supplied');
+    }
+
+    return 'paired-read';
+  } else {
+    throw new InvalidRequestError('Invalid paired-read R1 / R2 sample files supplied');
+  }
+}
+
+/**
+ * Helper function to generate single-read CSV Sample-Sheet from supplied array of
+ * UploadedFilePairInfo definitions, which each consisting of only R1 values.
  *
  * @param uploadedFilePairs
  */
-async function generateSampleSheetCsv(uploadedFilePairs: UploadedFilePairInfo[]): Promise<string> {
+async function generateSingleReadSampleSheetCsv(uploadedFilePairs: UploadedFilePairInfo[]): Promise<string> {
   /**
-   * Iterate over the supplied list of UploadedFiles to check the R1 & R2 file
-   * pairs exist, and generate CSV sample-sheet row record.
+   * Iterate over the supplied list of UploadedFiles to check the single R1 file exist, and generate CSV sample-sheet row record.
+   */
+  const sampleSheetCsvData: string[] = (
+    await Promise.all(
+      uploadedFilePairs.map(async (uploadedFilePair: UploadedFilePairInfo) => {
+        const r1 = uploadedFilePair.R1;
+
+        // Check the single-read R1 details are supplied
+        if (!r1) {
+          throw new InvalidRequestError('Single read sample file undefined');
+        }
+
+        // Check the single-read R1 file starts with the supplied SampleId
+        const r1FileName: string = r1.Key.split('/').pop();
+        if (!r1FileName.startsWith(uploadedFilePair.SampleId)) {
+          throw new InvalidRequestError(
+            `Sample Id '${uploadedFilePair.SampleId}' does not match single-read sample file: ${r1.Key}`,
+          );
+        }
+
+        // Check the single-read R1 file exists in the S3 Bucket / Key location
+        const singleReadFileExists: boolean = await s3Service.doesObjectExist({ Bucket: r1.Bucket, Key: r1.Key });
+        if (singleReadFileExists === false) {
+          throw new InvalidRequestError(`Single read sample file not found: ${r1.Key}`);
+        } else {
+          return `${uploadedFilePair.SampleId}, ${r1.S3Url}, `; // CSV Sample-Sheet row
+        }
+      }),
+    )
+  ).map((csvRow: Awaited<string>) => {
+    return csvRow;
+  });
+
+  const sampleSheetCsv: string = [...SAMPLE_SHEET_CSV_HEADER, ...sampleSheetCsvData].join('\n');
+  return sampleSheetCsv;
+}
+
+/**
+ * Helper function to generate paired-read CSV Sample-Sheet from supplied array of
+ * UploadedFilePairInfo definitions, which each consisting of both R1 & R1 pairs.
+ *
+ * @param uploadedFilePairs
+ */
+async function generatePairedReadsSampleSheetCsv(uploadedFilePairs: UploadedFilePairInfo[]): Promise<string> {
+  /**
+   * Iterate over the supplied list of UploadedFiles to check the paired R1 & R2 files exist, and generate CSV sample-sheet row record.
    */
   const sampleSheetCsvData: string[] = (
     await Promise.all(
@@ -116,15 +203,34 @@ async function generateSampleSheetCsv(uploadedFilePairs: UploadedFilePairInfo[])
         const r1 = uploadedFilePair.R1;
         const r2 = uploadedFilePair.R2;
 
-        const validPair: boolean[] = await Promise.all([
+        // Check the paired-read R1 and R2 details are supplied
+        if (!(r1 && r2)) {
+          throw new InvalidRequestError('Paired read R1/R2 sample file(s) undefined');
+        }
+
+        // Check the paired-read R1 & R2 files starts with the supplied SampleId
+        const r1FileName: string = r1.Key.split('/').pop();
+        const r2FileName: string = r2.Key.split('/').pop();
+        if (!r1FileName.startsWith(uploadedFilePair.SampleId)) {
+          throw new InvalidRequestError(
+            `Sample Id '${uploadedFilePair.SampleId}' does not match paired-read R1 sample file: ${r1.Key}`,
+          );
+        }
+        if (!r2FileName.startsWith(uploadedFilePair.SampleId)) {
+          throw new InvalidRequestError(
+            `Sample Id '${uploadedFilePair.SampleId}' does not match paired-read R2 sample file: ${r2.Key}`,
+          );
+        }
+
+        // Check the paired-read R1 & R2 files exist in the S3 Bucket / Key location
+        const pairedReadFilesExist: boolean[] = await Promise.all([
           s3Service.doesObjectExist({ Bucket: r1.Bucket, Key: r1.Key }),
           s3Service.doesObjectExist({ Bucket: r2.Bucket, Key: r2.Key }),
         ]);
-
-        if (validPair[0] === false) {
-          throw new Error(`Uploaded R1 sample file not found: ${r1.Key}`);
-        } else if (validPair[1] === false) {
-          throw new Error(`Uploaded R2 sample file not found: ${r2.Key}`);
+        if (pairedReadFilesExist[0] === false) {
+          throw new InvalidRequestError(`Paired read R1 sample file not found: ${r1.Key}`);
+        } else if (pairedReadFilesExist[1] === false) {
+          throw new InvalidRequestError(`Paired read R2 sample file not found: ${r2.Key}`);
         } else {
           return `${uploadedFilePair.SampleId}, ${r1.S3Url}, ${r2.S3Url}`; // CSV Sample-Sheet row
         }

--- a/packages/back-end/src/app/controllers/easy-genomics/upload/create-file-upload-sample-sheet.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/upload/create-file-upload-sample-sheet.lambda.ts
@@ -93,6 +93,7 @@ export const handler: Handler = async (
           Path: s3Path,
           Region: s3Region,
           S3Url: s3Url,
+          SampleSheetType: sampleSheetType,
         },
       };
       return buildResponse(200, JSON.stringify(response), event);

--- a/packages/shared-lib/src/app/schema/easy-genomics/upload/s3-file-upload-sample-sheet.ts
+++ b/packages/shared-lib/src/app/schema/easy-genomics/upload/s3-file-upload-sample-sheet.ts
@@ -11,12 +11,12 @@ export const UploadedFileInfoSchema = z
   })
   .strict();
 
-// DNA Sequenced R1 & R2 file pair of UploadedFileInfoSchema type
+// DNA Sequenced single read or paired R1 & R2 reads for UploadedFileInfoSchema type
 export const UploadedFilePairInfoSchema = z
   .object({
     SampleId: z.string(),
-    R1: UploadedFileInfoSchema,
-    R2: UploadedFileInfoSchema,
+    R1: UploadedFileInfoSchema.optional().nullable(),
+    R2: UploadedFileInfoSchema.optional().nullable(),
   })
   .strict();
 

--- a/packages/shared-lib/src/app/types/easy-genomics/upload/s3-file-upload-sample-sheet.d.ts
+++ b/packages/shared-lib/src/app/types/easy-genomics/upload/s3-file-upload-sample-sheet.d.ts
@@ -35,4 +35,5 @@ export type SampleSheetInfo = {
   Key: string;
   Region: string;
   S3Url: string;
+  SampleSheetType: string;
 };


### PR DESCRIPTION
## Update create-file-upload-sample-sheet API to support single-read / paired-read files
This PR updates the `/easy-genomics/upload/create-file-upload-sample-sheet` API to support single-read and paired-read sequenced files to generate the sample-sheet CSV file.

It also adds data validation and improved error messaging for the FE to handle as necessary.

## Type of Change*
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [X] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
This API will now handle requests that define:
 - one or more single R1 files
 - one or more paired R1 and R2 files

All other scenarios will return an InvalidRequest (HTTP 400) error with the appropriate message.

The sample-sheet generation also checks if the R1 / R2 file starts with the supplied `SampleId` value, and if it doesn't it will also return an InvalidRequest (HTTP 400) error.

The API's response has also been enhanced to include the `SampleSheetType` property that will either have: a `single-read` or a `paired-read` value.

## Testing*
See associated JIRA ticket for testing instructions.

## Impact
None.

## Additional Information
This API is dependent on the FE supplying the `SampleId` and it uses this value to check if the R1 / R2 file starts with the `SampleId`. 

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.