### PR TITLE
feat(EG-964): enforce ssl for s3 buckets

### DIFF
--- a/packages/back-end/src/infra/constructs/s3-construct.ts
+++ b/packages/back-end/src/infra/constructs/s3-construct.ts
@@ -23,6 +23,7 @@ export class S3Construct extends Construct {
       bucketKeyEnabled: true,
       autoDeleteObjects: true,
       removalPolicy: removalPolicy,
+      enforceSSL: true,
       lifecycleRules: [
         {
           prefix: 'uploads',


### PR DESCRIPTION
## Title*
Enforce SSL for S3 buckets

## Type of Change*
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [x] Security patch
- [ ] UI/UX improvement

## Description
Enforces SSL for S3 bucket interactions to comply with AWS Audit requirements.

## Testing*
Calling BE api calls that use S3, such as list buckets or files from S3, and via the FE when uploading files as part of creating a run.

## Impact
BE platform interactions with s3 are done via sdk anyway and are already compliant, presigned uploads are already ssl compliant.


## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [ ] Code has been commented in particularly hard-to-understand areas.