### PR TITLE
feat(EG-1056): display the sample sheet url to run details with open/copy/download functionality

### DIFF
--- a/packages/front-end/src/app/components/EGRunFormUploadData.vue
+++ b/packages/front-end/src/app/components/EGRunFormUploadData.vue
@@ -13,7 +13,6 @@
     UploadedFilePairInfo,
   } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/upload/s3-file-upload-sample-sheet';
   import { useToastStore } from '@FE/stores';
-  import usePipeline from '@FE/composables/usePipeline';
   import { useNetwork } from '@vueuse/core';
   import { RunType } from '@easy-genomics/shared-lib/src/app/types/base-entity';
 
@@ -44,7 +43,6 @@
   }
 
   const { $api } = useNuxtApp();
-  const { downloadSampleSheet } = usePipeline($api);
   const { isOnline } = useNetwork();
   const { platformToWipRunUpdateFunction, getWipRunForPlatform } = useMultiplatform();
 
@@ -879,17 +877,12 @@
       :lab-id="props.labId"
       :lab-name="labName"
       :pipeline-or-workflow-name="props.pipelineOrWorkflowName"
+      :platform="platform"
       :run-name="wipRun.runName"
+      :display-label="true"
     />
 
     <div class="flex justify-end pt-4">
-      <EGButton
-        v-if="hasSampleSheetUrl"
-        variant="secondary"
-        class="mr-2"
-        label="Download sample sheet"
-        @click="downloadSampleSheet(props.labId, wipRun.sampleSheetS3Url, props.pipelineOrWorkflowName, wipRun.runName)"
-      />
       <EGButton
         @click="startUploadProcess"
         :disabled="isUploadButtonDisabled"

--- a/packages/front-end/src/app/components/EGRunPipelineFormEditParameters.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineFormEditParameters.vue
@@ -121,6 +121,7 @@
     :lab-name="labName"
     :pipeline-or-workflow-name="pipelineName"
     :run-name="wipSeqeraRun.runName"
+    :display-label="true"
   />
 
   <div class="flex">

--- a/packages/front-end/src/app/components/EGRunWorkflowFormEditParameters.vue
+++ b/packages/front-end/src/app/components/EGRunWorkflowFormEditParameters.vue
@@ -92,6 +92,7 @@
     :lab-name="labName"
     :pipeline-or-workflow-name="workflowName"
     :run-name="wipOmicsRun.runName"
+    :display-label="true"
   />
 
   <div class="flex">

--- a/packages/front-end/src/app/components/EGS3SampleSheetBar.vue
+++ b/packages/front-end/src/app/components/EGS3SampleSheetBar.vue
@@ -111,7 +111,13 @@
       </div>
 
       <div class="ml-2 flex items-center gap-4" role="group" aria-label="URL Actions">
-        <button @click="open" class="cursor-pointer" :class="{ 'opacity-50': !url }" aria-label="Open in new tab">
+        <button
+          @click="open"
+          class="cursor-pointer"
+          :class="{ 'opacity-50': !url }"
+          aria-label="Open in new tab"
+          :disabled="isClicked"
+        >
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="25" viewBox="0 0 24 25" fill="none">
             <path
               d="M20.2916 12.5C19.9004 12.5 19.5833 12.8171 19.5833 13.2084V19.5833H5.41674V5.41674H11.7916C12.1829 5.41674 12.5 5.09959 12.5 4.70837C12.5 4.31715 12.1829 4 11.7916 4H5.41674C4.63771 4 4 4.6375 4 5.41674V19.5835C4 20.3623 4.63771 21 5.41674 21H19.5833C20.3623 21 21 20.3623 21 19.5833V13.2084C21 12.8171 20.6829 12.5 20.2916 12.5Z"
@@ -124,7 +130,13 @@
           </svg>
         </button>
 
-        <button @click="copy" class="cursor-pointer" :class="{ 'opacity-50': !url }" aria-label="Copy to clipboard">
+        <button
+          @click="copy"
+          class="cursor-pointer"
+          :class="{ 'opacity-50': !url }"
+          aria-label="Copy to clipboard"
+          :disabled="isClicked"
+        >
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="25" viewBox="0 0 24 25" fill="none">
             <path
               fill-rule="evenodd"
@@ -140,6 +152,7 @@
           class="cursor-pointer"
           :class="{ 'opacity-50': !url }"
           aria-label="Download sample sheet"
+          :disabled="isClicked"
         >
           <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
             <rect width="24" height="24" />

