### PR TITLE
fix: table multi-page sort broken by filter feature

### DIFF
--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -136,6 +136,9 @@
   watchEffect(async () => {
     uiStore.setRequestPending('loadLabRuns');
 
+    // without this following line, watchEffect doesn't pick up runsTableSort as a reactive dependency...
+    runsTableSort.value;
+
     try {
       runsTableItems.value = (
         await $api.labs.listLabRuns(

--- a/packages/front-end/src/app/components/EGTable.vue
+++ b/packages/front-end/src/app/components/EGTable.vue
@@ -76,6 +76,7 @@
       :rows="rows"
       :columns="columns"
       v-model:sort="sort"
+      sort-mode="manual"
       :loading="isLoading"
       :loading-state="{ icon: '', label: '' }"
       v-model="selected"


### PR DESCRIPTION
## Title*

Fix table multi-page sort not working again because of the filter feature

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Now, the table data is refetched on sort change, as it should

## Testing*

## Impact

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.