### PR TITLE
feat: implement cancelling omics runs

### DIFF
--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -165,7 +165,7 @@
       [{ label: 'View Files', click: () => viewRunDetails(run, 'File Manager') }],
     ];
 
-    if (['SUBMITTED', 'RUNNING'].includes(run.Status)) {
+    if (['SUBMITTED', 'STARTING', 'RUNNING'].includes(run.Status)) {
       buttons.push([{ label: 'Cancel Run', click: () => initCancelRun(run), isHighlighted: true }]);
     }
 
@@ -457,7 +457,7 @@
         await $api.seqeraRuns.cancelPipelineRun(props.labId, runId);
       } else {
         uiStore.setRequestPending('cancelOmicsRun');
-        // await $api.omicsRuns.cancelPipelineRun(props.labId, runId); // TODO
+        await $api.omicsRuns.cancelWorkflowRun(props.labId, runId);
       }
     } catch (e) {
       useToastStore().error('Failed to cancel run');

--- a/packages/front-end/src/app/repository/modules/omics-runs.ts
+++ b/packages/front-end/src/app/repository/modules/omics-runs.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/named
-import { StartRunCommandOutput } from '@aws-sdk/client-omics';
+import { CancelRunCommandOutput, StartRunCommandOutput } from '@aws-sdk/client-omics';
 import { ListRuns, ReadRun } from '@easy-genomics/shared-lib/src/app/types/aws-healthomics/aws-healthomics-api';
 import HttpFactory from '@FE/repository/factory';
 
@@ -44,6 +44,17 @@ class OmicsRunsModule extends HttpFactory {
     if (!res) {
       throw new Error('Failed to start omics run');
     }
+
+    return res;
+  }
+
+  async cancelWorkflowRun(labId: string, runId: string): Promise<CancelRunCommandOutput> {
+    const res = await this.callOmics<CancelRunCommandOutput>(
+      'PUT',
+      `/run/cancel-run-execution/${runId}?laboratoryId=${labId}`,
+    );
+
+    if (!res) throw new Error('Failed to cancel omics run');
 
     return res;
   }


### PR DESCRIPTION
## Title*

Implement cancelling Omics runs

## Type of Change*
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

I must have missed this a while back and it's never come up until now.

## Testing*

The cancel request is sent. However it seems that at the moment, cancel requests for either type of runs are failing. We'll look into this soon.

## Impact

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.