### PR TITLE
fix: control run stepper tab styling manually and simplify tab switching

### DIFF
--- a/packages/front-end/src/app/components/EGRunWorkflowStepper.vue
+++ b/packages/front-end/src/app/components/EGRunWorkflowStepper.vue
@@ -68,7 +68,12 @@
       tab: {
         base: 'font-serif w-auto mr-3 rounded-xl border border-solid',
         background: '',
-        active: 'text-white bg-primary border-primary',
+
+        // TODO: this is a hotfix for what seems to be a bug with UTabs where it reports the wrong tab as selected
+        // we have to handle the styling manually ourselves
+        // active: 'text-white bg-primary border-primary',
+        active: '',
+
         inactive: 'font-serif text-text-body border-background-dark-grey',
         height: '',
         padding: 'px-5 py-2',
@@ -76,22 +81,6 @@
       },
     },
   };
-
-  const selected = computed({
-    get() {
-      return clampIndex(selectedIndex.value);
-    },
-    set(index) {
-      if (!isStepValid(items.value[index].key)) {
-        for (let i = index; i < items.value.length; i++) {
-          setStepEnabled(items.value[i].key, false);
-        }
-      } else {
-        enableSelectedItem(index);
-        selectedIndex.value = index;
-      }
-    },
-  });
 
   /**
    * Set the enabled state of a step in the stepper
@@ -120,26 +109,9 @@
     }
   }
 
-  function enableSelectedItem(index: number) {
-    const selectedItem = items.value.find((_, i) => i === index);
-    if (selectedItem?.disabled) {
-      selectedItem.disabled = false;
-    }
-  }
-
-  function isStepValid(step: string) {
-    const stepItem = items.value.find((item) => item.key === step);
-
-    if (!stepItem) {
-      return false;
-    }
-
-    return !stepItem.disabled;
-  }
-
   function nextStep(val: string) {
     setStepEnabled(val, true);
-    selected.value = Math.min(items.value.length - 1, selectedIndex.value + 1);
+    selectedIndex.value = clampIndex(selectedIndex.value + 1);
   }
 
   function clampIndex(index: number) {
@@ -147,7 +119,7 @@
   }
 
   function previousStep() {
-    selected.value = clampIndex(selected.value - 1);
+    selectedIndex.value = clampIndex(selectedIndex.value - 1);
   }
 
   function disableAllSteps() {
@@ -178,9 +150,12 @@
 
 <template>
   <div :key="resetKey">
-    <UTabs v-model="selected" :items="items" :ui="EGTabsStyles" class="UTabs">
+    <UTabs :items="items" :ui="EGTabsStyles" class="UTabs" v-model="selectedIndex">
       <template #default="{ item, index, selected }">
-        <div class="relative flex items-center gap-2 truncate">
+        <div
+          class="relative flex items-center gap-2 truncate"
+          :class="selectedIndex === index && !hasLaunched ? 'active-tab' : ''"
+        >
           <UIcon
             v-if="selectedIndex > index || hasLaunched"
             name="i-heroicons-check-20-solid"
@@ -268,3 +243,12 @@
     </template>
   </div>
 </template>
+
+<style scoped lang="scss">
+  // this styling should be handled by the UTabs :ui, but isn't working correctly - see the EGTabsStyles for info
+  :deep(button:has(> .active-tab)) {
+    color: white;
+    background: #5524e0;
+    border: solid 1px #5524e0;
+  }
+</style>


### PR DESCRIPTION
## Title*

Fix the issue with the run workflow/pipeline stepper highlighting the wrong tab during steps 3 and 4

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

The issue, as far as I can tell, is caused by UTabs misbehaving. This patch controls the styling manually, but it's not a permanent solution.

## Testing*

## Impact

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.