### PR TITLE
fix(EG-1068): error when switching labs from breadcrumb while on a nested lab page eg stepper

### DIFF
--- a/packages/front-end/src/app/components/EGBreadcrumbLabs.vue
+++ b/packages/front-end/src/app/components/EGBreadcrumbLabs.vue
@@ -34,7 +34,7 @@
     // this is flexible enough to work in most different contexts; eg.
     // - normal user: /labs/[labId]
     // - superuser: /orgs/[orgId]/labs/[labId]
-    const newRoute = route.fullPath.replace(/\/labs\/[^\/]+/, `/labs/${labId}`);
+    const newRoute = route.fullPath.replace(/\/labs\/.+/, `/labs/${labId}`);
     router.push(newRoute);
   }
 </script>


### PR DESCRIPTION
## Title*

Fix errors when switching lab via breadcrumb while on a nested lab page

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Previously, the labs breadcrumb replaced only the `/lab/[labId]` part of the url, leaving any trailing characters. If you were on a nested page eg the run stepper, this caused errors.

Now, it replaces everything following `/lab/[labId]` as well so you land on the lab page no matter where you switched from.

## Testing*

## Impact

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.