### PR TITLE
fix(EG-1037): alignment of breadcrumb items with text that overflows the width

### DIFF
--- a/packages/front-end/src/app/components/EGBreadcrumbLabs.vue
+++ b/packages/front-end/src/app/components/EGBreadcrumbLabs.vue
@@ -52,7 +52,7 @@
         </UButton>
       </div>
       <template #item="{ item }">
-        {{ item.Name }}
+        <span class="w-full text-left">{{ item.Name }}</span>
       </template>
     </UDropdown>
   </div>

--- a/packages/front-end/src/app/components/EGBreadcrumbOrgs.vue
+++ b/packages/front-end/src/app/components/EGBreadcrumbOrgs.vue
@@ -63,7 +63,7 @@
         </UButton>
       </div>
       <template #item="{ item }">
-        {{ item.Name }}
+        <span class="w-full text-left">{{ item.Name }}</span>
       </template>
     </UDropdown>
   </div>


### PR DESCRIPTION
## Title*

Fix text alignment of breadcrumb items with text that overflows the width

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Before

![image](https://github.com/user-attachments/assets/8f5814cc-6968-4c68-9408-1279c3a7cd38)

After

![image](https://github.com/user-attachments/assets/732de440-f389-4539-9fcc-1eeec7e50b3b)

![image](https://github.com/user-attachments/assets/7b1ba2cf-d2b2-480d-b2c7-b1e19390f111)

## Testing*

## Impact

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.