### PR TITLE
fix(EG-981): fix user multi-org activation

### DIFF
--- a/packages/back-end/src/app/services/easy-genomics/platform-user-service.ts
+++ b/packages/back-end/src/app/services/easy-genomics/platform-user-service.ts
@@ -45,6 +45,7 @@ export class PlatformUserService extends DynamoDBService {
         [organizationUser.OrganizationId]: {
           Status: organizationUser.Status,
           LaboratoryAccess: {},
+          OrganizationAdmin: false,
         },
       },
     };

--- a/packages/back-end/src/app/services/easy-genomics/platform-user-service.ts
+++ b/packages/back-end/src/app/services/easy-genomics/platform-user-service.ts
@@ -1,4 +1,5 @@
 import { marshall } from '@aws-sdk/util-dynamodb';
+import { OrgUserStatus } from '@easy-genomics/shared-lib/src/app/types/base-entity';
 import { LaboratoryUser } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory-user';
 import { OrganizationUser } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/organization-user';
 import {
@@ -337,6 +338,106 @@ export class PlatformUserService extends DynamoDBService {
     } else {
       throw new Error(`${logRequestMessage} unsuccessful: HTTP Status Code=${response.$metadata.httpStatusCode}`);
     }
+  }
+
+  /**
+   * This function creates a DynamoDB transaction to:
+   *  - update the existing User to update multiple OrganizationAccess meta-data Status to 'Active' or 'Inactive'
+   *  - update the multiple Organization-User access mapping records Status to 'Active' or 'Inactive'
+   *
+   * This function is dependent on the caller to supply the User's details updated OrganizationAccess details for
+   * writing the User record.
+   *
+   * If any part of the transaction fails, the whole transaction will be rejected in order to avoid
+   * data inconsistency.
+   *
+   * @param existingUser
+   * @param organizationUsers
+   */
+  async editExistingUserAccessToOrganizations(
+    existingUser: User,
+    organizationUsers: OrganizationUser[],
+  ): Promise<Boolean> {
+    const logRequestMessage = `Edit Existing User To Organization UserId=${existingUser.UserId} Organizations=[${organizationUsers.map((_: OrganizationUser) => _.OrganizationId).join(', ')}] request`;
+    console.info(logRequestMessage);
+
+    // Retrieve the User's OrganizationAccess metadata to update
+    const existingUserOrganizationAccess: OrganizationAccess | undefined = existingUser.OrganizationAccess;
+    const updatedUserOrganizationAccess: OrganizationAccess = existingUserOrganizationAccess
+      ? this.updateUserOrganizationAccess(existingUserOrganizationAccess, organizationUsers)
+      : {};
+
+    const user: User = {
+      ...existingUser,
+      OrganizationAccess: {
+        ...existingUserOrganizationAccess,
+        ...updatedUserOrganizationAccess,
+      },
+    };
+
+    const response = await this.transactWriteItems({
+      TransactItems: [
+        {
+          // Using PutItem request to update the existing User record for marshalling convenience instead of UpdateItem
+          Put: {
+            TableName: this.USER_TABLE_NAME,
+            ConditionExpression: 'attribute_exists(#UserId)',
+            ExpressionAttributeNames: {
+              '#UserId': 'UserId',
+            },
+            Item: marshall(user),
+          },
+        },
+        // Perform all OrganizationUser updates in one transaction
+        ...organizationUsers.map((orgUser: OrganizationUser) => {
+          return {
+            // Using PutItem request to update the existing OrganizationUser record for marshalling convenience instead of UpdateItem
+            Put: {
+              TableName: this.ORGANIZATION_USER_TABLE_NAME,
+              ConditionExpression: 'attribute_exists(#OrganizationId) AND attribute_exists(#UserId)',
+              ExpressionAttributeNames: {
+                '#OrganizationId': 'OrganizationId',
+                '#UserId': 'UserId',
+              },
+              Item: marshall(orgUser),
+            },
+          };
+        }),
+      ],
+    });
+
+    if (response.$metadata.httpStatusCode === 200) {
+      return true;
+    } else {
+      throw new Error(`${logRequestMessage} unsuccessful: HTTP Status Code=${response.$metadata.httpStatusCode}`);
+    }
+  }
+
+  /**
+   * Private function to help generate updated User OrganizationAccess metadata for multiple Organization activations/deactivations.
+   * @param existingUserOrganizationAccess
+   * @param organizationUsers
+   * @private
+   */
+  private updateUserOrganizationAccess(
+    existingUserOrganizationAccess: OrganizationAccess,
+    organizationUsers: OrganizationUser[],
+  ): OrganizationAccess {
+    // Identify list of OrganizationIds matching OrganizationUsers array to approve for updating
+    const organizationIds: string[] = organizationUsers.map((ou: OrganizationUser) => ou.OrganizationId);
+
+    // Return updated User OrganizationAccess metadata with approved OrganizationAccess activations/deactivations
+    return <OrganizationAccess>Object.entries(existingUserOrganizationAccess)
+      .filter((x: [string, OrganizationAccessDetails]) => organizationIds.includes(x[0]))
+      .reduce((obj: OrganizationAccess, item: [string, OrganizationAccessDetails]) => {
+        const orgId: string = item[0];
+        const orgAccessDetails: OrganizationAccessDetails = item[1];
+
+        const status: OrgUserStatus =
+          organizationUsers.find((_: OrganizationUser) => _.OrganizationId === orgId)?.Status ||
+          orgAccessDetails.Status;
+        return (obj[orgId] = { ...orgAccessDetails, Status: status }), obj;
+      }, {});
   }
 
   /**

--- a/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
@@ -1033,8 +1033,9 @@ export class EasyGenomicsNestedStack extends NestedStack {
       new PolicyStatement({
         resources: [
           `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-organization-user-table`,
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-organization-user-table/index/*`,
         ],
-        actions: ['dynamodb:GetItem', 'dynamodb:PutItem'],
+        actions: ['dynamodb:Query', 'dynamodb:GetItem', 'dynamodb:PutItem'],
         effect: Effect.ALLOW,
       }),
       new PolicyStatement({


### PR DESCRIPTION
## Title*
Fix user invitation to multiple organization activation workflow

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

This PR fixes the user invitation to multiple organization activation workflow to update all `Invited` OrganizationUser mapping records to `Active`, and also update the User's `OrganizationAccess` metadata, which is used to assist user access and switching.

The existing `PlatformUserService` -> `editExistingUserAccessToOrganization(existingUser: User, organizationUser: OrganizationUser)` method is unmodified as it is used to service individual User / OrganizationUser updating.

A new `PlatformUserService` -> `editExistingUserAccessToOrganizations(existingUser: User, organizationUsers: OrganizationUser[])` method was added to efficiently process multiple OrganizationUser invitation activations using the DynamoDB transaction functionality for atomic consistency.

---

This PR also fixes a minor bug when inviting a new User to an Organization where the `OrganizationAdmin` boolean property was missing in the OrganizationAccess metadata, resulting in an undefined property.

## Testing*
See associated JIRA ticket for testing instructions.

## Impact
None.

## Additional Information
None.

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.