### PR TITLE
feat(EG-1095): add default seqera endpoint url field to org settings

### DIFF
--- a/packages/front-end/src/app/components/EGFormOrgDetails.vue
+++ b/packages/front-end/src/app/components/EGFormOrgDetails.vue
@@ -14,16 +14,28 @@
     defineProps<{
       name?: string;
       description?: string;
+      seqeraBaseUrl?: string;
     }>(),
     {
       name: '',
       description: '',
+      seqeraBaseUrl: '',
     },
+  );
+
+  // when the prop changes (as it will when autofilled with the default value) we need to manually update the form
+  watch(
+    () => props.seqeraBaseUrl,
+    (newVal) => (formState.NextFlowTowerApiBaseUrl = newVal),
   );
 
   // Form-related refs and computed props
   const didFormStateChange = computed(() => {
-    return props.name !== formState.Name || props.description !== formState.Description;
+    return (
+      props.name !== formState.Name ||
+      props.description !== formState.Description ||
+      props.seqeraBaseUrl !== formState.NextFlowTowerApiBaseUrl
+    );
   });
   const orgNameCharCount = computed(() => formState.Name.length);
   const orgDescriptionCharCount = computed(() => formState.Description.length);
@@ -36,6 +48,7 @@
   const formState = reactive({
     Name: props.name,
     Description: props.description,
+    NextFlowTowerApiBaseUrl: props.seqeraBaseUrl,
     isFormValid: false,
     isFormDisabled: true,
   });
@@ -101,6 +114,14 @@
           :disabled="isPending"
         />
         <EGCharacterCounter :value="orgDescriptionCharCount" :max="ORG_DESCRIPTION_MAX_LENGTH" />
+      </EGFormGroup>
+      <EGFormGroup label="Default Seqera Endpoint URL" name="NextFlowTowerApiBaseUrl">
+        <EGInput
+          v-model.trim="formState.NextFlowTowerApiBaseUrl"
+          @blur="validateForm"
+          placeholder="If left blank, will default to the value defined in the config file easy-genomics.yaml"
+          :disabled="isPending"
+        />
       </EGFormGroup>
     </EGCard>
     <EGButton

--- a/packages/front-end/src/app/components/EGFormOrgDetails.vue
+++ b/packages/front-end/src/app/components/EGFormOrgDetails.vue
@@ -23,12 +23,6 @@
     },
   );
 
