### PR TITLE
fix(EG-1084): update lab users and settings tabs

### DIFF
--- a/packages/front-end/tests/e2e/sys-admin/Organizations_System_Admin.spec.e2e.ts
+++ b/packages/front-end/tests/e2e/sys-admin/Organizations_System_Admin.spec.e2e.ts
@@ -234,8 +234,8 @@ test('07 - View All labs tab', async ({ page, baseURL }) => {
         await page.waitForTimeout(2000);
 
         //Lab Users tab
-        await expect(page.getByRole('tab', { name: 'Lab Users' })).toBeVisible();
-        await expect(page.getByRole('tab', { name: 'Details' })).toBeVisible();
+        await expect(page.getByRole('tab', { name: 'Users' })).toBeVisible();
+        await expect(page.getByRole('tab', { name: 'Settings' })).toBeVisible();
         await page.waitForTimeout(2000);
         await expect(page.getByRole('row', { name: labManagerName })).toBeVisible();
 

--- a/packages/front-end/tests/e2e/sys-admin/Organizations_System_Admin.spec.e2e.ts
+++ b/packages/front-end/tests/e2e/sys-admin/Organizations_System_Admin.spec.e2e.ts
@@ -233,14 +233,14 @@ test('07 - View All labs tab', async ({ page, baseURL }) => {
         await page.getByRole('row', { name: labNameUpdated }).click();
         await page.waitForTimeout(2000);
 
-        //Lab Users tab
+        //Users tab
         await expect(page.getByRole('tab', { name: 'Users' })).toBeVisible();
         await expect(page.getByRole('tab', { name: 'Settings' })).toBeVisible();
         await page.waitForTimeout(2000);
         await expect(page.getByRole('row', { name: labManagerName })).toBeVisible();
 
-        //Details tab
-        await page.getByRole('tab', { name: 'Details' }).click();
+        //Settings tab
+        await page.getByRole('tab', { name: 'Settings' }).click();
         await expect(page.getByText(labNameUpdated).nth(0)).toBeVisible();
         await expect(page.getByRole('button', { name: 'Edit' })).toBeDisabled();
       }


### PR DESCRIPTION
## Title*
This to correct the name of the Users and Settings tab which was missed in the previous PR

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Additional fix for the renamed tabs (Users & Settings)

## Testing*
Test case passed locally
![Screenshot 2025-03-20 at 6 37 19 PM](https://github.com/user-attachments/assets/0e5d3957-5cf8-4adc-a99f-0b92f310f6ae)


## Impact
This only affects 1 file - Organizations_System_Admin.spec.e2e.ts

## Additional Information
None

## Checklist*
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.