### PR TITLE
feat(EG-1052): meta PR

### DIFF
--- a/packages/front-end/src/app/components/EGBreadcrumbLabs.vue
+++ b/packages/front-end/src/app/components/EGBreadcrumbLabs.vue
@@ -11,12 +11,26 @@
 
   const isOpen = ref<boolean>(false);
 
+  const currentOrgId = computed<string | null>(
+    () => (userStore.isSuperuser ? (route.params.orgId as string) : userStore.currentOrgId) ?? null,
+  );
+
+  onBeforeMount(async () => {
+    // there are some cases (eg. sign in straight to a lab page) where the labs might not have been loaded
+    // in that case we'll fetch them now
+
+    if (currentOrgId.value === null) return; // this is probably a problem but nothing we can do
+
+    if (!(currentOrgId.value in labsStore.labIdsByOrg)) {
+      await labsStore.loadLabsForOrg(currentOrgId.value);
+    }
+  });
+
   const currentLab = computed<Laboratory | null>(() => labsStore.labs[labId] || null);
 
   const otherLabs = computed<Laboratory[]>(() => {
     // for superuser, use the org in the url; for normal user, currentOrgId
-    const currentOrgId = userStore.isSuperuser ? (route.params.orgId as string) : userStore.currentOrgId;
-    return Object.values(labsStore.labsForOrg(currentOrgId || ''))
+    return Object.values(labsStore.labsForOrg(currentOrgId.value || ''))
       .filter((lab) => lab.LaboratoryId !== labId)
       .sort((a, b) => useSort().stringSortCompare(a.Name, b.Name));
   });

--- a/packages/front-end/src/app/components/EGBreadcrumbOrgs.vue
+++ b/packages/front-end/src/app/components/EGBreadcrumbOrgs.vue
@@ -47,12 +47,16 @@
     userStore.currentOrg.OrganizationId = switchToOrgId.value!;
     userStore.mostRecentLab.LaboratoryId = null; // Reset
 
-    const userId: string | undefined = userStore.currentUserDetails.id;
-    if (userId) {
-      await $api.users.updateUserLastAccessInfo(userId, userStore.currentOrg.OrganizationId, '');
-      await useAuth().getRefreshedToken();
-      await useUser().setCurrentUserDataFromToken();
-    }
+    // update default org/lab in api
+    await $api.users.updateUserLastAccessInfo(
+      userStore.currentUserDetails.id!,
+      userStore.currentOrg.OrganizationId,
+      undefined,
+    );
+
+    // refresh values from api
+    await useAuth().getRefreshedToken();
+    await useUser().setCurrentUserDataFromToken();
 
     router.push('/');
     useUiStore().incrementRemountAppKey();

