### PR TITLE
fix(EG-991): signing out from run stepper triggering confirm cancel modal

### DIFF
--- a/packages/front-end/src/app/pages/labs/[labId]/run-pipeline/[pipelineId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/run-pipeline/[pipelineId].vue
@@ -46,6 +46,13 @@
    * Intercept any navigation away from the page (including the browser back button) and present the modal
    */
   onBeforeRouteLeave((to, from, next) => {
+    const noConfirmRoutes = ['/signin'];
+
+    if (noConfirmRoutes.some((route) => to.path.startsWith(route))) {
+      next(true);
+      return;
+    }
+
     if (hasLaunched.value) {
       // if the pipeline has launched no need to confirm cancel
       next(true);

--- a/packages/front-end/src/app/pages/labs/[labId]/run-workflow/[workflowId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/run-workflow/[workflowId].vue
@@ -51,6 +51,13 @@
    * Intercept any navigation away from the page (including the browser back button) and present the modal
    */
   onBeforeRouteLeave((to, from, next) => {
+    const noConfirmRoutes = ['/signin'];
+
+    if (noConfirmRoutes.some((route) => to.path.startsWith(route))) {
+      next(true);
+      return;
+    }
+
     if (hasLaunched.value) {
       // if the pipeline has launched no need to confirm cancel
       next(true);


### PR DESCRIPTION
## Title*

Fix the confirm cancel run modal popup triggering on signout from run stepper pages

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

If the navigation to path starts with `/signin` it will go ahead without confirmation

## Testing*

## Impact

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.