### PR TITLE
fix(EG-1006): file upload icon alignment

### DIFF
--- a/packages/front-end/src/app/components/EGRunFormUploadData.vue
+++ b/packages/front-end/src/app/components/EGRunFormUploadData.vue
@@ -362,6 +362,8 @@
       return;
     }
 
+    toastStore.success('Your files have begun uploading');
+
     await uploadFiles();
 
     await postUploadHook();

--- a/packages/front-end/src/app/components/EGRunFormUploadData.vue
+++ b/packages/front-end/src/app/components/EGRunFormUploadData.vue
@@ -815,16 +815,33 @@
             </template>
             {{ row.fileName }}
           </div>
-          <div class="file-cell flex w-[10%] items-center justify-end gap-2">
+
+          <div class="file-cell flex w-[10%] items-center justify-end gap-4">
             <!-- retry button -->
             <button
               v-if="row.error"
-              class="mr-2"
               :class="[canRetryUpload(row) ? 'text-gray-900 hover:text-gray-700' : 'cursor-not-allowed text-gray-400']"
               @click="retryUpload(row)"
               :disabled="!isOnline || !canRetryUpload(row)"
             >
               <UIcon name="i-heroicons-arrow-path" size="20" />
+            </button>
+
+            <!-- complete check -->
+            <UIcon
+              v-if="!row.error && row.progress === 100"
+              size="20"
+              name="i-heroicons-check"
+              class="text-alert-success-text"
+            />
+
+            <!-- cancel upload button -->
+            <button
+              v-if="!row.error && row.progress && row.progress < 100"
+              class="text-gray-500 hover:text-gray-700"
+              @click="cancelUpload(row.fileName)"
+            >
+              <UIcon name="i-heroicons-x-mark" size="20" />
             </button>
 
             <!-- delete button -->
@@ -838,17 +855,6 @@
               @click="removeFile(row)"
             >
               <UIcon name="i-heroicons-trash" size="20" />
-            </button>
-
-            <!-- complete check -->
-            <UIcon
-              v-if="!row.error && row.progress === 100"
-              size="20"
-              name="i-heroicons-check"
-              class="text-alert-success-text"
-            />
-            <button v-else class="text-gray-500 hover:text-gray-700" @click="cancelUpload(row.fileName)">
-              <UIcon name="i-heroicons-x" size="20" />
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Title*

Fix file upload icon alignment and re-enable cancel upload button

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [X] UI/UX improvement

## Description

Makes the alignment of all the icons on uploaded files consistent.

Also stumbled upon the cancel upload button that wasn't rendering and fixed that.

![image](https://github.com/user-attachments/assets/0dfb5e04-6be4-4d24-837b-8ca145aa635f)

## Testing*

The only functional change is bringing back the cancel upload button. I tested it and it works.

## Impact

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.