### PR TITLE
feat(EG-1073): change details tabs to settings and use page header on create lab/org pages

### DIFF
--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -116,8 +116,8 @@
     const runsTab = { key: 'runs', label: 'Pipeline Runs' };
     const seqeraPipelinesTab = { key: 'seqeraPipelines', label: 'Seqera Pipelines' };
     const omicsWorkflowsTab = { key: 'omicsWorkflows', label: 'HealthOmics Workflows' };
-    const usersTab = { key: 'users', label: 'Lab Users' };
-    const detailsTab = { key: 'details', label: 'Details' };
+    const usersTab = { key: 'users', label: 'Users' };
+    const detailsTab = { key: 'details', label: 'Settings' };
 
     const seqeraAvailable = lab.value?.NextFlowTowerEnabled && !missingPAT.value;
     const omicsAvailable = lab.value?.AwsHealthOmicsEnabled;

--- a/packages/front-end/src/app/components/EGOrgView.vue
+++ b/packages/front-end/src/app/components/EGOrgView.vue
@@ -44,7 +44,7 @@
     },
     {
       slot: 'details',
-      label: 'Details',
+      label: 'Settings',
     },
   ];
 

--- a/packages/front-end/src/app/pages/admin/orgs/create.vue
+++ b/packages/front-end/src/app/pages/admin/orgs/create.vue
@@ -26,9 +26,11 @@
 
 <template>
   <div class="w-full">
-    <EGBack :back-action="() => $router.push({ path: '/admin/orgs' })" />
-    <EGText tag="h1" class="mb-6">Create a new Organization</EGText>
-    <EGText tag="h4" class="mb-4">Organization details</EGText>
+    <EGPageHeader
+      title="Create a new Organization"
+      :back-action="() => $router.push({ path: '/admin/orgs' })"
+      show-back
+    />
     <EGFormOrgDetails @submit-form-org-details="onSubmit($event)" />
   </div>
 </template>

--- a/packages/front-end/src/app/pages/labs/create.vue
+++ b/packages/front-end/src/app/pages/labs/create.vue
@@ -11,9 +11,7 @@
 
 <template>
   <div class="w-full">
-    <EGBack :back-action="() => $router.push({ path: '/labs' })" />
-    <EGText tag="h1" class="mb-6">Create a new lab</EGText>
-    <EGText tag="h4" class="mb-4">Lab details</EGText>
+    <EGPageHeader title="Create a new lab" :back-action="() => router.push({ path: '/labs' })" show-back />
   </div>
 
   <EGFormLabDetails :form-mode="LabDetailsFormModeEnum.enum.Create" />


### PR DESCRIPTION
## Title*

Change details tabs to say Settings

## Type of Change*
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [X] UI/UX improvement

## Description

- Details -> Settings
- Lab Users -> Users
- create lab/org pages headers -> EGPageHeader

## Testing*

## Impact

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.