### PR TITLE
fix(EG-992): green toast missing on file upload start

### DIFF
--- a/packages/front-end/src/app/components/EGRunFormUploadData.vue
+++ b/packages/front-end/src/app/components/EGRunFormUploadData.vue
@@ -362,6 +362,8 @@
       return;
     }
 
+    toastStore.success('Your files have begun uploading');
+
     await uploadFiles();
 
     await postUploadHook();


### PR DESCRIPTION
## Title*

Fix green toast missing on file upload start

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Smply (re)adds a green toast on file upload commencement

![image](https://github.com/user-attachments/assets/ad733e25-5ac6-41f1-9d77-c994344842ac)

## Testing*

## Impact

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.