### PR TITLE
fix(EG-996): fix Seqera Pipeline launch regression

### DIFF
--- a/packages/back-end/src/app/controllers/nf-tower/workflow/create-workflow-execution.lambda.ts
+++ b/packages/back-end/src/app/controllers/nf-tower/workflow/create-workflow-execution.lambda.ts
@@ -75,7 +75,7 @@ export const handler: Handler = async (
     console.log('createWorkflowLaunchRequest:', createWorkflowLaunchRequest);
 
     // Retrieve Seqera Cloud / NextFlow Tower AccessToken from SSM
-    const getParameterResponse: GetParameterCommandOutput = await ssmService
+    const getParameterResponse: GetParameterCommandOutput | void = await ssmService
       .getParameter({
         Name: `/easy-genomics/organization/${laboratory.OrganizationId}/laboratory/${laboratory.LaboratoryId}/nf-access-token`,
         WithDecryption: true,
@@ -88,7 +88,7 @@ export const handler: Handler = async (
         }
       });
 
-    const accessToken: string | undefined = getParameterResponse.Parameter?.Value;
+    const accessToken: string | undefined = getParameterResponse ? getParameterResponse.Parameter?.Value : undefined;
     if (!accessToken) {
       throw new LaboratoryAccessTokenUnavailableError();
     }

--- a/packages/back-end/src/app/controllers/nf-tower/workflow/create-workflow-execution.lambda.ts
+++ b/packages/back-end/src/app/controllers/nf-tower/workflow/create-workflow-execution.lambda.ts
@@ -10,6 +10,7 @@ import {
   LaboratoryNotFoundError,
   MissingNextFlowTowerAccessError,
   RequiredIdNotFoundError,
+  SeqeraApiError,
   UnauthorizedAccessError,
 } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
 import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
@@ -100,7 +101,9 @@ export const handler: Handler = async (
       REST_API_METHOD.POST,
       { Authorization: `Bearer ${accessToken}` },
       createWorkflowLaunchRequest, // Delegate request body validation to Seqera Cloud / NextFlow Tower
-    );
+    ).catch((error: any) => {
+      throw new SeqeraApiError(error.message);
+    });
 
     return buildResponse(200, JSON.stringify(response), event);
   } catch (err: any) {

--- a/packages/back-end/src/app/utils/rest-api-utils.ts
+++ b/packages/back-end/src/app/utils/rest-api-utils.ts
@@ -59,7 +59,7 @@ export async function httpRequest<T>(
       case 204: // No Content
         return <T>{};
       default:
-        throw new Error(`${response.status} ${JSON.stringify(response.body)}`.trim());
+        throw new Error(`${response.status} ${response.statusText}: ${await response.text()}`);
     }
   } catch (error: any) {
     console.error(error.message);

--- a/packages/front-end/src/app/components/EGRunPipelineFormReview.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineFormReview.vue
@@ -29,7 +29,17 @@
   const wipSeqeraRun = computed<WipSeqeraRunData | undefined>(() => runStore.wipSeqeraRuns[seqeraRunTempId]);
   const pipeline = computed<SeqeraPipeline | undefined>(() => seqeraPipelineStore.pipelines[props.pipelineId]);
 
-  const paramsText = JSON.stringify(props.params);
+  // Explicitly remove Seqera pipeline paramsText properties that contain variable references
+  const paramsFiltered = Object.entries(props.params)
+    // Sanity check to ensure key-value parameters
+    .filter((param: string[]) => param.length == 2)
+    // Filtering out properties where the value contains variable '${...}' references
+    .filter((param: string[]) => !(typeof param[1] === 'string' && param[1].match(/\${(.*?)*\}/)))
+    // Remove null entries
+    .filter((el) => el != null)
+    // Convert array to JSON Object that respects the value type
+    .reduce((o, [key, value]) => ({ ...o, [key]: value }), {});
+  const paramsText = JSON.stringify(paramsFiltered);
   const schema = JSON.parse(JSON.stringify(props.schema));
 
   const schemaDefinitions = schema.$defs || schema.definitions;

--- a/packages/front-end/src/app/components/EGRunPipelineFormReview.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineFormReview.vue
@@ -34,7 +34,7 @@
     // Sanity check to ensure key-value parameters
     .filter((param: string[]) => param.length == 2)
     // Filtering out properties where the value contains variable '${...}' references
-    .filter((param: string[]) => !(typeof param[1] === 'string' && param[1].match(/\${(.*?)*\}/)))
+    .filter((param: string[]) => !(typeof param[1] === 'string' && param[1].match(/\${([^}]*)\}/)))
     // Remove null entries
     .filter((el) => el != null)
     // Convert array to JSON Object that respects the value type

--- a/packages/shared-lib/src/app/utils/HttpError.ts
+++ b/packages/shared-lib/src/app/utils/HttpError.ts
@@ -443,3 +443,14 @@ export class OmicsWorkflowNotFoundError extends HttpError {
     super(`Workflow '${workflowId}' could not be found`, 404, 'EG-503', messageOpt);
   }
 }
+
+// Seqera Cloud errors
+
+/**
+ * Seqera Cloud API error
+ */
+export class SeqeraApiError extends HttpError {
+  constructor(messageOpt?: string) {
+    super('Seqera Cloud API error', 400, 'EG-600', messageOpt);
+  }
+}


### PR DESCRIPTION
## Title*
Fix Seqera Pipeline launching regression.

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
This PR removes any `paramsText` properties that references variables `${...}` in order to get Seqera Pipelines to launch properly. Without this sanitization the Seqera Launch API will return the error message:

```
{
    "message": "Invalid ParamsText - Overwritten parameters cannot contain referenced values"
}
```

It also improves the handling of the returned error message to aid debugging and error display in the FE.

## Testing*
Perform Seqera Pipeline launch from Easy Genomics and it should be successful.

## Impact
Fixes launching Seqera Pipelines.

## Additional Information
None

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.