--- a/packages/front-end/src/app/components/EGS3SampleSheetBar.vue
+++ b/packages/front-end/src/app/components/EGS3SampleSheetBar.vue
@@ -1,41 +1,51 @@
 <script setup lang="ts">
+  import usePipeline from '@FE/composables/usePipeline';
+
   const props = withDefaults(
     defineProps<{
       url: string;
       labId: string;
       pipelineOrWorkflowName: string;
+      platform: string;
       runName: string;
       labName: string;
       disabled?: boolean;
+      displayLabel?: boolean;
     }>(),
     {
       url: '',
       labId: '',
       pipelineOrWorkflowName: '',
+      platform: '',
       runName: '',
       labName: '',
       disabled: false,
+      displayLabel: false,
     },
   );
 
   const router = useRouter();
-  const isCopied = ref(false);
+  const isClicked = ref(false);
+  const clickedAction = ref();
+  const { $api } = useNuxtApp();
+  const { downloadSampleSheet } = usePipeline($api);
 
-  const copyToClipboard = async () => {
+  const copy = async () => {
     if (!props.url) return;
 
     try {
       await navigator.clipboard.writeText(props.url);
-      isCopied.value = true;
+      clickedAction.value = 'Copied';
+      isClicked.value = true;
       setTimeout(() => {
-        isCopied.value = false;
+        isClicked.value = false;
       }, 2000);
     } catch (error) {
       console.error('Failed to copy URL:', error);
     }
   };
 
-  const openSampleSheet = () => {
+  const open = () => {
     if (!props.url) return;
 
     const baseUrl = window.location.origin;
@@ -44,25 +54,42 @@
       query: {
         url: props.url,
         pipelineOrWorkflowName: props.pipelineOrWorkflowName,
+        platform: props.platform,
         runName: props.runName,
       },
     });
 
+    clickedAction.value = 'Opening Sample Sheet';
+    isClicked.value = true;
+    setTimeout(() => {
+      isClicked.value = false;
+    }, 2000);
     window.open(baseUrl + url.href, '_blank');
+  };
+
+  const download = () => {
+    clickedAction.value = 'Downloading Sample Sheet';
+    isClicked.value = true;
+    setTimeout(() => {
+      isClicked.value = false;
+    }, 2000);
+    downloadSampleSheet(props.labId, props.url, props.pipelineOrWorkflowName, props.runName);
   };
 </script>
 
 <template>
   <div class="sample-sheet-bar">
-    <EGText v-if="url" tag="h5" class="mb-2">Sample Sheet:</EGText>
-    <EGText v-else tag="h5" class="mb-2">Sample Sheet now generating, please wait...</EGText>
+    <div v-if="props.displayLabel">
+      <EGText v-if="url" tag="h5" class="mb-2">Sample Sheet:</EGText>
+      <EGText v-else tag="h5" class="mb-2">Sample Sheet now generating, please wait...</EGText>
+    </div>
     <div
       :class="[{ 'pointer-events-none opacity-50': disabled }]"
       class="border-r-1 bg-primary-muted mb-4 flex items-center justify-between rounded p-4"
     >
       <div
         class="text-primary hover:text-primary-900 relative cursor-pointer text-xs"
-        @click="copyToClipboard"
+        @click="copy"
         role="button"
         tabindex="0"
         :aria-label="`Copy URL: ${url}`"
@@ -72,19 +99,19 @@
           <USkeleton class="mb-2 h-2 w-[500px] rounded" />
           <USkeleton class="h-2 w-[400px] rounded" />
         </div>
-        <div :class="{ copied: true, show: isCopied }" role="status" aria-live="polite" class="flex items-center gap-1">
-          Copied
+        <div
+          :class="{ copied: true, show: isClicked }"
+          role="status"
+          aria-live="polite"
+          class="flex items-center gap-1"
+        >
+          {{ clickedAction }}
           <UIcon name="i-heroicons-check-20-solid" class="h-4 w-4 text-white" />
         </div>
       </div>
 
       <div class="ml-2 flex items-center gap-4" role="group" aria-label="URL Actions">
-        <button
-          @click="openSampleSheet"
-          class="cursor-pointer"
-          :class="{ 'opacity-50': !url }"
-          aria-label="Open in new tab"
-        >
+        <button @click="open" class="cursor-pointer" :class="{ 'opacity-50': !url }" aria-label="Open in new tab">
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="25" viewBox="0 0 24 25" fill="none">
             <path
               d="M20.2916 12.5C19.9004 12.5 19.5833 12.8171 19.5833 13.2084V19.5833H5.41674V5.41674H11.7916C12.1829 5.41674 12.5 5.09959 12.5 4.70837C12.5 4.31715 12.1829 4 11.7916 4H5.41674C4.63771 4 4 4.6375 4 5.41674V19.5835C4 20.3623 4.63771 21 5.41674 21H19.5833C20.3623 21 21 20.3623 21 19.5833V13.2084C21 12.8171 20.6829 12.5 20.2916 12.5Z"
