### PR TITLE
feat(EG-703): add url bar loading state 

### DIFF
--- a/packages/front-end/src/app/components/EGButton.vue
+++ b/packages/front-end/src/app/components/EGButton.vue
@@ -129,6 +129,7 @@
   }
 
   .button-gradient:not([disabled]):hover {
+    background-color: #5524e0;
     background-position: -250px 0px; /* Note: this will not look right if a button ever gets wider than 250px */
   }
 </style>

--- a/packages/front-end/src/app/components/EGRunFormUploadData.vue
+++ b/packages/front-end/src/app/components/EGRunFormUploadData.vue
@@ -100,15 +100,17 @@
     filePairs.value.some((filePair) => filePair.r1File && filePair.r2File),
   );
 
+  const areAllFilesUploaded = computed(() => filesNotUploaded.value.length === 0);
+
+  const areAllPairsComplete = computed<boolean>(() => {
+    return filePairs.value.every((pair) => pair.r1File);
+  });
+
   const canProceedToNextStep = computed<boolean>(() => {
     // Check both conditions:
     // 1. All existing files are uploaded successfully
     // 2. All pairs are complete (have both R1 and R2)
-    return areAllFilesUploaded.value && areAllPairsComplete.value;
-  });
-
-  const areAllPairsComplete = computed<boolean>(() => {
-    return filePairs.value.every((pair) => pair.r1File);
+    return areAllFilesUploaded.value && areAllPairsComplete.value && hasSampleSheetUrl.value;
   });
 
   // overall upload status for all files
@@ -160,9 +162,6 @@
 
     return noInternet || noFiles || hasIncompletePairs || hasBothSinglesAndPairs || isUploading;
   });
