### PR TITLE
feat(EG-1054): add filtering support for list-laboratory-runs API

### DIFF
--- a/packages/back-end/src/app/utils/rest-api-utils.ts
+++ b/packages/back-end/src/app/utils/rest-api-utils.ts
@@ -125,3 +125,29 @@ export function getAwsHealthOmicsApiQueryParameters(event: APIGatewayProxyEvent)
 
   return apiQueryParameters;
 }
+
+/**
+ * Helper function to return valid query parameters that exist in the object's properties.
+ * @param objectProperties
+ * @param queryParameters
+ */
+export function getFilters(objectProperties: string[], queryParameters: [string, string][]): [string, string][] {
+  return queryParameters.filter((_: [string, string]) => objectProperties.includes(_[0]));
+}
+
+/**
+ * Helper recursive function to apply filters object records by the supplied filters.
+ * @param results
+ * @param filters
+ */
+export function getFilterResults<T>(results: T[], filters: [string, string][]): T[] {
+  if (filters.length === 0) {
+    return results;
+  }
+
+  const filter: [string, string] = filters.shift();
+  const filterResults = results.filter((r: T) => r[filter[0]] === filter[1]);
+
+  // Recursion
+  return getFilterResults<T>(filterResults, filters);
+}

--- a/packages/back-end/src/app/utils/rest-api-utils.ts
+++ b/packages/back-end/src/app/utils/rest-api-utils.ts
@@ -145,8 +145,16 @@ export function getFilterResults<T>(results: T[], filters: [string, string][]): 
     return results;
   }
 
-  const filter: [string, string] = filters.shift();
-  const filterResults = results.filter((r: T) => r[filter[0]] === filter[1]);
+  const [filterKey, filterVal] = filters.shift();
+  const filterResults = results.filter((r: T) => {
+    if (filterVal.startsWith('*')) {
+      return r[filterKey].endsWith(filterVal.slice(1)); // Ignore leading *
+    } else if (filterVal.endsWith('*')) {
+      return r[filterKey].startsWith(filterVal.slice(0, -1)); // Ignore trailing *
+    } else {
+      return r[filterKey] === filterVal;
+    }
+  });
 
   // Recursion
   return getFilterResults<T>(filterResults, filters);

--- a/packages/front-end/src/app/repository/modules/labs.ts
+++ b/packages/front-end/src/app/repository/modules/labs.ts
@@ -199,7 +199,7 @@ class LabsModule extends HttpFactory {
   }
 
   async listLabRuns(labId: string): Promise<LaboratoryRun[]> {
-    const res = await this.call<LaboratoryRun[]>('GET', `/laboratory/run/list-laboratory-runs?laboratoryId=${labId}`);
+    const res = await this.call<LaboratoryRun[]>('GET', `/laboratory/run/list-laboratory-runs?LaboratoryId=${labId}`);
 
     if (!res) {
       throw new Error('Failed to retrieve Laboratory runs');


### PR DESCRIPTION
## Title*
Add filtering support for list-laboratory-runs API

## Type of Change*
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
This PR adds logic to support filtering for the `/easy-genomics/laboratory/run/list-laboratory-runs` API to support filtering by one or more properties in the `LaboratoryRun` object type through the use of query parameters.

The filtering is performed in the order of the supplied query parameters, and the query parameters must match the `LaboratoryRun`'s property names and property value stored in the database record (i.e. it is case-sensitive).

e.g.
 - `/easy-genomics/laboratory/run/list-laboratory-runs?LaboratoryId={LabId}&Status=COMPLETED`

The filtering also supports partial filtering by the supplied value with the use of '*' character.

e.g.
 - `/easy-genomics/laboratory/run/list-laboratory-runs?LaboratoryId={LabId}&RunName=*-my-test-run-name` // filter records with RunName ending with `-my-test-run-name`
 - `/easy-genomics/laboratory/run/list-laboratory-runs?LaboratoryId={LabId}&RunName=my-test-run-name-*` // filter records with RunName starting with `my-test-run-name-`

The filtering logic is reusable and can be easily added to other List APIs to provide the same filtering behavior with respect to its object's own properties.

## Testing*
See associated JIRA ticket for testing instructions.

## Impact
None.

## Additional Information
None.

## Checklist*
- [X] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.