### PR TITLE
fix(EG-1032): allow toggling org admin on invited users

### DIFF
--- a/packages/front-end/src/app/components/EGUserAccess.vue
+++ b/packages/front-end/src/app/components/EGUserAccess.vue
@@ -284,7 +284,7 @@
         <UToggle
           class="ml-2"
           :model-value="!!selectedUserOrgAdmin"
-          :disabled="selectedUserOrgAdmin === null || useUiStore().anyRequestPending(['updateUser', 'toggleOrgAdmin'])"
+          :disabled="useUiStore().anyRequestPending(['updateUser', 'toggleOrgAdmin'])"
           :ui="{
             base: 'test-org-admin-toggle',
           }"


### PR DESCRIPTION
## Title*

Allow toggling org admin on invited users

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

This is needed so that the superuser setting up a new org can set the first user(s) to org admins straight away, before the invitations are accepted

## Testing*

I toggled admin on an invited user and it seemed to work fine

## Impact

This change is intended for the superuser but applies to any user that can toggle org admin.

It mutates user records for users that are on status = INVITED, which we don't normally do.

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.