### PR TITLE
feat(EG-1065): add createdAt column as default sort and make lastUpdated only show changed date

### DIFF
--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -105,6 +105,7 @@
 
   const runsTableColumns = [
     { key: 'RunName', label: 'Run Name', sortable: true, sort: stringSortCompare },
+    { key: 'CreatedAt', label: 'Created At', sortable: true, sort: stringSortCompare },
     { key: 'lastUpdated', label: 'Last Updated', sortable: true, sort: stringSortCompare },
     { key: 'Status', label: 'Status', sortable: true, sort: stringSortCompare },
     { key: 'Owner', label: 'Owner', sortable: true, sort: stringSortCompare },
@@ -553,7 +554,7 @@
           :row-click-action="viewRunDetails"
           :table-data="combinedRuns"
           :columns="runsTableColumns"
-          :sort="{ column: 'lastUpdated', direction: 'desc' }"
+          :sort="{ column: 'CreatedAt', direction: 'desc' }"
           :is-loading="useUiStore().anyRequestPending(['loadLabData', 'loadLabRuns'])"
           :show-pagination="!useUiStore().anyRequestPending(['loadLabData', 'loadLabRuns'])"
         >
@@ -562,9 +563,14 @@
             <div v-if="run.WorkflowName" class="text-muted text-xs font-normal">{{ run.WorkflowName }}</div>
           </template>
 
+          <template #CreatedAt-data="{ row: run }">
+            <div class="text-body text-sm font-medium">{{ getDate(run.CreatedAt) }}</div>
+            <div class="text-muted">{{ getTime(run.CreatedAt) }}</div>
+          </template>
+
           <template #lastUpdated-data="{ row: run }">
-            <div class="text-body text-sm font-medium">{{ getDate(run.ModifiedAt ?? run.CreatedAt) }}</div>
-            <div class="text-muted">{{ getTime(run.ModifiedAt ?? run.CreatedAt) }}</div>
+            <div class="text-body text-sm font-medium">{{ getDate(run.ModifiedAt) }}</div>
+            <div class="text-muted">{{ getTime(run.ModifiedAt) }}</div>
           </template>
 
           <template #Status-data="{ row: run }">


### PR DESCRIPTION
## Title*

Add the CreatedAt column to the lab runs table

## Type of Change*
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

![image](https://github.com/user-attachments/assets/6f229fd4-5179-40cd-8957-394f51ef9b69)

Also changed: LastUpdated used to coalesce `LastUpdated ?? CreatedAt`, but as we now have the CreatedAt in its own column I made LastUpdated just show LastUpdated - see the row above without a LastUpdated value.

## Testing*

## Impact

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.