### PR TITLE
feat(EG-1053): communicate the more obscure reasons why the upload button would be disabled

### DIFF
--- a/packages/front-end/src/app/components/EGRunFormUploadData.vue
+++ b/packages/front-end/src/app/components/EGRunFormUploadData.vue
@@ -165,6 +165,17 @@
 
   const isDropzoneEnabled = computed(() => uploadStatus.value !== 'uploading');
 
+  const uploadButtonDisabledReason = computed<string | null>(() => {
+    // don't need internet connection message because the modal takes care of it
+    // don't need no files uploaded message because there will visibly be nothing there which should be self explanatory
+    if (!areAllPairsComplete.value) return 'There is an R2 file with no matching R1 file.';
+    if (haveMatchedFiles.value && haveUnmatchedFiles.value)
+      return 'There is a mix of single files and pair files. Files must be all single files or all pair files.';
+    // don't need uploading message because there's already a visual indicator of activity in progress
+
+    return null;
+  });
+
   const isUploadButtonDisabled = computed(() => {
     const noInternet = !isOnline.value;
     const noFiles = filesNotUploaded.value.length === 0;
@@ -870,6 +881,14 @@
           </div>
         </div>
       </div>
+    </div>
+
+    <div
+      v-if="uploadButtonDisabledReason"
+      class="bg-alert-danger-muted text-alert-danger my-10 flex items-center gap-2 rounded-lg p-6"
+    >
+      <UIcon class="text-2xl" name="i-heroicons-exclamation-triangle" />
+      <div>{{ uploadButtonDisabledReason }}</div>
     </div>
 
     <EGS3SampleSheetBar


### PR DESCRIPTION
## Title*

Communicate why the upload button is disabled for the more obscure reasons

## Type of Change*
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

![image](https://github.com/user-attachments/assets/903f3f11-ec40-4781-808f-63e6bbe2ca88)

This covers two cases which might be unclear:

- mix of single/pair files
- R2 file with no matching R1

The other reasons I concluded were clear enough and to add a message would be overexplaining:

- no internet connection
- no files selected yet
- upload is in progress

## Testing*

Tested those two cases, plus both at once, in which case it prioritizes the unmatched R2 message, which handily avoids the single/pair mix message also showing because the unmatched R2 is kind of treated as a single file

## Impact

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.