### PR TITLE
fix(EG-844): hide hidden params from run pipeline step 4

### DIFF
--- a/packages/front-end/src/app/components/EGRunPipelineFormReview.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineFormReview.vue
@@ -174,14 +174,16 @@
       <template #item="{ item, open }">
         <section class="stroke-light flex flex-col bg-white text-left">
           <dl>
-            <div
-              v-for="(property, propertyKey, index) in item.content.properties"
-              :key="`property-${propertyKey}`"
-              class="property-row grid grid-cols-[auto_1fr] gap-x-4 border-b bg-white px-4 py-4 last:border-0 dark:bg-gray-800"
-            >
-              <dt class="w-56 whitespace-pre-wrap break-words font-medium text-black">{{ propertyKey }}</dt>
-              <dd class="text-muted whitespace-pre-wrap break-words">{{ params[propertyKey] }}</dd>
-            </div>
+            <template v-for="(property, propertyKey, index) in item.content.properties">
+              <div
+                v-if="!property.hidden"
+                :key="`property-${propertyKey}`"
+                class="property-row grid grid-cols-[auto_1fr] gap-x-4 border-b bg-white px-4 py-4 last:border-0 dark:bg-gray-800"
+              >
+                <dt class="w-56 whitespace-pre-wrap break-words font-medium text-black">{{ propertyKey }}</dt>
+                <dd class="text-muted whitespace-pre-wrap break-words">{{ params[propertyKey] }}</dd>
+              </div>
+            </template>
           </dl>
         </section>
       </template>


### PR DESCRIPTION
## Title*

A Seqera pipeline's hidden fields were not shown on the input step, but were shown on the review step; now they are not

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

See title

## Testing*

I tested on the Seqera pipeline `k-florek_workshop-build2`, which has the hidden field `email`. It initially appeared in the review step. After this fix it was not rendered.

## Impact

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.