### PR TITLE
fix(EG-929): regression stopping green toasts from getting dismissed by clicking anywhere

### DIFF
--- a/packages/front-end/src/app/components/EGToast.vue
+++ b/packages/front-end/src/app/components/EGToast.vue
@@ -107,7 +107,7 @@
   <!-- invisible full screen overlay to pick up clicks and dismiss the green toast -->
   <div
     v-if="variant === 'success'"
-    class="z-99999 fixed bottom-px left-px right-px top-px"
+    class="z-99999 pointer-events-auto fixed bottom-px left-px right-px top-px"
     @click.stop="callback"
   ></div>
 


### PR DESCRIPTION
## Title*

Fix regression stopping green toasts from getting dismissed by clicking anywhere

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

I broke the green toast dismiss by click anywhere when I implemented the breadcrumbs because the invisible overlay wrapper from the toasts was blocking the breadcrumbs so I disabled the pointer events but that also disabled the green toast hitbox and this fixes that

## Testing*

## Impact

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.