### PR TITLE
feat(EG-978): update Step 3 UI to display & validate required parameters

### DIFF
--- a/packages/front-end/src/app/components/EGRunPipelineFormEditParameters.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineFormEditParameters.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   import { ButtonSizeEnum } from '@FE/types/buttons';
-  import { useRunStore } from '@FE/stores';
+  import { useRunStore, useToastStore } from '@FE/stores';
   import { WipSeqeraRunData } from '@FE/stores/run';
 
   const props = defineProps<{
@@ -74,6 +74,17 @@
     );
 
     return filteredProperties.every((property: any) => property.hidden);
+  }
+
+  function onSubmit() {
+    const paramsRequired: string[] = wipSeqeraRun.value?.paramsRequired || [];
+    const missingParams = paramsRequired.filter((paramName: string) => !wipSeqeraRun.value?.params[paramName]);
+
+    if (missingParams.length > 0) {
+      useToastStore().error(`The '${missingParams.shift()}' field is required. Please try again.`);
+    } else {
+      emit('next-step');
+    }
   }
 
   watch(
@@ -168,7 +179,7 @@
           label="Previous step"
           @click="emit('previous-step')"
         />
-        <EGButton :size="ButtonSizeEnum.enum.sm" type="submit" label="Save & Continue" @click="emit('next-step')" />
+        <EGButton :size="ButtonSizeEnum.enum.sm" type="submit" label="Save & Continue" @click="onSubmit" />
       </div>
     </div>
   </div>

--- a/packages/front-end/src/app/components/EGRunPipelineParameterInputs.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineParameterInputs.vue
@@ -42,7 +42,15 @@
         propValues[propName] = false; // Initialize boolean fields to false if not defined
       }
     } else {
-      propValues[propName] = props.params[propName];
+      if (propName === 'input') {
+        // Set initial input with generated param value, then use existing value to maintain any user modifications
+        propValues[propName] = !propValues[propName] ? props.params[propName] : propValues[propName];
+      } else if (propName === 'outdir') {
+        // Set initial outdir with generated param value, then use existing value to maintain any user modifications
+        propValues[propName] = !propValues[propName] ? props.params[propName] : propValues[propName];
+      } else {
+        propValues[propName] = props.params[propName];
+      }
     }
   });
 
@@ -51,14 +59,6 @@
       runStore.wipSeqeraRuns[seqeraRunTempId].params[key] = propValues[key];
     }
   });
-
-  watch(
-    () => runStore.wipSeqeraRuns[seqeraRunTempId].sampleSheetS3Url,
-    () => {
-      runStore.wipSeqeraRuns[seqeraRunTempId].params['input'] =
-        runStore.wipSeqeraRuns[seqeraRunTempId].sampleSheetS3Url;
-    },
-  );
 </script>
 
 <template>
@@ -66,12 +66,17 @@
     <div v-for="(propertyDetail, propertyName) in section.properties" :key="propertyName" class="mb-6">
       <!-- ignore Seqera "file upload" input types -->
       <template v-if="!propertyDetail?.hidden && !usePipeline().isParamsFormatFilePath(propertyDetail.format)">
-        <component
-          :is="components[propertyType(propertyDetail)]"
-          :name="propertyName"
-          :details="propertyDetail"
-          v-model="propValues[propertyName]"
-        />
+        <EGFormGroup
+          :label="propertyName"
+          :required="runStore.wipSeqeraRuns[seqeraRunTempId].paramsRequired.includes(propertyName)"
+        >
+          <component
+            :is="components[propertyType(propertyDetail)]"
+            :name="''"
+            :details="propertyDetail"
+            v-model="propValues[propertyName]"
+          />
+        </EGFormGroup>
       </template>
 
       <!-- Special exception for Seqera "file upload" input type at this point in the schema, used as an S3 bucket
@@ -83,7 +88,13 @@
           propertyName === 'input'
         "
       >
-        <EGInput name="input" v-model="runStore.wipSeqeraRuns[seqeraRunTempId].sampleSheetS3Url" />
+        <EGFormGroup
+          label="input"
+          name="input"
+          :required="runStore.wipSeqeraRuns[seqeraRunTempId].paramsRequired.includes('input')"
+        >
+          <EGInput name="input" v-model="propValues['input']" />
+        </EGFormGroup>
       </template>
     </div>
   </div>

--- a/packages/front-end/src/app/pages/labs/[labId]/run-pipeline/[pipelineId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/run-pipeline/[pipelineId].vue
@@ -94,12 +94,20 @@
       .filter((_) => _)
       .reduce((acc, cur) => ({ ...acc, [Object.keys(cur)[0]]: Object.values(cur)[0] }), {});
 
+    // Identify Seqera pipeline schema required parameters
+    const paramsRequired: string[] = definitions.input_output_options.required
+      ? definitions.input_output_options.required
+      : [];
+
     schema.value = {
       ...originalSchema,
       $defs: filteredDefinitions,
     };
     if (pipelineSchemaResponse.params) {
-      runStore.updateWipSeqeraRun(seqeraRunTempId.value, { params: JSON.parse(pipelineSchemaResponse.params) });
+      runStore.updateWipSeqeraRun(seqeraRunTempId.value, {
+        params: JSON.parse(pipelineSchemaResponse.params),
+        paramsRequired: paramsRequired,
+      });
     }
   }
 

--- a/packages/front-end/src/app/stores/run.ts
+++ b/packages/front-end/src/app/stores/run.ts
@@ -21,6 +21,7 @@ export interface WipSeqeraRunData {
   s3Bucket?: string;
   s3Path?: string;
   files?: FilePair[];
+  paramsRequired: string[];
 }
 
 export interface WipOmicsRunData {
@@ -34,6 +35,7 @@ export interface WipOmicsRunData {
   s3Bucket?: string;
   s3Path?: string;
   files?: FilePair[];
+  paramsRequired: string[];
 }
 
 interface RunState {


### PR DESCRIPTION
## Title*
Update Step 3 UI to display & validate required parameters for Seqera Pipelines and AWS HealthOmics Workflows

## Type of Change*
- [X] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
This PR adds the display of `*` along side the name of required parameters for Seqera Pipelines and AWS HealthOmics Workflows, and adds validation logic to check the required parameters are not empty. If there are empty required parameters it will display an error dialog message indicating which need to be updated.

This PR has been updated to also fix some existing bugs with the Seqera Pipeline Step 3 form behaviour:
* Updating the `input` field no longer changes the generated sample-sheet url value.
* Pass through the updated values to Step 4, and retain the updated values if switching back to Step 3.

## Testing*
Test launching a Seqera Pipeline or AWS HealthOmics Workflow using the Easy Genomics stepper UI.

## Impact
None.

## Additional Information
None.

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.