-  // when the prop changes (as it will when autofilled with the default value) we need to manually update the form
-  watch(
-    () => props.seqeraBaseUrl,
-    (newVal) => (formState.NextFlowTowerApiBaseUrl = newVal),
-  );
-
   // Form-related refs and computed props
   const didFormStateChange = computed(() => {
     return (

--- a/packages/front-end/src/app/components/EGOrgView.vue
+++ b/packages/front-end/src/app/components/EGOrgView.vue
@@ -2,7 +2,6 @@
   import { OrganizationUserDetails } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/organization-user-details';
   import { OrgUser } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/user-unified';
   import { UserSchema } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/user';
-  import { useOrgsStore, useToastStore, useUiStore } from '@FE/stores';
   import useUser from '@FE/composables/useUser';
   import { ButtonVariantEnum } from '@FE/types/buttons';
   import { DeletedResponse } from '@FE/types/api';
@@ -24,6 +23,8 @@
   const buttonRequestPending = ref<Record<number, boolean>>({});
   const orgUsersDetailsData = ref<OrgUser[]>([]);
   const showInviteModule = ref(false);
+
+  const resetFormKey = ref(0);
 
   const hasNoData = computed<boolean>(() => orgUsersDetailsData.value.length === 0);
   const isLoading = computed<boolean>(() => useUiStore().anyRequestPending(['fetchOrgData', 'editOrg']));
@@ -197,6 +198,8 @@
       throw error;
     } finally {
       useUiStore().setRequestComplete('fetchOrgData');
+      // force remount of form to get fresh org values
+      resetFormKey.value++;
     }
   }
 
@@ -326,6 +329,7 @@
   <UTabs :ui="EGTabsStyles" :default-index="0" :items="tabItems">
     <template #details>
       <EGFormOrgDetails
+        :key="resetFormKey"
         @submit-form-org-details="onSubmit($event)"
         :name="org.Name"
         :description="org.Description"

--- a/packages/front-end/src/app/components/EGOrgView.vue
+++ b/packages/front-end/src/app/components/EGOrgView.vue
@@ -269,8 +269,8 @@
   async function onSubmit(event: FormSubmitEvent<OrgDetailsForm>) {
     try {
       useUiStore().setRequestPending('editOrg');
-      const { Name, Description } = event.data;
-      await $api.orgs.update(props.orgId, { Name, Description });
+      const { Name, Description, NextFlowTowerApiBaseUrl } = event.data;
+      await $api.orgs.update(props.orgId, { Name, Description, NextFlowTowerApiBaseUrl });
       await fetchOrgData();
       useToastStore().success('Organization updated');
     } catch (error) {
@@ -325,7 +325,12 @@
 
   <UTabs :ui="EGTabsStyles" :default-index="0" :items="tabItems">
     <template #details>
-      <EGFormOrgDetails @submit-form-org-details="onSubmit($event)" :name="org.Name" :description="org.Description" />
+      <EGFormOrgDetails
+        @submit-form-org-details="onSubmit($event)"
+        :name="org.Name"
+        :description="org.Description"
+        :seqera-base-url="org.NextFlowTowerApiBaseUrl"
+      />
     </template>
 
     <template #labs v-if="props.superuser">

--- a/packages/front-end/src/app/pages/admin/orgs/create.vue
+++ b/packages/front-end/src/app/pages/admin/orgs/create.vue
@@ -12,8 +12,8 @@
   async function onSubmit(event: FormSubmitEvent<OrgDetailsForm>) {
     try {
       useUiStore().setRequestPending('createOrg');
-      const { Name, Description } = event.data;
-      await $api.orgs.create({ Name, Description });
+      const { Name, Description, NextFlowTowerApiBaseUrl } = event.data;
+      await $api.orgs.create({ Name, Description, NextFlowTowerApiBaseUrl });
       useToastStore().success('Organization created');
       router.push({ path: '/admin/orgs' });
     } catch (error) {

--- a/packages/front-end/src/app/repository/modules/orgs.ts
+++ b/packages/front-end/src/app/repository/modules/orgs.ts
@@ -117,7 +117,7 @@ class OrgsModule extends HttpFactory {
     return res;
   }
 
-  async update(orgId: string, body: Organization): Promise<Organization | undefined> {
+  async update(orgId: string, body: Partial<Organization>): Promise<Organization | undefined> {
     try {
       UpdateOrganizationSchema.parse(body);
     } catch (error) {

--- a/packages/front-end/src/app/types/forms.ts
+++ b/packages/front-end/src/app/types/forms.ts
@@ -49,6 +49,7 @@ export const OrgDescriptionSchema = z
 export const OrgDetailsFormSchema = z.object({
   Name: OrgNameSchema,
   Description: OrgDescriptionSchema,
+  NextFlowTowerApiBaseUrl: z.string().min(0),
 });
 export type OrgDetailsForm = z.infer<typeof OrgDetailsFormSchema>;
 


### PR DESCRIPTION
## Title*

Add Default Seqera Endpoint URL field to Org settings

## Type of Change*
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

![image](https://github.com/user-attachments/assets/e6ac1385-60ad-4fa1-b55c-553f358580af)

![image](https://github.com/user-attachments/assets/57bfa4a1-a06d-4ac5-be58-c96a8fe4554c)

## Testing*

Tested saving and creating with values, and blank input which gets set to config default

## Impact

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.