### PR TITLE
fix(EG-1066): update create-file-upload-sample-sheet API to validate sample ids for duplicates

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/upload/create-file-upload-sample-sheet.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/upload/create-file-upload-sample-sheet.lambda.ts
@@ -66,6 +66,12 @@ export const handler: Handler = async (
     const s3Region: string = bucketLocation ? bucketLocation : 'us-east-1';
     const sampleSheetType: string = getSampleSheetType(request);
 
+    // Validate SampleSheet request to check for any duplicate SampleIds
+    const sampleIds: string[] = request.UploadedFilePairs.map((_: UploadedFilePairInfo) => _.SampleId);
+    if (sampleIds.length !== [...new Set(sampleIds)].length) {
+      throw new InvalidRequestError('Invalid sample sheet request: duplicate Sample Id(s) found');
+    }
+
     const sampleSheetCsv: string =
       sampleSheetType === 'paired-read'
         ? await generatePairedReadsSampleSheetCsv(request.UploadedFilePairs, validateS3FilesExist)


### PR DESCRIPTION
## Title*
Update create-file-upload-sample-sheet API to validate sample ids for duplicates.

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
This PR adds extra validation checking for duplicate sample ids in the samplesheet request to create a new samplesheet.

If duplicate sample ids are found, then it will throw the following error:
```
{
    "Error": "Invalid request: Invalid sample sheet request: duplicate Sample Id(s) found",
    "ErrorCode": "EG-102"
}
```

## Testing*
Test via Postman to supply duplicate sample Ids in the samplesheet request.

## Impact
None.

## Additional Information
None.

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.