@@ -96,18 +123,41 @@
             />
           </svg>
         </button>
-        <button
-          @click="copyToClipboard"
-          class="cursor-pointer"
-          :class="{ 'opacity-50': !url }"
-          aria-label="Copy to clipboard"
-        >
+
+        <button @click="copy" class="cursor-pointer" :class="{ 'opacity-50': !url }" aria-label="Copy to clipboard">
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="25" viewBox="0 0 24 25" fill="none">
             <path
               fill-rule="evenodd"
               clip-rule="evenodd"
               d="M20 17.6207C20 18.047 19.6559 18.3923 19.2301 18.3923C18.8044 18.3923 18.4603 18.047 18.4603 17.6207V5.04317H8.94491C8.51915 5.04317 8.17504 4.69787 8.17504 4.27158C8.17504 3.84606 8.51915 3.5 8.94491 3.5H19.2301C19.6558 3.5 19.9999 3.8453 19.9999 4.27158L20 17.6207ZM8.17508 9.24168L6.63 10.7887H8.17508V9.24168ZM4.22967 11.0095C4.08317 11.1538 4 11.3509 4 11.5603V20.7284C4 21.1547 4.34411 21.5 4.76986 21.5H15.6221C16.0478 21.5 16.3934 21.1547 16.3934 20.7284V7.37916C16.3934 6.95288 16.0478 6.60758 15.6221 6.60758H8.94498C8.73516 6.60758 8.54136 6.69161 8.39639 6.83829L4.23045 11.0086L4.22967 11.0095ZM9.71485 8.1508V11.5604C9.71485 11.9867 9.37074 12.332 8.94498 12.332H5.53965V19.9569H14.8521V8.15086L9.71485 8.1508Z"
               fill="#5524E0"
+            />
+          </svg>
+        </button>
+
+        <button
+          @click="download"
+          class="cursor-pointer"
+          :class="{ 'opacity-50': !url }"
+          aria-label="Download sample sheet"
+        >
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <rect width="24" height="24" />
+            <path
+              d="M-1584 -4223C-1584 -4224.1 -1583.1 -4225 -1582 -4225H1954C1955.1 -4225 1956 -4224.1 1956 -4223V2977C1956 2978.1 1955.1 2979 1954 2979H-1582C-1583.1 2979 -1584 2978.1 -1584 2977V-4223Z"
+            />
+            <path
+              d="M-1582 -4224H1954V-4226H-1582V-4224ZM1955 -4223V2977H1957V-4223H1955ZM1954 2978H-1582V2980H1954V2978ZM-1583 2977V-4223H-1585V2977H-1583ZM-1582 2978C-1582.55 2978 -1583 2977.55 -1583 2977H-1585C-1585 2978.66 -1583.66 2980 -1582 2980V2978ZM1955 2977C1955 2977.55 1954.55 2978 1954 2978V2980C1955.66 2980 1957 2978.66 1957 2977H1955ZM1954 -4224C1954.55 -4224 1955 -4223.55 1955 -4223H1957C1957 -4224.66 1955.66 -4226 1954 -4226V-4224ZM-1582 -4226C-1583.66 -4226 -1585 -4224.66 -1585 -4223H-1583C-1583 -4223.55 -1582.55 -4224 -1582 -4224V-4226Z"
+              fill="#5524E0"
+              fill-opacity="0.1"
+            />
+            <rect width="1200" height="2703" transform="translate(-72 -731)" />
+            <path
+              d="M3 16.5V18.75C3 19.3467 3.23705 19.919 3.65901 20.341C4.08097 20.7629 4.65326 21 5.25 21H18.75C19.3467 21 19.919 20.7629 20.341 20.341C20.7629 19.919 21 19.3467 21 18.75V16.5M16.5 12L12 16.5M12 16.5L7.5 12M12 16.5V3"
+              stroke="#5524E0"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
             />
           </svg>
         </button>

