### PR TITLE
fix(EG-1038): remove redundant file input change error check

### DIFF
--- a/packages/front-end/src/app/components/EGRunFormUploadData.vue
+++ b/packages/front-end/src/app/components/EGRunFormUploadData.vue
@@ -214,11 +214,6 @@
   }
 
   function handleFileInputChange(e: Event) {
-    if (!e.isTrusted) {
-      console.error('File input change event not trusted');
-      return;
-    }
-
     const target = e.target as HTMLInputElement;
     if (!target) {
       console.error('File input change event target not found');


### PR DESCRIPTION
## Title*
Remove unnecessary `isTrusted` check from file input handler

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
`isTrusted` property is a read-only property of Event objects that indicates whether or not the event was generated by a user action versus programmatically triggered. This error was triggered during a recent demonstration of the product in a closed network environment when attempting to add a file to the upload queue. While the error itself hasn't been reproducible in our dev environment, the handling of the error is largely redundant because:

1. Browser security already prevents programmatic file input manipulation
2. File selection still requires user interaction via system file picker

As such the error event handler can be safely removed to workaround the original issue.

## Testing*
Regression tested the file input mechanism.

## Impact
No security implications as browser-level protections remain in place

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.