### PR TITLE
feat(EG-1077): enhance samplesheet csv name to inc run name

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/upload/create-file-upload-sample-sheet.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/upload/create-file-upload-sample-sheet.lambda.ts
@@ -48,7 +48,7 @@ export const handler: Handler = async (
     }
 
     const sampleSheetName: string = request.SampleSheetName;
-    if (!sampleSheetName.match(/^[a-zA-Z0-9._:!@#$%^()-]+(.csv)$/)) {
+    if (!sampleSheetName.match(/^[a-zA-Z0-9._:!@#$%^()-]+(\.csv)$/)) {
       throw new InvalidRequestError(`Invalid sample sheet name: ${sampleSheetName}`);
     }
 

--- a/packages/back-end/src/app/controllers/easy-genomics/upload/create-file-upload-sample-sheet.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/upload/create-file-upload-sample-sheet.lambda.ts
@@ -48,7 +48,7 @@ export const handler: Handler = async (
     }
 
     const sampleSheetName: string = request.SampleSheetName;
-    if (!sampleSheetName.match(/^[a-zA-Z0-9._:!@#$%^()\[\]-]+(.csv)$/)) {
+    if (!sampleSheetName.match(/^[a-zA-Z0-9._:!@#$%^()-]+(.csv)$/)) {
       throw new InvalidRequestError(`Invalid sample sheet name: ${sampleSheetName}`);
     }
 

--- a/packages/back-end/src/app/controllers/easy-genomics/upload/create-file-upload-sample-sheet.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/upload/create-file-upload-sample-sheet.lambda.ts
@@ -47,6 +47,11 @@ export const handler: Handler = async (
       throw new InvalidRequestError('Invalid sample sheet request');
     }
 
+    const sampleSheetName: string = request.SampleSheetName;
+    if (!sampleSheetName.match(/^[a-zA-Z0-9._:!@#$%^()\[\]-]+(.csv)$/)) {
+      throw new InvalidRequestError(`Invalid sample sheet name: ${sampleSheetName}`);
+    }
+
     const laboratoryId: string = request.LaboratoryId;
     const transactionId: string = request.TransactionId;
     const laboratory: Laboratory = await laboratoryService.queryByLaboratoryId(laboratoryId);
@@ -58,7 +63,7 @@ export const handler: Handler = async (
 
     const platform: string = request.Platform === 'AWS HealthOmics' ? 'aws-healthomics' : 'seqera-platform';
     const s3Path: string = `${laboratory.OrganizationId}/${laboratory.LaboratoryId}/${platform}/${transactionId}`;
-    const s3Key: string = `${s3Path}/sample-sheet.csv`;
+    const s3Key: string = `${s3Path}/${sampleSheetName}`;
     const s3Url: string = `s3://${s3Bucket}/${s3Key}`;
     const bucketLocation = (await s3Service.getBucketLocation({ Bucket: s3Bucket })).LocationConstraint;
 
@@ -95,7 +100,7 @@ export const handler: Handler = async (
       const response: SampleSheetResponse = {
         TransactionId: transactionId,
         SampleSheetInfo: {
-          Name: 'sample-sheet.csv',
+          Name: sampleSheetName,
           Size: sampleSheetCsv.length,
           Checksum: sampleSheetCsvChecksum,
           Bucket: s3Bucket,

--- a/packages/front-end/src/app/components/EGRunFormUploadData.vue
+++ b/packages/front-end/src/app/components/EGRunFormUploadData.vue
@@ -497,10 +497,9 @@
   async function getSampleSheetCsv(uploadedFilePairs: UploadedFilePairInfo[]): Promise<SampleSheetResponse> {
     if (!wipRun.value.transactionId) throw new Error('no transaction id on wip run');
 
-    const sampleSheetName = `samplesheet-${props.pipelineOrWorkflowName}-[${wipRun.value.runName}].csv`.replace(
-      '/',
-      ':',
-    );
+    const sampleSheetName: string = wipRun.value.runName
+      ? `samplesheet-${wipRun.value.runName}.csv`
+      : 'samplesheet.csv';
 
     const request: SampleSheetRequest = {
       SampleSheetName: sampleSheetName,

--- a/packages/front-end/src/app/components/EGRunFormUploadData.vue
+++ b/packages/front-end/src/app/components/EGRunFormUploadData.vue
@@ -497,7 +497,13 @@
   async function getSampleSheetCsv(uploadedFilePairs: UploadedFilePairInfo[]): Promise<SampleSheetResponse> {
     if (!wipRun.value.transactionId) throw new Error('no transaction id on wip run');
 
+    const sampleSheetName = `samplesheet-${props.pipelineOrWorkflowName}-[${wipRun.value.runName}].csv`.replace(
+      '/',
+      ':',
+    );
+
     const request: SampleSheetRequest = {
+      SampleSheetName: sampleSheetName,
       LaboratoryId: props.labId,
       TransactionId: wipRun.value.transactionId,
       Platform: props.platform,

--- a/packages/front-end/src/app/components/EGS3SampleSheetBar.vue
+++ b/packages/front-end/src/app/components/EGS3SampleSheetBar.vue
@@ -73,6 +73,7 @@
     setTimeout(() => {
       isClicked.value = false;
     }, 2000);
+
     downloadSampleSheet(props.labId, props.url);
   };
 </script>

--- a/packages/front-end/src/app/components/EGS3SampleSheetBar.vue
+++ b/packages/front-end/src/app/components/EGS3SampleSheetBar.vue
@@ -73,7 +73,7 @@
     setTimeout(() => {
       isClicked.value = false;
     }, 2000);
-    downloadSampleSheet(props.labId, props.url, props.pipelineOrWorkflowName, props.runName);
+    downloadSampleSheet(props.labId, props.url);
   };
 </script>
 

--- a/packages/front-end/src/app/composables/usePipeline.ts
+++ b/packages/front-end/src/app/composables/usePipeline.ts
@@ -2,7 +2,7 @@ export default function usePipeline($api: any) {
   /**
    * Downloads the sample sheet as a CSV file.
    */
-  async function downloadSampleSheet(labId: string, sampleSheetS3Url: string, pipelineName: string, runName: string) {
+  async function downloadSampleSheet(labId: string, sampleSheetS3Url: string) {
     const fileDownloadUrlResponse = await $api.file.requestFileDownloadUrl({
       LaboratoryId: labId,
       S3Uri: sampleSheetS3Url,
@@ -10,7 +10,6 @@ export default function usePipeline($api: any) {
     const sampleSheetCsvData = await (await fetch(fileDownloadUrlResponse.DownloadUrl)).text();
     const link = document.createElement('a');
     link.href = `data:text/csv;charset=utf-8,${sampleSheetCsvData}`;
-    link.download = `samplesheet-${pipelineName}--${runName}.csv`;
     link.style.visibility = 'hidden';
     document.body.appendChild(link);
     link.click();

--- a/packages/front-end/src/app/composables/usePipeline.ts
+++ b/packages/front-end/src/app/composables/usePipeline.ts
@@ -8,9 +8,11 @@ export default function usePipeline($api: any) {
       S3Uri: sampleSheetS3Url,
     });
     const sampleSheetCsvData = await (await fetch(fileDownloadUrlResponse.DownloadUrl)).text();
+    const downloadFileName = `${sampleSheetS3Url}`.split('#')[0].split('?')[0].split('/').pop();
     const link = document.createElement('a');
     link.href = `data:text/csv;charset=utf-8,${sampleSheetCsvData}`;
     link.style.visibility = 'hidden';
+    link.download = downloadFileName;
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);

--- a/packages/shared-lib/src/app/schema/easy-genomics/upload/s3-file-upload-sample-sheet.ts
+++ b/packages/shared-lib/src/app/schema/easy-genomics/upload/s3-file-upload-sample-sheet.ts
@@ -21,6 +21,7 @@ export const UploadedFilePairInfoSchema = z
 
 export const SampleSheetRequestSchema = z
   .object({
+    SampleSheetName: z.string(),
     LaboratoryId: z.string().uuid(),
     TransactionId: z.string().uuid(),
     Platform: z.enum(['AWS HealthOmics', 'Seqera Cloud']),

--- a/packages/shared-lib/src/app/types/easy-genomics/upload/s3-file-upload-sample-sheet.d.ts
+++ b/packages/shared-lib/src/app/types/easy-genomics/upload/s3-file-upload-sample-sheet.d.ts
@@ -3,6 +3,7 @@
 import { RunType } from "@SharedLib/types/base-entity";
 
 export type SampleSheetRequest = {
+  SampleSheetName: string;
   LaboratoryId: string;
   TransactionId: string;
   Platform: RunType,


### PR DESCRIPTION
## Title*
Enhance samplesheet csv name to inc run name

## Type of Change*
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [X] UI/UX improvement

## Description
This PR improves the SampleSheet generation API to save the Sample Sheet csv file on S3 with the Run Name to make it easier for reviewing files on S3, and also make the Sample Sheet csv file downloaded filename consistent between the Sample Sheet purple bar and the File Manager.

Instead of the Sample Sheet csv file being saved as `samplesheet.csv` it is now saved as `samplesheet-{Run Name}.csv`.

## Testing*
See associated JIRA ticket for testing instructions.

## Impact
None.

## Additional Information
None.

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.