### PR TITLE
fix(EG-1092): update BE laboratory APIs test call to seqera to use NextFlowTowerApiBaseUrl

### DIFF
--- a/packages/front-end/src/app/components/EGFormLabDetails.vue
+++ b/packages/front-end/src/app/components/EGFormLabDetails.vue
@@ -426,6 +426,7 @@
         label="Personal Access Token"
         name="NextFlowTowerAccessToken"
         eager-validation
+        :required="formMode === LabDetailsFormModeEnum.enum.Create"
       >
         <!-- Next Flow Tower: Access Token: Create  Mode -->
         <EGPasswordInput
@@ -434,6 +435,7 @@
           :password="true"
           :autocomplete="AutoCompleteOptionsEnum.enum.NewPassword"
           :disabled="!isEditing || isSubmittingFormData"
+          :required="formMode === LabDetailsFormModeEnum.enum.Create"
         />
         <!-- Next Flow Tower: Access Token: Edit  Mode -->
         <EGPasswordInput

--- a/packages/shared-lib/src/app/utils/HttpError.ts
+++ b/packages/shared-lib/src/app/utils/HttpError.ts
@@ -264,13 +264,13 @@ export class LaboratoryAccessTokenUnavailableError extends HttpError {
 }
 
 /**
- * Laboratory WorkspaceId Or Access Token Incorrect
+ * Laboratory Seqera Credentials Incorrect
  *
  * @param messageOpt - optional additional message
  */
-export class LaboratoryWorkspaceIdOrAccessTokenIncorrectError extends HttpError {
+export class LaboratorySeqeraCredentialsIncorrectError extends HttpError {
   constructor(messageOpt?: string) {
-    super('Laboratory WorkspaceId or Access Token is incorrect', 400, 'EG-308', messageOpt);
+    super('Laboratory Seqera BaseApiUrl, WorkspaceId, or AccessToken are incorrect', 400, 'EG-308', messageOpt);
   }
 }
 


### PR DESCRIPTION
## Title*
Update BE laboratory APIs test call to seqera to use NextFlowTowerApiBaseUrl

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
This PR fixes the Seqera API test logic used in the `/easy-genomics/laboratory/create-laboratory` and `/easy-genomics/laboratory/update-laboratory` APIs to use the Lab's supplied `NextFlowTowerApiBaseUrl` instead of the BE configuration value.

It also fixes the FE CreateLaboratory Settings UI to make the `NextFlowTowerAccessToken` field mandatory only when creating a new Laboratory.

## Testing*
See associated JIRA ticket for testing instructions.

## Impact
None.

## Additional Information
None.

## Checklist*
- [X] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.