### PR TITLE
fix: retry upload allowed logic

### DIFF
--- a/packages/front-end/src/app/components/EGRunFormUploadData.vue
+++ b/packages/front-end/src/app/components/EGRunFormUploadData.vue
@@ -732,21 +732,10 @@
     // If the file isn't in error state, can't retry
     if (!row.error) return false;
 
-    // TODO: this logic hasn't been updated with the single file feature
-    // Find the matching pair for this file
-    const isPairedFile = filePairs.value.some((pair) => {
-      const isR1 = pair.r1File?.name === row.fileName;
-      const isR2 = pair.r2File?.name === row.fileName;
+    // if there's a problem with the selected files, that needs to be addressed before uploading
+    if (filesProblemAlertMessage.value !== null) return false;
 
-      // If this is R1, check if R2 exists
-      if (isR1) return !!pair.r2File;
-      // If this is R2, check if R1 exists
-      if (isR2) return !!pair.r1File;
-
-      return false;
-    });
-
-    return isPairedFile && isOnline.value;
+    return true;
   };
 
   watch(canProceedToNextStep, (val) => {


### PR DESCRIPTION
## Title*

Fix logic controlling if single upload retry is allowed

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Retrying individual file uploads introduces edge cases where the file upload can get into invalid states and generate a sample sheet, eg. mix of single/paired or unpaired R2.

The previous logic applied to the paired-only approach from before the single file feature. The new logic just ensures that the above invalid states are inaccessible.

## Testing*

Tested that retry buttons are disabled for those two cases.

## Impact

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.