### PR TITLE
feat(EG-1055): open file explorer to /results

### DIFF
--- a/packages/front-end/src/app/components/EGFileExplorer.vue
+++ b/packages/front-end/src/app/components/EGFileExplorer.vue
@@ -26,6 +26,7 @@
       s3Prefix: string;
       s3Contents: S3Response | null;
       isLoading?: boolean;
+      startPath?: string[];
     }>(),
     { isLoading: true },
   );
@@ -37,25 +38,31 @@
   const s3Bucket = props.s3Bucket;
   const s3Prefix = props.s3Prefix;
 
-  const hasOpenedResults = ref(false);
+  const hasOpenedStartPath = ref(false);
 
-  // open file browser to `/results` dir (if present)
+  // open file browser to start path (if present)
   watch(
     () => currentPath.value[0].children,
     (rootDirChildren) => {
-      if (hasOpenedResults.value) return; // only do this once
+      if (hasOpenedStartPath.value) return; // only do this once
+      if (!props.startPath) return;
 
-      // if not at root dir somehow, don't touch it
+      // if not at root dir, don't touch it
       if (currentPath.value.length > 1) {
-        hasOpenedResults.value = true;
+        hasOpenedStartPath.value = true;
         return;
       }
 
-      const resultsChild = rootDirChildren.find((node) => node.type === 'directory' && node.name === 'results');
-      if (!resultsChild) return;
+      let currentChildren = rootDirChildren;
+      for (const step of props.startPath) {
+        const resultsChild = currentChildren.find((node) => node.type === 'directory' && node.name === step);
+        if (!resultsChild) break;
 
-      openDirectory(resultsChild);
-      hasOpenedResults.value = true;
+        openDirectory(resultsChild);
+        currentChildren = resultsChild.children;
+      }
+
+      hasOpenedStartPath.value = true;
     },
   );
 

--- a/packages/front-end/src/app/components/EGFileExplorer.vue
+++ b/packages/front-end/src/app/components/EGFileExplorer.vue
@@ -51,7 +51,7 @@
         return;
       }
 
-      const resultsChild = rootDirChildren.find((node) => node.name === 'results');
+      const resultsChild = rootDirChildren.find((node) => node.type === 'directory' && node.name === 'results');
       if (!resultsChild) return;
 
       openDirectory(resultsChild);

--- a/packages/front-end/src/app/components/EGFileExplorer.vue
+++ b/packages/front-end/src/app/components/EGFileExplorer.vue
@@ -37,6 +37,28 @@
   const s3Bucket = props.s3Bucket;
   const s3Prefix = props.s3Prefix;
 
+  const hasOpenedResults = ref(false);
+
+  // open file browser to `/results` dir (if present)
+  watch(
+    () => currentPath.value[0].children,
+    (rootDirChildren) => {
+      if (hasOpenedResults.value) return; // only do this once
+
+      // if not at root dir somehow, don't touch it
+      if (currentPath.value.length > 1) {
+        hasOpenedResults.value = true;
+        return;
+      }
+
+      const resultsChild = rootDirChildren.find((node) => node.name === 'results');
+      if (!resultsChild) return;
+
+      openDirectory(resultsChild);
+      hasOpenedResults.value = true;
+    },
+  );
+
   const updatedS3Contents = computed(() => {
     if (props.s3Contents) {
       const transformedData = transformS3Data(props.s3Contents, s3Prefix);

--- a/packages/front-end/src/app/pages/labs/[labId]/run/[labRunId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/run/[labRunId].vue
@@ -33,10 +33,15 @@
     let i = 0;
     while (inputS3Url.value[i] === outputS3Url[i]) i++;
 
-    const outputRelativeLocation = outputS3Url.slice(i);
+    let outputRelativeLocation = outputS3Url.slice(i);
     if (!outputRelativeLocation.match(/^(\/[^\/]+)+$/)) return null;
 
-    return outputRelativeLocation.split('/').slice(1);
+    // omics generates an additional sub-folder with the omics run id which we also want to descend into
+    if (labRun.value?.Platform === 'AWS HealthOmics' && !!labRun.value?.ExternalRunId) {
+      outputRelativeLocation += '/' + labRun.value.ExternalRunId;
+    }
+
+    return outputRelativeLocation.split('/').filter((step) => !!step); // filter out blank steps ie ''
   });
 
   const isLoading = computed<boolean>(() => uiStore.isRequestPending('loadLabRuns'));


### PR DESCRIPTION
## Title*

Open File Browser to `/results`

## Type of Change*
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

When the File Browser loads in the S3 tree info, if the root dir contains a `results` dir in its children, it takes the step into that dir.

## Testing*

## Impact

This will happen anywhere we have a File Browser - right now I believe that's just the results page but if we use it elsewhere we might need to make this feature optional.

## Additional Information

## Checklist*
- [ ] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [ ] Code adheres to the coding and style guidelines of the project.
- [ ] Code has been commented in particularly hard-to-understand areas.