--- a/packages/front-end/src/app/components/EGBreadcrumbOrgs.vue
+++ b/packages/front-end/src/app/components/EGBreadcrumbOrgs.vue
@@ -45,7 +45,7 @@
 
   async function doSwitchOrg(): Promise<void> {
     userStore.currentOrg.OrganizationId = switchToOrgId.value!;
-    userStore.currentLab.LaboratoryId = ''; // Reset
+    userStore.mostRecentLab.LaboratoryId = ''; // Reset
 
     const userId: string | undefined = userStore.currentUserDetails.id;
     if (userId) {

--- a/packages/front-end/src/app/components/EGBreadcrumbOrgs.vue
+++ b/packages/front-end/src/app/components/EGBreadcrumbOrgs.vue
@@ -45,7 +45,7 @@
 
   async function doSwitchOrg(): Promise<void> {
     userStore.currentOrg.OrganizationId = switchToOrgId.value!;
-    userStore.mostRecentLab.LaboratoryId = ''; // Reset
+    userStore.mostRecentLab.LaboratoryId = null; // Reset
 
     const userId: string | undefined = userStore.currentUserDetails.id;
     if (userId) {

--- a/packages/front-end/src/app/components/EGHeader.vue
+++ b/packages/front-end/src/app/components/EGHeader.vue
@@ -39,12 +39,16 @@
     userStore.currentOrg.OrganizationId = switchToOrgId.value!;
     userStore.mostRecentLab.LaboratoryId = null; // Reset
 
-    const userId: string | undefined = userStore.currentUserDetails.id;
-    if (userId) {
-      await $api.users.updateUserLastAccessInfo(userId, userStore.currentOrg.OrganizationId, '');
-      await useAuth().getRefreshedToken();
-      await useUser().setCurrentUserDataFromToken();
-    }
+    // update default org/lab in api
+    await $api.users.updateUserLastAccessInfo(
+      userStore.currentUserDetails.id!,
+      userStore.currentOrg.OrganizationId,
+      undefined,
+    );
+
+    // refresh values from api
+    await useAuth().getRefreshedToken();
+    await useUser().setCurrentUserDataFromToken();
 
     $router.push('/');
     useUiStore().incrementRemountAppKey();

--- a/packages/front-end/src/app/components/EGHeader.vue
+++ b/packages/front-end/src/app/components/EGHeader.vue
@@ -37,7 +37,7 @@
 
   async function doSwitchOrg(): Promise<void> {
     userStore.currentOrg.OrganizationId = switchToOrgId.value!;
-    userStore.mostRecentLab.LaboratoryId = ''; // Reset
+    userStore.mostRecentLab.LaboratoryId = null; // Reset
 
     const userId: string | undefined = userStore.currentUserDetails.id;
     if (userId) {

--- a/packages/front-end/src/app/components/EGHeader.vue
+++ b/packages/front-end/src/app/components/EGHeader.vue
@@ -37,7 +37,7 @@
 
   async function doSwitchOrg(): Promise<void> {
     userStore.currentOrg.OrganizationId = switchToOrgId.value!;
-    userStore.currentLab.LaboratoryId = ''; // Reset
+    userStore.mostRecentLab.LaboratoryId = ''; // Reset
 
     const userId: string | undefined = userStore.currentUserDetails.id;
     if (userId) {

--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -37,7 +37,7 @@
 
   const { stringSortCompare } = useSort();
 
-  const orgId = userStore.currentOrg.OrganizationId || labStore.labs[props.labId].OrganizationId;
+  const orgId = labStore.labs[props.labId].OrganizationId;
   const labUsers = ref<LabUser[]>([]);
   const seqeraPipelines = computed<SeqeraPipeline[]>(() => seqeraPipelinesStore.pipelinesForLab(props.labId));
   const omicsWorkflows = computed<OmicsWorkflow[]>(() => omicsWorkflowsStore.workflowsForLab(props.labId));

--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -26,6 +26,7 @@
   const { $api } = useNuxtApp();
   const $router = useRouter();
   const modal = useModal();
+  const { updateDefaultLab } = useUser();
 
   const runStore = useRunStore();
   const labStore = useLabsStore();
@@ -181,21 +182,17 @@
     tabIndex.value = tabMatchIndex !== -1 ? tabMatchIndex : 0;
   }
 
-  onMounted(() => {
+  onMounted(async () => {
     // set tabIndex according to initialTab prop
     setTabIndex();
 
-    const userId: string | undefined = userStore.currentUserDetails.id;
-    if (userId) {
-      $api.users.updateUserLastAccessInfo(
-        userId,
-        userStore.currentOrg.OrganizationId,
-        userStore.mostRecentLab.LaboratoryId,
-      );
-    }
+    // clean up timeout
     if (intervalId) {
       clearTimeout(intervalId);
     }
+
+    // update most recent lab
+    await updateDefaultLab(props.labId);
   });
 
   onBeforeRouteLeave(() => {

--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -190,7 +190,7 @@
       $api.users.updateUserLastAccessInfo(
         userId,
         userStore.currentOrg.OrganizationId,
-        userStore.currentLab.LaboratoryId,
+        userStore.mostRecentLab.LaboratoryId,
       );
     }
     if (intervalId) {

--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -37,7 +37,6 @@
 
   const { stringSortCompare } = useSort();
 
-  const orgId = labStore.labs[props.labId].OrganizationId;
   const labUsers = ref<LabUser[]>([]);
   const seqeraPipelines = computed<SeqeraPipeline[]>(() => seqeraPipelinesStore.pipelinesForLab(props.labId));
   const omicsWorkflows = computed<OmicsWorkflow[]>(() => omicsWorkflowsStore.workflowsForLab(props.labId));
@@ -53,6 +52,7 @@
   const tabIndex = ref(0);
   let intervalId: number | undefined;
 
+  const orgId = computed<string | null>(() => labStore.labs[props.labId].OrganizationId ?? null);
   const lab = computed<Laboratory | null>(() => labStore.labs[props.labId] ?? null);
   const labName = computed<string>(() => lab.value?.Name || '');
 
@@ -343,11 +343,7 @@
   async function loadLabData(): Promise<void> {
     useUiStore().setRequestPending('loadLabData');
     try {
-      if (labStore.labIdsByOrg.length === 0) {
-        await labStore.loadLabsForOrg(orgId);
-      } else {
-        await labStore.loadLab(props.labId);
-      }
+      await labStore.loadLab(props.labId);
     } catch (error) {
       console.error('Error retrieving Lab data', error);
     } finally {
@@ -533,7 +529,7 @@
   <EGPageHeader
     :title="labName"
     description="View your Lab users, details and pipelines/workflows"
-    :back-action="() => (superuser ? $router.push(`/orgs/${orgId}`) : $router.push('/labs'))"
+    :back-action="() => (superuser ? $router.push(`/orgs/${orgId || ''}`) : $router.push('/labs'))"
     :show-back="true"
     show-org-breadcrumb
     show-lab-breadcrumb
@@ -545,7 +541,7 @@
       @click="showAddUserModule = !showAddUserModule"
     />
     <EGAddLabUsersModule
-      v-if="showAddUserModule"
+      v-if="showAddUserModule && !!orgid"
       @added-user-to-lab="handleUserAddedToLab()"
       :org-id="orgId"
       :lab-id="labId"

--- a/packages/front-end/src/app/composables/useAuth.ts
+++ b/packages/front-end/src/app/composables/useAuth.ts
@@ -24,8 +24,8 @@ export default function useAuth() {
         if (useUserStore().isSuperuser) {
           await navigateTo('/orgs');
         } else {
-          const labsUri: string = useUserStore().currentLab.LaboratoryId
-            ? `/labs/${useUserStore().currentLab.LaboratoryId}`
+          const labsUri: string = useUserStore().mostRecentLab.LaboratoryId
+            ? `/labs/${useUserStore().mostRecentLab.LaboratoryId}`
             : '/labs';
           await navigateTo(labsUri);
         }

--- a/packages/front-end/src/app/composables/useAuth.ts
+++ b/packages/front-end/src/app/composables/useAuth.ts
@@ -21,14 +21,7 @@ export default function useAuth() {
       if (user) {
         await useUser().setCurrentUserDataFromToken();
         await useOrgsStore().loadOrgs();
-        if (useUserStore().isSuperuser) {
-          await navigateTo('/orgs');
-        } else {
-          const labsUri: string = useUserStore().mostRecentLab.LaboratoryId
-            ? `/labs/${useUserStore().mostRecentLab.LaboratoryId}`
-            : '/labs';
-          await navigateTo(labsUri);
-        }
+        await navigateTo('/');
       }
     } catch (error: any) {
       if (error.code === 'NotAuthorizedException') {

--- a/packages/front-end/src/app/composables/useUser.ts
+++ b/packages/front-end/src/app/composables/useUser.ts
@@ -129,10 +129,14 @@ export default function useUser() {
 
       userStore.currentUserPermissions.orgPermissions = parsedOrgAccess as OrganizationAccess;
 
+      // set default org and default lab
       userStore.currentOrg.OrganizationId = decodedToken.DefaultOrganization
         ? decodedToken.DefaultOrganization
         : Object.keys(parsedOrgAccess)[0];
-      userStore.mostRecentLab.LaboratoryId = decodedToken.DefaultLaboratory ? decodedToken.DefaultLaboratory : null;
+
+      if (!userStore.mostRecentLab.LaboratoryId && !!decodedToken.DefaultLaboratory) {
+        userStore.mostRecentLab.LaboratoryId = decodedToken.DefaultLaboratory;
+      }
 
       // retrieve and set personal details
       userStore.currentUserDetails.firstName = decodedToken.FirstName;
@@ -144,6 +148,19 @@ export default function useUser() {
     }
   }
 
+  async function updateDefaultLab(labId: string): Promise<void> {
+    const { $api } = useNuxtApp();
+    const userStore = useUserStore();
+
+    userStore.mostRecentLab.LaboratoryId = labId;
+
+    await $api.users.updateUserLastAccessInfo(
+      userStore.currentUserDetails.id!,
+      userStore.currentOrg.OrganizationId!,
+      userStore.mostRecentLab.LaboratoryId,
+    );
+  }
+
   return {
     displayName,
     initials,
@@ -151,5 +168,6 @@ export default function useUser() {
     invite,
     resendInvite,
     setCurrentUserDataFromToken,
+    updateDefaultLab,
   };
 }

--- a/packages/front-end/src/app/composables/useUser.ts
+++ b/packages/front-end/src/app/composables/useUser.ts
@@ -129,11 +129,14 @@ export default function useUser() {
 
       userStore.currentUserPermissions.orgPermissions = parsedOrgAccess as OrganizationAccess;
 
-      // set default org and default lab
+      // set default org, or if no value use first org
       userStore.currentOrg.OrganizationId = decodedToken.DefaultOrganization
         ? decodedToken.DefaultOrganization
         : Object.keys(parsedOrgAccess)[0];
 
+      // set most recent lab from default lab value
+      // this function gets called on every page view so if there's already a value in the store, don't overwrite
+      // if this is a fresh sign in, the store will always be empty anyway and it will use the incoming default value
       if (!userStore.mostRecentLab.LaboratoryId && !!decodedToken.DefaultLaboratory) {
         userStore.mostRecentLab.LaboratoryId = decodedToken.DefaultLaboratory;
       }

--- a/packages/front-end/src/app/composables/useUser.ts
+++ b/packages/front-end/src/app/composables/useUser.ts
@@ -132,7 +132,7 @@ export default function useUser() {
       userStore.currentOrg.OrganizationId = decodedToken.DefaultOrganization
         ? decodedToken.DefaultOrganization
         : Object.keys(parsedOrgAccess)[0];
-      userStore.currentLab.LaboratoryId = decodedToken.DefaultLaboratory ? decodedToken.DefaultLaboratory : '';
+      userStore.mostRecentLab.LaboratoryId = decodedToken.DefaultLaboratory ? decodedToken.DefaultLaboratory : '';
 
       // retrieve and set personal details
       userStore.currentUserDetails.firstName = decodedToken.FirstName;

--- a/packages/front-end/src/app/composables/useUser.ts
+++ b/packages/front-end/src/app/composables/useUser.ts
@@ -132,7 +132,7 @@ export default function useUser() {
       userStore.currentOrg.OrganizationId = decodedToken.DefaultOrganization
         ? decodedToken.DefaultOrganization
         : Object.keys(parsedOrgAccess)[0];
-      userStore.mostRecentLab.LaboratoryId = decodedToken.DefaultLaboratory ? decodedToken.DefaultLaboratory : '';
+      userStore.mostRecentLab.LaboratoryId = decodedToken.DefaultLaboratory ? decodedToken.DefaultLaboratory : null;
 
       // retrieve and set personal details
       userStore.currentUserDetails.firstName = decodedToken.FirstName;

--- a/packages/front-end/src/app/pages/index.vue
+++ b/packages/front-end/src/app/pages/index.vue
@@ -1,10 +1,21 @@
 <script setup lang="ts">
-  const $route = useRoute();
   const $router = useRouter();
 
+  const userStore = useUserStore();
+
   onMounted(() => {
-    if ($route.path !== '/labs') {
-      $router.push('/labs');
+    if (userStore.isSuperuser) {
+      $router.push('/orgs');
+    } else {
+      let dest = '/labs';
+
+      if (userStore.mostRecentLabId !== null) {
+        dest += `/${userStore.mostRecentLabId}`;
+      }
+
+      $router.push(dest);
     }
   });
 </script>
+
+<template></template>

--- a/packages/front-end/src/app/stores/user.ts
+++ b/packages/front-end/src/app/stores/user.ts
@@ -96,16 +96,8 @@ const useUserStore = defineStore('userStore', {
 
     canViewLabForOrg:
       (_state: UserStoreState) =>
-      (orgId: string, labId: string): boolean => {
-        const canViewLabForOrg =
-          useUserStore().isOrgAdminForOrg(orgId) || useUserStore().isLabMemberForOrg(orgId, labId);
-
-        if (canViewLabForOrg && useUserStore().mostRecentLab.LaboratoryId !== labId) {
-          useUserStore().mostRecentLab.LaboratoryId = labId;
-        }
-
-        return canViewLabForOrg;
-      },
+      (orgId: string, labId: string): boolean =>
+        useUserStore().isOrgAdminForOrg(orgId) || useUserStore().isLabMemberForOrg(orgId, labId),
 
     canEditLabUsersForOrg:
       (_state: UserStoreState) =>

--- a/packages/front-end/src/app/stores/user.ts
+++ b/packages/front-end/src/app/stores/user.ts
@@ -8,7 +8,7 @@ interface UserStoreState {
   currentOrg: {
     OrganizationId: string | null;
   };
-  currentLab: {
+  mostRecentLab: {
     LaboratoryId: string | null;
   };
   currentUserPermissions: {
@@ -28,7 +28,7 @@ const initialState = (): UserStoreState => ({
   currentOrg: {
     OrganizationId: null,
   },
-  currentLab: {
+  mostRecentLab: {
     LaboratoryId: null,
   },
   currentUserPermissions: {
@@ -52,7 +52,7 @@ const useUserStore = defineStore('userStore', {
 
   getters: {
     currentOrgId: (state: UserStoreState) => state.currentOrg.OrganizationId,
-    currentLabId: (state: UserStoreState) => state.currentLab.LaboratoryId,
+    mostRecentLabId: (state: UserStoreState) => state.mostRecentLab.LaboratoryId,
 
     // permissions
 
@@ -100,8 +100,8 @@ const useUserStore = defineStore('userStore', {
         const canViewLabForOrg =
           useUserStore().isOrgAdminForOrg(orgId) || useUserStore().isLabMemberForOrg(orgId, labId);
 
-        if (canViewLabForOrg && useUserStore().currentLab.LaboratoryId !== labId) {
-          useUserStore().currentLab.LaboratoryId = labId;
+        if (canViewLabForOrg && useUserStore().mostRecentLab.LaboratoryId !== labId) {
+          useUserStore().mostRecentLab.LaboratoryId = labId;
         }
 
         return canViewLabForOrg;


### PR DESCRIPTION
Changes:

- bc8e3ac: refactor(EG-1052): rename currentLab -> mostRecentLab because unlike currentOrg there is not a global current lab

Thinking in terms of "current lab" is subtly very misleading. This has previously caused components (specifically the pinia stores) to be designed under the assumption of there being a single, current lab, like an app. This has incurred sizeable refactoring work in the past because EasyG is a website and can have multiple tabs with multiple labs open at the same time (unlike orgs - there really is a single current org). I've called the lab store `mostRecentLab` because that's what it really is.

- 9758fba: refactor(EG-1052): move most recent lab logic to root page

The "open the most recent lab if available" logic is useful outside of just signing in. A user might have an EasyG bookmark that we want to open to their last used lab whatever it may be. To enable this, I moved the direction logic to the root path `/`, instead of in the sign in procedure, and direct to `/` post-sign in so that continues to work the same way.

- 8f5f95e: refactor(EG-1052): use null instead of empty string for unset most recent lab

If a value is not present, I tend to use `null` as a more obvious representation of this than `''`. This pattern is in use throughout the FE so this is consistent with established patterns.

- ca85d71: refactor(EG-1052): set mostRecentLab on lab view

I made the most recent lab update as simple and consistent as possible by putting it in the `onMounted` of the lab view.

I also tweaked the "load default org and lab" logic to not overwrite an existing most recent lab value, as that function gets called on every page view. I commented this better in 25ce670.

- 6c34f95: refactor(EG-1052): unsuppress error if user id is missing which should never be the case

I removed a conditional which should be an invalid case and surfaced the error instead, so that we don't miss that something is going wrong if it does somehow happen

- 2d399cd: refactor(EG-1052): read orgId from lab to prevent potential data conflict

The lab that `LabView` reads from is specified by `props.labId` and includes the org id on the lab object. Patching in the org id from a different source (the user store) introduces the possibility of a data conflict if our approach to organization handling ever changes, or the `LabView` component is ever used to display a lab cross-organization. It shouldn't matter now, but it could save some headaches in the future.

- d8bd253: refactor(EG-1052): load all labs if required from breadcrumb so lab page can only load itself

I offloaded the responsibility of fetching all labs if not present to the labs breadcrumb, so that the LabView always just needs to worry about loading its own lab.