-
-  // Add a computed property to check if all file pairs are complete and all files are successfully uploaded
-  const areAllFilesUploaded = computed(() => filesNotUploaded.value.length === 0);
 
   // reset files error states
   function clearErrorsFromFiles(files: FileDetails[]) {
@@ -862,7 +861,7 @@
     </div>
 
     <EGS3SampleSheetBar
-      v-if="hasSampleSheetUrl"
+      v-if="uploadStatus === 'success'"
       :disabled="uploadStatus === 'uploading'"
       :url="localProps.wipRun.sampleSheetS3Url"
       :lab-id="localProps.labId"

--- a/packages/front-end/src/app/components/EGS3SampleSheetBar.vue
+++ b/packages/front-end/src/app/components/EGS3SampleSheetBar.vue
@@ -22,6 +22,8 @@
   const isCopied = ref(false);
 
   const copyToClipboard = async () => {
+    if (!props.url) return;
+
     try {
       await navigator.clipboard.writeText(props.url);
       isCopied.value = true;
@@ -34,6 +36,8 @@
   };
 
   const openSampleSheet = () => {
+    if (!props.url) return;
+
     const baseUrl = window.location.origin;
     const url = router.resolve({
       path: `/labs/${props.labId}/run-pipeline/sample-sheet`,
@@ -78,7 +82,7 @@
 
       <div class="flex items-center gap-4" role="group" aria-label="URL Actions">
         <button
-          @click="url ? openSampleSheet : null"
+          @click="openSampleSheet"
           class="cursor-pointer"
           :class="{ 'opacity-50': !url }"
           aria-label="Open in new tab"
@@ -95,7 +99,7 @@
           </svg>
         </button>
         <button
-          @click="url ? copyToClipboard : null"
+          @click="copyToClipboard"
           class="cursor-pointer"
           :class="{ 'opacity-50': !url }"
           aria-label="Copy to clipboard"

--- a/packages/front-end/src/app/components/EGS3SampleSheetBar.vue
+++ b/packages/front-end/src/app/components/EGS3SampleSheetBar.vue
@@ -52,7 +52,8 @@
 
 <template>
   <div class="sample-sheet-bar">
-    <EGText tag="h5" class="mb-2">Sample Sheet:</EGText>
+    <EGText v-if="hasSampleSheetUrl" tag="h5" class="mb-2">Sample Sheet:</EGText>
+    <EGText v-else tag="h5" class="mb-2">Sample Sheet now generating, please wait...</EGText>
     <div
       :class="[{ 'pointer-events-none opacity-50': disabled }]"
       class="border-r-1 bg-primary-muted mb-4 flex items-center justify-between rounded p-4"
@@ -64,7 +65,11 @@
         tabindex="0"
         :aria-label="`Copy URL: ${url}`"
       >
-        {{ url }}
+        <div v-if="url">{{ url }}</div>
+        <div v-else class="flex">
+          <USkeleton class="mb-2 h-2 w-[500px] rounded" />
+          <USkeleton class="h-2 w-[400px] rounded" />
+        </div>
         <div :class="{ copied: true, show: isCopied }" role="status" aria-live="polite" class="flex items-center gap-1">
           Copied
           <UIcon name="i-heroicons-check-20-solid" class="h-4 w-4 text-white" />
@@ -72,7 +77,12 @@
       </div>
 
       <div class="flex items-center gap-4" role="group" aria-label="URL Actions">
-        <button @click="openSampleSheet" class="cursor-pointer" aria-label="Open in new tab">
+        <button
+          @click="hasSampleSheetUrl ? openSampleSheet : null"
+          class="cursor-pointer"
+          :class="{ 'opacity-50': !hasSampleSheetUrl }"
+          aria-label="Open in new tab"
+        >
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="25" viewBox="0 0 24 25" fill="none">
             <path
               d="M20.2916 12.5C19.9004 12.5 19.5833 12.8171 19.5833 13.2084V19.5833H5.41674V5.41674H11.7916C12.1829 5.41674 12.5 5.09959 12.5 4.70837C12.5 4.31715 12.1829 4 11.7916 4H5.41674C4.63771 4 4 4.6375 4 5.41674V19.5835C4 20.3623 4.63771 21 5.41674 21H19.5833C20.3623 21 21 20.3623 21 19.5833V13.2084C21 12.8171 20.6829 12.5 20.2916 12.5Z"
@@ -84,7 +94,12 @@
             />
           </svg>
         </button>
-        <button @click="copyToClipboard" class="cursor-pointer" aria-label="Copy to clipboard">
+        <button
+          @click="hasSampleSheetUrl ? copyToClipboard : null"
+          class="cursor-pointer"
+          :class="{ 'opacity-50': !hasSampleSheetUrl }"
+          aria-label="Copy to clipboard"
+        >
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="25" viewBox="0 0 24 25" fill="none">
             <path
               fill-rule="evenodd"

--- a/packages/front-end/src/app/components/EGS3SampleSheetBar.vue
+++ b/packages/front-end/src/app/components/EGS3SampleSheetBar.vue
@@ -52,7 +52,7 @@
 
 <template>
   <div class="sample-sheet-bar">
-    <EGText v-if="hasSampleSheetUrl" tag="h5" class="mb-2">Sample Sheet:</EGText>
+    <EGText v-if="url" tag="h5" class="mb-2">Sample Sheet:</EGText>
     <EGText v-else tag="h5" class="mb-2">Sample Sheet now generating, please wait...</EGText>
     <div
       :class="[{ 'pointer-events-none opacity-50': disabled }]"
@@ -66,7 +66,7 @@
         :aria-label="`Copy URL: ${url}`"
       >
         <div v-if="url">{{ url }}</div>
-        <div v-else class="flex">
+        <div v-else class="flex flex-col">
           <USkeleton class="mb-2 h-2 w-[500px] rounded" />
           <USkeleton class="h-2 w-[400px] rounded" />
         </div>
@@ -78,9 +78,9 @@
 
       <div class="flex items-center gap-4" role="group" aria-label="URL Actions">
         <button
-          @click="hasSampleSheetUrl ? openSampleSheet : null"
+          @click="url ? openSampleSheet : null"
           class="cursor-pointer"
-          :class="{ 'opacity-50': !hasSampleSheetUrl }"
+          :class="{ 'opacity-50': !url }"
           aria-label="Open in new tab"
         >
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="25" viewBox="0 0 24 25" fill="none">
@@ -95,9 +95,9 @@
           </svg>
         </button>
         <button
-          @click="hasSampleSheetUrl ? copyToClipboard : null"
+          @click="url ? copyToClipboard : null"
           class="cursor-pointer"
-          :class="{ 'opacity-50': !hasSampleSheetUrl }"
+          :class="{ 'opacity-50': !url }"
           aria-label="Copy to clipboard"
         >
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="25" viewBox="0 0 24 25" fill="none">


### PR DESCRIPTION
## Title*
Add loading state to URL bar until sample sheet URL has been generated. 

## Type of Change*
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [X] UI/UX improvement

## Description
UX behaviour now displays a loading state in the URL bar when uploaded files are in a `success` state and keeps the "Next" button in a disabled state. One the URL becomes available both these boolean states turn `true` and the user can proceed to Step 3.

![image](https://github.com/user-attachments/assets/d46a2837-390a-45b6-8b1b-89e7ea7980e8)


## Testing*
Manually tested by throttling network requests and simulating behaviour in browser.

## Additional Information
Also contains a small improvement to the primary button hover to smooth out hover transition.

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.