### PR TITLE
feat(EG-1071): filter my own runs with run table BE sort

### DIFF
--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -15,6 +15,7 @@
   import { Pipeline as SeqeraPipeline } from '@easy-genomics/shared-lib/src/app/types/nf-tower/nextflow-tower-api';
   import { WorkflowListItem as OmicsWorkflow } from '@aws-sdk/client-omics';
   import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory-run';
+  import { TableSort } from './EGTable.vue';
 
   const props = defineProps<{
     superuser?: boolean;
@@ -125,11 +126,18 @@
     { key: 'actions', label: 'Actions' },
   ];
 
+  const runsTableSort = ref<TableSort>({ column: 'CreatedAt', direction: 'desc' });
+
   const runsTableItems = computed<LaboratoryRunTableItem[]>(() =>
-    runStore.labRunsForLab(props.labId).map((labRun) => ({
-      ...labRun,
-      lastUpdated: labRun.ModifiedAt ?? labRun.CreatedAt ?? '',
-    })),
+    runStore
+      .labRunsForLab(props.labId)
+      .map((labRun) => ({
+        ...labRun,
+        lastUpdated: labRun.ModifiedAt ?? labRun.CreatedAt ?? '',
+      }))
+      .sort((a: any, b: any) =>
+        stringSortCompare(a[runsTableSort.value.column], b[runsTableSort.value.column], runsTableSort.value.direction),
+      ),
   );
 
   function runsActionItems(run: LaboratoryRun): object[] {
@@ -566,7 +574,7 @@
           :row-click-action="viewRunDetails"
           :table-data="runsTableItems"
           :columns="runsTableColumns"
-          :sort="{ column: 'CreatedAt', direction: 'desc' }"
+          v-model:sort="runsTableSort"
           :is-loading="useUiStore().anyRequestPending(['loadLabData', 'loadLabRuns'])"
           :show-pagination="!useUiStore().anyRequestPending(['loadLabData', 'loadLabRuns'])"
         >

--- a/packages/front-end/src/app/repository/modules/labs.ts
+++ b/packages/front-end/src/app/repository/modules/labs.ts
@@ -198,8 +198,12 @@ class LabsModule extends HttpFactory {
     return res;
   }
 
-  async listLabRuns(labId: string): Promise<LaboratoryRun[]> {
-    const res = await this.call<LaboratoryRun[]>('GET', `/laboratory/run/list-laboratory-runs?LaboratoryId=${labId}`);
+  async listLabRuns(labId: string, filterOwner?: string): Promise<LaboratoryRun[]> {
+    let queryUrl = `/laboratory/run/list-laboratory-runs?LaboratoryId=${labId}`;
+
+    if (filterOwner) queryUrl += '&Owner=' + filterOwner;
+
+    const res = await this.call<LaboratoryRun[]>('GET', queryUrl);
 
     if (!res) {
       throw new Error('Failed to retrieve Laboratory runs');


### PR DESCRIPTION
## Title*

Implement My Own Runs filter checkbox using new BE filtering function

## Type of Change*
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

![image](https://github.com/user-attachments/assets/36e43b2b-582a-496d-b7b5-66569c4705f2)

## Testing*

When checkbox is changed, the runs are refetched from the BE using the server-side filter.

The table behaves correctly in displaying the updated rows. Testing included:

- filtered values were less than 1 page - pagination disappeared ✅ 
- filtered values were more than 1 page - pagination worked as expected ✅ 
- sort remains across filter changes and results follow sort in all cases ✅ 

## Impact

## Additional Information

- Future design changes may be implemented in further PRs pending designs being created for this feature.

## Checklist*
- [X] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.