### PR TITLE
feat(EG-1076): add open button for html files

### DIFF
--- a/packages/front-end/src/app/stores/ui.ts
+++ b/packages/front-end/src/app/stores/ui.ts
@@ -40,7 +40,8 @@ type PendingRequest =
   | 'loadLabRuns'
   | 'updateDefaultOrg'
   | 'generateSampleSheet'
-  | 'downloadSampleSheet';
+  | 'downloadSampleSheet'
+  | `downloadHtmlFileButton-${string}`;
 
 interface UiStoreState {
   pendingRequests: Set<string>;


### PR DESCRIPTION
## Title*

Add an open button for HTML files

## Type of Change*
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [X] UI/UX improvement

## Description

![image](https://github.com/user-attachments/assets/f6adbdb2-0c4d-4815-a682-f52034c48a8d)

Open button makes behaviour clearer and shows visual feedback while loading.

## Testing*

## Impact

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.