--- a/packages/front-end/src/app/pages/labs/[labId]/run/[labRunId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/run/[labRunId].vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
   import { S3Response } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/file/request-list-bucket-objects';
   import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory-run';
+  import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
+  import { useLabsStore, useRunStore, useUiStore } from '@FE/stores';
 
   const $route = useRoute();
   const $router = useRouter();
@@ -8,12 +10,14 @@
   const { handleS3Download } = useFileDownload();
   const { platformToPipelineOrWorkflow } = useMultiplatform();
 
+  const labsStore = useLabsStore();
   const runStore = useRunStore();
   const uiStore = useUiStore();
 
   const labId = $route.params.labId as string;
   const labRunId = $route.params.labRunId as string;
 
+  const lab = computed<Laboratory | null>(() => labsStore.labs[labId] ?? null);
   const labRun = computed<LaboratoryRun | null>(() => runStore.labRuns[labRunId] ?? null);
   // The LaboratoryRun's InputS3Url is the authoritative reference to obtain S3Bucket & S3Prefix for the File Manager
   const inputS3Url: string = labRun.value?.InputS3Url;
@@ -201,12 +205,14 @@
 
             <div :class="rowStyle">
               <dt :class="rowLabelStyle">Sample Sheet</dt>
-              <dd :class="rowContentStyle">
-                <EGButton
-                  label="Download"
-                  variant="secondary"
-                  @click="downloadSampleSheet"
-                  :loading="uiStore.isRequestPending('downloadSampleSheet')"
+              <dd :class="rowContentStyle" style="width: 90%">
+                <EGS3SampleSheetBar
+                  :url="labRun.SampleSheetS3Url"
+                  :lab-id="labId"
+                  :lab-name="lab.labName"
+                  :pipeline-or-workflow-name="labRun.WorkflowName"
+                  :platform="labRun.Platform"
+                  :run-name="labRun.RunName"
                 />
               </dd>
             </div>

--- a/packages/front-end/src/app/pages/labs/[labId]/run/[labRunId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/run/[labRunId].vue
@@ -213,6 +213,7 @@
                   :pipeline-or-workflow-name="labRun.WorkflowName"
                   :platform="labRun.Platform"
                   :run-name="labRun.RunName"
+                  :display-label="false"
                 />
               </dd>
             </div>

--- a/packages/front-end/src/app/pages/labs/[labId]/sample-sheet.vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/sample-sheet.vue
@@ -5,6 +5,7 @@
     metadata: {
       labName: string;
       pipelineOrWorkflowName: string;
+      platform: string;
       runName: string;
     };
   }
@@ -29,7 +30,7 @@
 
   onMounted(async () => {
     try {
-      const { url, pipelineOrWorkflowName, runName } = route.query;
+      const { url, pipelineOrWorkflowName, platform, runName } = route.query;
 
       if (!labId || !url) {
         throw new Error('Missing required parameters');
@@ -58,6 +59,7 @@
         metadata: {
           labName: labName.value,
           pipelineOrWorkflowName: pipelineOrWorkflowName as string,
+          platform: platform as string,
           runName: runName as string,
         },
       };
@@ -73,16 +75,20 @@
       <EGText tag="h3" class="mb-4">Sample Sheet</EGText>
       <div class="mb-8 space-y-1">
         <EGText tag="p">
-          <strong>Run name:</strong>
-          {{ tableData.metadata.runName }}
+          <strong>Laboratory:</strong>
+          {{ tableData.metadata.labName }}
+        </EGText>
+        <EGText tag="p">
+          <strong>Platform:</strong>
+          {{ tableData.metadata.platform }}
         </EGText>
         <EGText tag="p">
           <strong>Pipeline:</strong>
           {{ tableData.metadata.pipelineOrWorkflowName }}
         </EGText>
         <EGText tag="p">
-          <strong>Laboratory:</strong>
-          {{ tableData.metadata.labName }}
+          <strong>Run name:</strong>
+          {{ tableData.metadata.runName }}
         </EGText>
       </div>
       <table>


### PR DESCRIPTION
## Title*
Display the sample sheet url to run details with open/copy/download functionality

## Type of Change*
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
This PR add sample sheet url (aka purple bar) to the Pipeline Run Details page.

The Sample Sheet URL component was modified to improve re-usability in the Pipeline Run Details page, Stepper 2 and Stepper 3 pages, and also extended to support the download functionality.

The Sample Sheet viewer display was also extended to include some extra metadata to provide some context on the samplesheet to aid re-usability in the future.

## Testing*
- Test a new Pipeline/Workflow launch and test the SampleSheet URL functionality to open/copy/download the samplesheet.
- Access a Pipeline Run Details page and test the SampleSheet URL functionality to open/copy/download the samplesheet.

## Impact
None.

## Additional Information
None.

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.