### PR TITLE
fix(EG-851): no labs screen showing two create a lab buttons

### DIFF
--- a/packages/front-end/src/app/pages/labs/index.vue
+++ b/packages/front-end/src/app/pages/labs/index.vue
@@ -1,16 +1,19 @@
 <script setup lang="ts">
   const $router = useRouter();
+
+  const userStore = useUserStore();
+  const labsStore = useLabsStore();
 </script>
 
 <template>
   <EGPageHeader title="Labs" :show-back="false">
     <EGButton
-      v-if="useUserStore().canCreateLab()"
+      v-if="userStore.canCreateLab() && labsStore.labsForOrg(userStore.currentOrgId!).length > 0"
       label="Create a new Lab"
       class="self-end"
       @click="() => $router.push({ path: `/labs/create` })"
     />
   </EGPageHeader>
 
-  <EGLabsList :org-id="useUserStore().currentOrgId" />
+  <EGLabsList :org-id="userStore.currentOrgId" />
 </template>


### PR DESCRIPTION
## Title*

Removes the redundant extra create lab button at the top right

![image](https://github.com/user-attachments/assets/bc030623-143d-4e7e-9c5f-5b4724776ded)


## Type of Change*
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [X] UI/UX improvement

## Description

## Testing*

## Impact

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.