### PR TITLE
feat(EG-1022): remove org and lab names from page header

### DIFF
--- a/packages/front-end/src/app/components/EGHeader.vue
+++ b/packages/front-end/src/app/components/EGHeader.vue
@@ -15,11 +15,9 @@
   const userStore = useUserStore();
   const orgsStore = useOrgsStore();
   const uiStore = useUiStore();
-  const labsStore = useLabsStore();
 
   const { signOutAndRedirect } = useAuth();
   const $router = useRouter();
-  const $route = useRoute();
   const labsPath = '/labs';
   const orgsPath = '/orgs';
 
@@ -112,11 +110,6 @@
       orgId === userStore.currentUserDetails.defaultOrgId && uiStore.isRequestPending('updateDefaultOrg'),
     'bg-background-grey': uiStore.isRequestPending('updateDefaultOrg'),
   });
-
-  const currentLabName = computed<string | null>(() => {
-    const currentLabId = $route.params.labId as string;
-    return labsStore.labs[currentLabId]?.Name ?? null;
-  });
 </script>
 
 <template>
@@ -124,15 +117,6 @@
     <div class="header-container" :class="{ 'flex w-full flex-row items-center justify-between pl-4': props.isAuthed }">
       <template v-if="props.isAuthed">
         <img class="mr-2 w-[140px]" src="@/assets/images/easy-genomics-logo.svg" alt="EasyGenomics logo" />
-
-        <div class="flex flex-col items-center">
-          <div class="text-body text-lg" v-if="!!orgsStore.orgs[userStore.currentOrgId]?.Name">
-            {{ orgsStore.orgs[userStore.currentOrgId].Name }}
-          </div>
-          <div class="text-muted" v-if="currentLabName">
-            {{ currentLabName }}
-          </div>
-        </div>
 
         <div class="flex items-center gap-4">
           <ULink


### PR DESCRIPTION
## Title*

Remove org and lab names from page header

## Type of Change*
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [X] UI/UX improvement

## Description

Now that we have the breadcrumbs showing current org and lab, it's no longer necessary to display them in the page header.

## Testing*

## Impact

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.