### PR TITLE
feat(EG-1005): separate s3 path for aws-healthomics and seqera-platform files

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/upload/create-file-upload-request.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/upload/create-file-upload-request.lambda.ts
@@ -95,9 +95,10 @@ export const handler: Handler = async (
           throw new Error(`File size is too large: '${file.Name}'`);
         } else {
           /**
-           * The S3 Key will consist of: {organizationId}/{laboratoryId}/next-flow/{transactionId}/{file name}
+           * The S3 Key will consist of: {organizationId}/{laboratoryId}/{platform}/{transactionId}/{file name}
            */
-          const s3Path: string = `${laboratory.OrganizationId}/${laboratory.LaboratoryId}/next-flow/${transactionId}`;
+          const platform: string = request.Platform === 'AWS HealthOmics' ? 'aws-healthomics' : 'seqera-platform';
+          const s3Path: string = `${laboratory.OrganizationId}/${laboratory.LaboratoryId}/${platform}/${transactionId}`;
           const s3Key: string = `${s3Path}/${file.Name}`;
 
           const preSignedUrl = await s3Service.getPreSignedUploadUrl({

--- a/packages/back-end/src/app/controllers/easy-genomics/upload/create-file-upload-sample-sheet.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/upload/create-file-upload-sample-sheet.lambda.ts
@@ -56,7 +56,8 @@ export const handler: Handler = async (
       throw new InvalidRequestError(`Laboratory ${laboratoryId} S3 Bucket needs to be configured`);
     }
 
-    const s3Path: string = `${laboratory.OrganizationId}/${laboratory.LaboratoryId}/next-flow/${transactionId}`;
+    const platform: string = request.Platform === 'AWS HealthOmics' ? 'aws-healthomics' : 'seqera-platform';
+    const s3Path: string = `${laboratory.OrganizationId}/${laboratory.LaboratoryId}/${platform}/${transactionId}`;
     const s3Key: string = `${s3Path}/sample-sheet.csv`;
     const s3Url: string = `s3://${s3Bucket}/${s3Key}`;
     const bucketLocation = (await s3Service.getBucketLocation({ Bucket: s3Bucket })).LocationConstraint;

--- a/packages/front-end/src/app/components/EGRunFormUploadData.vue
+++ b/packages/front-end/src/app/components/EGRunFormUploadData.vue
@@ -471,6 +471,7 @@
     const request: SampleSheetRequest = {
       LaboratoryId: props.labId,
       TransactionId: wipRun.value.transactionId,
+      Platform: props.platform,
       UploadedFilePairs: uploadedFilePairs,
     };
 
@@ -483,6 +484,7 @@
     const request: FileUploadRequest = {
       LaboratoryId: props.labId,
       TransactionId: wipRun.value.transactionId,
+      Platform: props.platform,
       Files: files.map((file) => ({ Name: file.name, Size: file.size })),
     };
 

--- a/packages/shared-lib/src/app/schema/easy-genomics/upload/s3-file-upload-manifest.ts
+++ b/packages/shared-lib/src/app/schema/easy-genomics/upload/s3-file-upload-manifest.ts
@@ -10,6 +10,7 @@ export const FileUploadRequestSchema = z
   .object({
     LaboratoryId: z.string().uuid(),
     TransactionId: z.string().uuid(),
+    Platform: z.enum(['AWS HealthOmics', 'Seqera Cloud']),
     Files: z.array(FileInfoSchema),
   })
   .strict();

--- a/packages/shared-lib/src/app/schema/easy-genomics/upload/s3-file-upload-sample-sheet.ts
+++ b/packages/shared-lib/src/app/schema/easy-genomics/upload/s3-file-upload-sample-sheet.ts
@@ -23,6 +23,7 @@ export const SampleSheetRequestSchema = z
   .object({
     LaboratoryId: z.string().uuid(),
     TransactionId: z.string().uuid(),
+    Platform: z.enum(['AWS HealthOmics', 'Seqera Cloud']),
     UploadedFilePairs: z.array(UploadedFilePairInfoSchema),
   })
   .strict();

--- a/packages/shared-lib/src/app/types/easy-genomics/upload/s3-file-upload-manifest.d.ts
+++ b/packages/shared-lib/src/app/types/easy-genomics/upload/s3-file-upload-manifest.d.ts
@@ -1,7 +1,10 @@
 // create-file-upload-request API FileUploadRequest & FileUploadManifest type definitions
+import { RunType } from "@SharedLib/types/base-entity";
+
 export type FileUploadRequest = {
   LaboratoryId: string,
   TransactionId: string,
+  Platform: RunType,
   Files: FileInfo[]
 };
 

--- a/packages/shared-lib/src/app/types/easy-genomics/upload/s3-file-upload-sample-sheet.d.ts
+++ b/packages/shared-lib/src/app/types/easy-genomics/upload/s3-file-upload-sample-sheet.d.ts
@@ -1,8 +1,11 @@
 // create-file-upload-sample-sheet API SampleSheetRequest & SampleSheetResponse type definitions
 
+import { RunType } from "@SharedLib/types/base-entity";
+
 export type SampleSheetRequest = {
   LaboratoryId: string;
   TransactionId: string;
+  Platform: RunType,
   UploadedFilePairs: UploadedFilePairInfo[];
 };
 


### PR DESCRIPTION
## Title*
Separate s3 path for aws-healthomics and seqera-platform files

## Type of Change*
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
This PR updates the S3 paths for file uploads and sample-sheets to replace the hard-coded `'next-flow'` value with the respective `aws-healthomics` or `seqera-platform` value instead.

## Testing*
Perform Seqera Pipeline / AWS HealthOmics Workflow launches, and the S3 Url will include `aws-healthomics` or `seqera-platform` instead of `next-flow`.

This will appear in the Lab Run's S3InputUrl, S3OutputUrl, and the samplesheet contents too for R1 / R2 paths to the uploaded Fastq files.

## Impact
None.

## Additional Information
None.

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.