### PR TITLE
feat(EG-1087): update Organization create/update APIs to support NextFlowTowerApiBaseUrl setting

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/organization/create-organization.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/organization/create-organization.lambda.ts
@@ -39,8 +39,8 @@ export const handler: Handler = async (
       .add({
         ...request,
         OrganizationId: uuidv4(),
-        AwsHealthOmicsEnabled: request.AwsHealthOmicsEnabled || false,
-        NextFlowTowerEnabled: request.NextFlowTowerEnabled || false,
+        AwsHealthOmicsEnabled: request.AwsHealthOmicsEnabled || true,
+        NextFlowTowerEnabled: request.NextFlowTowerEnabled || true,
         NextFlowTowerApiBaseUrl: request.NextFlowTowerApiBaseUrl || process.env.SEQERA_API_BASE_URL,
         CreatedAt: new Date().toISOString(),
         CreatedBy: userId,

--- a/packages/back-end/src/app/controllers/easy-genomics/organization/create-organization.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/organization/create-organization.lambda.ts
@@ -35,12 +35,13 @@ export const handler: Handler = async (
     // Data validation safety check
     if (!CreateOrganizationSchema.safeParse(request).success) throw new InvalidRequestError();
 
-    const response: Organization = await organizationService
+    const response: Organization | void = await organizationService
       .add({
         ...request,
         OrganizationId: uuidv4(),
         AwsHealthOmicsEnabled: request.AwsHealthOmicsEnabled || false,
         NextFlowTowerEnabled: request.NextFlowTowerEnabled || false,
+        NextFlowTowerApiBaseUrl: request.NextFlowTowerApiBaseUrl || process.env.SEQERA_API_BASE_URL,
         CreatedAt: new Date().toISOString(),
         CreatedBy: userId,
       })

--- a/packages/back-end/src/app/controllers/easy-genomics/organization/update-organization.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/organization/update-organization.lambda.ts
@@ -36,11 +36,12 @@ export const handler: Handler = async (
 
     // Lookup by OrganizationId to confirm existence before updating
     const existing: Organization = await organizationService.get(id);
-    const updated: Organization = await organizationService
+    const updated: Organization | void = await organizationService
       .update(
         {
           ...existing,
           ...request,
+          NextFlowTowerApiBaseUrl: request.NextFlowTowerApiBaseUrl || process.env.SEQERA_API_BASE_URL,
           ModifiedAt: new Date().toISOString(),
           ModifiedBy: userId,
         },

--- a/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
@@ -172,6 +172,16 @@ export class EasyGenomicsNestedStack extends NestedStack {
             SNS_USER_DELETION_TOPIC: this.sns.snsTopics.get('user-deletion-topic')?.topicArn || '',
           },
         },
+        '/easy-genomics/organization/create-organization': {
+          environment: {
+            SEQERA_API_BASE_URL: this.props.seqeraApiBaseUrl,
+          },
+        },
+        '/easy-genomics/organization/update-organization': {
+          environment: {
+            SEQERA_API_BASE_URL: this.props.seqeraApiBaseUrl,
+          },
+        },
         '/easy-genomics/organization/delete-organization': {
           environment: {
             SNS_ORGANIZATION_DELETION_TOPIC: this.sns.snsTopics.get('organization-deletion-topic')?.topicArn || '',

--- a/packages/back-end/src/main.ts
+++ b/packages/back-end/src/main.ts
@@ -166,21 +166,22 @@ if (process.env.CI_CD === 'true') {
 
   seqeraApiBaseUrl = configSettings['back-end']['seqera-api-base-url'] || SEQERA_API_BASE_URL;
 
-  if (
-    configSettings['back-end']['vpc-peering'] &&
-    configSettings['back-end']['vpc-peering']['external-vpc-id'] &&
-    configSettings['back-end']['vpc-peering']['external-aws-account-id'] &&
-    configSettings['back-end']['vpc-peering']['external-aws-region'] &&
-    configSettings['back-end']['vpc-peering']['external-role-arn'] &&
-    configSettings['back-end']['vpc-peering']['external-cidr-block']
-  ) {
-    vpcPeering = {
-      externalVpcId: configSettings['back-end']['vpc-peering']['external-vpc-id'],
-      externalAwsAccountId: configSettings['back-end']['vpc-peering']['external-aws-account-id'],
-      externalAwsRegion: configSettings['back-end']['vpc-peering']['external-aws-region'],
-      externalRoleArn: configSettings['back-end']['vpc-peering']['external-role-arn'],
-      externalCidrBlock: configSettings['back-end']['vpc-peering']['external-cidr-block'],
-    };
+  const vpcPeeringSettings = configSettings['back-end']['vpc-peering'];
+  if (vpcPeeringSettings) {
+    const externalVpcId = vpcPeeringSettings['external-vpc-id'];
+    const externalAwsAccountId = vpcPeeringSettings['external-aws-account-id'];
+    const externalAwsRegion = vpcPeeringSettings['external-aws-region'];
+    const externalRoleArn = vpcPeeringSettings['external-role-arn'];
+    const externalCidrBlock = vpcPeeringSettings['external-cidr-block'];
+    if (externalVpcId && externalAwsAccountId && externalAwsRegion && externalRoleArn && externalCidrBlock) {
+      vpcPeering = {
+        externalVpcId: externalVpcId,
+        externalAwsAccountId: externalAwsAccountId,
+        externalAwsRegion: externalAwsRegion,
+        externalRoleArn: externalRoleArn,
+        externalCidrBlock: externalCidrBlock,
+      };
+    }
   }
 
   if (!awsAccountId) {

--- a/packages/shared-lib/src/app/schema/easy-genomics/organization.ts
+++ b/packages/shared-lib/src/app/schema/easy-genomics/organization.ts
@@ -8,6 +8,7 @@ export const OrganizationSchema = z
     Country: z.string().optional(),
     AwsHealthOmicsEnabled: z.boolean().optional(),
     NextFlowTowerEnabled: z.boolean().optional(),
+    NextFlowTowerApiBaseUrl: z.string().optional(),
     CreatedAt: z.string().optional(),
     CreatedBy: z.string().optional(),
     ModifiedAt: z.string().optional(),
@@ -22,6 +23,7 @@ export const CreateOrganizationSchema = z
     Country: z.string().optional(),
     AwsHealthOmicsEnabled: z.boolean().optional(),
     NextFlowTowerEnabled: z.boolean().optional(),
+    NextFlowTowerApiBaseUrl: z.string().optional(),
   })
   .strict();
 
@@ -32,5 +34,6 @@ export const UpdateOrganizationSchema = z
     Country: z.string().optional(),
     AwsHealthOmicsEnabled: z.boolean().optional(),
     NextFlowTowerEnabled: z.boolean().optional(),
+    NextFlowTowerApiBaseUrl: z.string().optional(),
   })
   .strict();

--- a/packages/shared-lib/src/app/types/easy-genomics/organization.d.ts
+++ b/packages/shared-lib/src/app/types/easy-genomics/organization.d.ts
@@ -15,6 +15,7 @@
  *   Country?: <string>,
  *   AwsHealthOmicsEnabled?: <string>,
  *   NextFlowTowerEnabled?: <string>,
+ *   NextFlowTowerApiBaseUrl?: <string>,
  *   BillingContact?: <string>,
  *   BillingMethod?: <string>,
  *   CreatedAt?: <string>,
@@ -34,6 +35,7 @@ export interface Organization extends BaseAttributes {
   Country?: string;
   AwsHealthOmicsEnabled?: boolean;
   NextFlowTowerEnabled?: boolean;
+  NextFlowTowerApiBaseUrl?: string;
   BillingContact?: string;
   BillingMethod?: string;
 }

--- a/packages/shared-lib/src/app/types/easy-genomics/sample-data.ts
+++ b/packages/shared-lib/src/app/types/easy-genomics/sample-data.ts
@@ -16,6 +16,7 @@ export const organization: Organization = {
   Country: 'USA',
   AwsHealthOmicsEnabled: true,
   NextFlowTowerEnabled: true,
+  NextFlowTowerApiBaseUrl: 'https://api.cloud.seqera.io',
   CreatedAt: new Date().toISOString(),
 };
 


### PR DESCRIPTION
## Title*
Update Organization create/update APIs to support `NextFlowTowerApiBaseUrl` setting

## Type of Change*
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
This PR enhances the existing Organization `create-organization` and `update-organization` API endpoints to support the the `NextFlowTowerApiBaseUrl` setting at the Organization level. 

If it is undefined, it will default to the value set in Back-End main stack's `seqeraApiBaseUrl` setting, which defaults to `https://api.cloud.seqera.io` or can be overridden by the optional `easy-genomics.yaml` > `back-end` > `seqera-api-base-url`  configuration parameter.

This enhancement is to allow the FE to easily obtain the associated parent Organization's `NextFlowTowerApiBaseUrl` value when creating a new Laboratory, or updating an existing Laboratory to make the Laboratory's Seqera Base API URL more visible and configurable.

## Testing*
See associate JIRA ticket for testing instructions.

## Impact
None

## Additional Information
None

## Checklist*
- [X] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.