### PR TITLE
feat(EG-1088): BE support for lab pipeline/workflow restrictions

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/pipeline/update-laboratory-pipelines.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/pipeline/update-laboratory-pipelines.lambda.ts
@@ -48,11 +48,19 @@ export const handler: Handler = async (
       throw new UnauthorizedAccessError();
     }
 
+    // Only store Workflows/Pipelines that have been selected
+    const awsHealthOmicsWorkflows = Object.entries(<AwsHealthOmicsWorkflows>request.AwsHealthOmicsWorkflows).filter(
+      (value: [string, boolean]) => value[1] === true,
+    );
+    const nextFlowTowerPipelines = Object.entries(<NextFlowTowerPipelines>request.NextFlowTowerPipelines).filter(
+      (value: [string, boolean]) => value[1] === true,
+    );
+
     const response: Laboratory | void = await laboratoryPipelineService
       .updateLaboratoryPipelines({
         ...existing,
-        AwsHealthOmicsWorkflows: <AwsHealthOmicsWorkflows>request.AwsHealthOmicsWorkflows,
-        NextFlowTowerPipelines: <NextFlowTowerPipelines>request.NextFlowTowerPipelines,
+        AwsHealthOmicsWorkflows: <AwsHealthOmicsWorkflows>Object.fromEntries(awsHealthOmicsWorkflows),
+        NextFlowTowerPipelines: <NextFlowTowerPipelines>Object.fromEntries(nextFlowTowerPipelines),
         ModifiedAt: new Date().toISOString(),
         ModifiedBy: userId,
       })

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/pipeline/update-laboratory-pipelines.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/pipeline/update-laboratory-pipelines.lambda.ts
@@ -1,0 +1,68 @@
+import {
+  UpdateLaboratoryPipelines,
+  UpdateLaboratoryPipelinesSchema,
+} from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/laboratory-pipeline';
+import {
+  AwsHealthOmicsWorkflows,
+  Laboratory,
+  NextFlowTowerPipelines,
+} from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
+import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/src/app/utils/common';
+import {
+  InvalidRequestError,
+  RequiredIdNotFoundError,
+  UnauthorizedAccessError,
+} from '@easy-genomics/shared-lib/src/app/utils/HttpError';
+import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
+import { LaboratoryPipelineService } from '@BE/services/easy-genomics/laboratory-pipeline-service';
+import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
+import { validateOrganizationAdminAccess } from '@BE/utils/auth-utils';
+
+const laboratoryService = new LaboratoryService();
+const laboratoryPipelineService = new LaboratoryPipelineService();
+
+export const handler: Handler = async (
+  event: APIGatewayProxyWithCognitoAuthorizerEvent,
+): Promise<APIGatewayProxyResult> => {
+  console.log('EVENT: \n' + JSON.stringify(event, null, 2));
+  try {
+    // Get Path Parameter
+    const id: string = event.pathParameters?.id || '';
+    if (id === '') throw new RequiredIdNotFoundError();
+
+    const userId: string = event.requestContext.authorizer.claims['cognito:username'];
+    // Put Request Body
+    const request: UpdateLaboratoryPipelines = event.isBase64Encoded
+      ? JSON.parse(atob(event.body!))
+      : JSON.parse(event.body!);
+    // Data validation safety check
+    if (!UpdateLaboratoryPipelinesSchema.safeParse(request).success) {
+      throw new InvalidRequestError();
+    }
+
+    // Lookup by LaboratoryId to confirm existence before updating
+    const existing: Laboratory = await laboratoryService.queryByLaboratoryId(id);
+
+    // Only Organisation Admins are allowed to edit laboratories
+    if (!validateOrganizationAdminAccess(event, existing.OrganizationId)) {
+      throw new UnauthorizedAccessError();
+    }
+
+    const response: Laboratory | void = await laboratoryPipelineService
+      .updateLaboratoryPipelines({
+        ...existing,
+        AwsHealthOmicsWorkflows: <AwsHealthOmicsWorkflows>request.AwsHealthOmicsWorkflows,
+        NextFlowTowerPipelines: <NextFlowTowerPipelines>request.NextFlowTowerPipelines,
+        ModifiedAt: new Date().toISOString(),
+        ModifiedBy: userId,
+      })
+      .catch((error: any) => {
+        throw error;
+      });
+
+    return buildResponse(200, JSON.stringify(response), event);
+  } catch (err: any) {
+    console.error(err);
+    return buildErrorResponse(err, event);
+  }
+};

--- a/packages/back-end/src/app/services/easy-genomics/laboratory-pipeline-service.ts
+++ b/packages/back-end/src/app/services/easy-genomics/laboratory-pipeline-service.ts
@@ -1,0 +1,46 @@
+import { TransactWriteItemsCommandOutput } from '@aws-sdk/client-dynamodb';
+import { marshall } from '@aws-sdk/util-dynamodb';
+import { LaboratorySchema } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/laboratory';
+import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
+import { LaboratoryService } from './laboratory-service';
+
+export class LaboratoryPipelineService extends LaboratoryService {
+  readonly LABORATORY_TABLE_NAME: string = `${process.env.NAME_PREFIX}-laboratory-table`;
+  readonly LABORATORY_PIPELINE_TABLE_NAME: string = `${process.env.NAME_PREFIX}-laboratory-pipeline-table`;
+
+  public constructor() {
+    super();
+  }
+
+  public updateLaboratoryPipelines = async (laboratory: Laboratory): Promise<Laboratory> => {
+    const logRequestMessage = `Update Laboratory Pipelines LaboratoryId=${laboratory.LaboratoryId}, Name=${laboratory.Name} request`;
+    console.info(logRequestMessage);
+
+    // Data validation safety check
+    if (!LaboratorySchema.safeParse(laboratory).success) throw new Error('Invalid request');
+
+    // Perform transaction update request
+    const response: TransactWriteItemsCommandOutput = await this.transactWriteItems({
+      TransactItems: [
+        {
+          Put: {
+            TableName: this.LABORATORY_TABLE_NAME,
+            ConditionExpression: 'attribute_exists(#OrganizationId) AND attribute_exists(#LaboratoryId)',
+            ExpressionAttributeNames: {
+              '#OrganizationId': 'OrganizationId',
+              '#LaboratoryId': 'LaboratoryId',
+            },
+            Item: marshall(laboratory, { removeUndefinedValues: true }),
+          },
+        },
+      ],
+    });
+
+    if (response.$metadata.httpStatusCode === 200) {
+      // Transaction Updates do not return the updated Laboratory details, so explicitly retrieve it
+      return this.get(laboratory.OrganizationId, laboratory.LaboratoryId);
+    } else {
+      throw new Error(`${logRequestMessage} unsuccessful: HTTP Status Code=${response.$metadata.httpStatusCode}`);
+    }
+  };
+}

--- a/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
@@ -1005,6 +1005,18 @@ export class EasyGenomicsNestedStack extends NestedStack {
       }),
     ]);
 
+    // /easy-genomics/laboratory/pipeline/update-laboratory-pipelines
+    this.iam.addPolicyStatements('/easy-genomics/laboratory/pipeline/update-laboratory-pipelines', [
+      new PolicyStatement({
+        resources: [
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table`,
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table/index/*`,
+        ],
+        actions: ['dynamodb:Query', 'dynamodb:PutItem'],
+        effect: Effect.ALLOW,
+      }),
+    ]);
+
     // /easy-genomics/user/create-user-invitation-request
     this.iam.addPolicyStatements('/easy-genomics/user/create-user-invitation-request', [
       new PolicyStatement({

--- a/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
@@ -1012,7 +1012,7 @@ export class EasyGenomicsNestedStack extends NestedStack {
           `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table`,
           `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table/index/*`,
         ],
-        actions: ['dynamodb:Query', 'dynamodb:PutItem'],
+        actions: ['dynamodb:GetItem', 'dynamodb:Query', 'dynamodb:PutItem'],
         effect: Effect.ALLOW,
       }),
     ]);

--- a/packages/front-end/src/app/components/EGFormLabDetails.vue
+++ b/packages/front-end/src/app/components/EGFormLabDetails.vue
@@ -530,7 +530,11 @@
         <UToggle class="ml-2" v-model="state.AwsHealthOmicsEnabled" :disabled="!isEditing || isSubmittingFormData" />
       </EGFormGroup>
 
-      <template v-if="formMode !== LabDetailsFormModeEnum.enum.Create">
+      <template
+        v-if="
+          (state.NextFlowTowerEnabled || state.AwsHealthOmicsEnabled) && formMode !== LabDetailsFormModeEnum.enum.Create
+        "
+      >
         <hr class="mb-6" />
 
         <!-- Pipeline Restrictions -->

--- a/packages/front-end/src/app/components/EGFormLabDetails.vue
+++ b/packages/front-end/src/app/components/EGFormLabDetails.vue
@@ -23,6 +23,10 @@
     UpdateLaboratory,
     UpdateLaboratorySchema,
   } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/laboratory';
+  import {
+    UpdateLaboratoryPipelines,
+    UpdateLaboratoryPipelinesSchema,
+  } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/laboratory-pipeline';
   import { ERROR_CODES } from '@easy-genomics/shared-lib/src/app/constants/errorMessages';
 
   const props = withDefaults(
@@ -388,12 +392,22 @@
     showPipelineRestrictionsModal.value = true;
   }
 
-  function savePipelineRestrictions() {
+  async function savePipelineRestrictions() {
     showPipelineRestrictionsModal.value = false;
-    toastStore.info('Pipeline restrictions saving not implemented yet');
 
-    console.log('seqera:', JSON.stringify(inputSeqeraPipelinesRestrictions.value));
-    console.log('omics:', JSON.stringify(inputOmicsPipelinesRestrictions.value));
+    const labPipelines: UpdateLaboratoryPipelines = {
+      AwsHealthOmicsWorkflows: inputOmicsPipelinesRestrictions.value,
+      NextFlowTowerPipelines: inputSeqeraPipelinesRestrictions.value,
+    };
+
+    const parseResult = UpdateLaboratoryPipelinesSchema.safeParse(labPipelines);
+    if (!parseResult.success) {
+      const message = 'Update lab pipelines failed to parse lab details';
+      console.error(`${message}; parseResult: `, parseResult);
+      throw new Error(message);
+    }
+
+    await $api.labs.updateLabPipelines(labId, labPipelines);
   }
 </script>
 

--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -37,8 +37,6 @@
   const { stringSortCompare } = useSort();
 
   const labUsers = ref<LabUser[]>([]);
-  const seqeraPipelines = computed<SeqeraPipeline[]>(() => seqeraPipelinesStore.pipelinesForLab(props.labId));
-  const omicsWorkflows = computed<OmicsWorkflow[]>(() => omicsWorkflowsStore.workflowsForLab(props.labId));
   const canAddUsers = computed<boolean>(() => userStore.canAddLabUsers(props.labId));
   const showAddUserModule = ref(false);
   const searchOutput = ref('');
@@ -55,6 +53,11 @@
   const orgId = computed<string | null>(() => labStore.labs[props.labId].OrganizationId ?? null);
   const lab = computed<Laboratory | null>(() => labStore.labs[props.labId] ?? null);
   const labName = computed<string>(() => lab.value?.Name || '');
+  const labPipelines: string[] = computed<string[]>(() => Object.keys(lab.value?.NextFlowTowerPipelines));
+  const labWorkflows: string[] = computed<string[]>(() => Object.keys(lab.value?.AwsHealthOmicsWorkflows));
+
+  const seqeraPipelines = computed<SeqeraPipeline[]>(() => seqeraPipelinesStore.pipelinesForLab(props.labId));
+  const omicsWorkflows = computed<OmicsWorkflow[]>(() => omicsWorkflowsStore.workflowsForLab(props.labId));
 
   /**
    * Fetch Lab details, pipelines, workflows, runs, and Lab users before component mount and start periodic fetching
@@ -643,7 +646,7 @@
       <div v-if="item.key === 'seqeraPipelines'">
         <EGTable
           :row-click-action="viewRunSeqeraPipeline"
-          :table-data="seqeraPipelines"
+          :table-data="seqeraPipelines.filter((pipeline) => labPipelines.includes(pipeline.pipelineId.toString()))"
           :columns="seqeraPipelinesTableColumns"
           :is-loading="useUiStore().anyRequestPending(['loadLabData', 'getSeqeraPipelines'])"
           :show-pagination="!useUiStore().anyRequestPending(['loadLabData', 'getSeqeraPipelines'])"
@@ -676,7 +679,7 @@
       <div v-if="item.key === 'omicsWorkflows'">
         <EGTable
           :row-click-action="viewRunOmicsWorkflow"
-          :table-data="omicsWorkflows"
+          :table-data="omicsWorkflows.filter((workflow) => labWorkflows.includes(workflow.id.toString()))"
           :columns="omicsWorkflowsTableColumns"
           :is-loading="useUiStore().anyRequestPending(['loadLabData', 'getOmicsWorkflows'])"
           :show-pagination="!useUiStore().anyRequestPending(['loadLabData', 'getOmicsWorkflows'])"

--- a/packages/front-end/src/app/repository/modules/labs.ts
+++ b/packages/front-end/src/app/repository/modules/labs.ts
@@ -1,4 +1,5 @@
 import { CreateLaboratory, UpdateLaboratory } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/laboratory';
+import { UpdateLaboratoryPipelines } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/laboratory-pipeline';
 import { LaboratoryRunSchema } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/laboratory-run';
 import { RemoveLaboratoryUserSchema } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/laboratory-user';
 import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
@@ -233,6 +234,15 @@ class LabsModule extends HttpFactory {
     }
 
     validateApiResponse(LaboratoryRunSchema, res);
+    return res;
+  }
+
+  async updateLabPipelines(labId: string, labPipelines: UpdateLaboratoryPipelines): Promise<Laboratory> {
+    const res = await this.call<any>('PUT', `/laboratory/pipeline/update-laboratory-pipelines/${labId}`, labPipelines);
+    if (!res) {
+      console.error('Error calling update laboratory platform access API');
+      throw new Error('Failed to update laboratory platform access API');
+    }
     return res;
   }
 }

--- a/packages/shared-lib/src/app/schema/easy-genomics/laboratory-pipeline.ts
+++ b/packages/shared-lib/src/app/schema/easy-genomics/laboratory-pipeline.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+import { AwsHealthOmicsWorkflowsSchema, NextFlowTowerPipelinesSchema } from './laboratory';
+
+export const LaboratoryPipelineSchema = z.object({
+  PipelineId: z.string(),
+  LaboratoryId: z.string(),
+  OrganizationId: z.string(),
+  Platform: z.enum(['AWS HealthOmics', 'Seqera Cloud']),
+  CreatedAt: z.string().optional(),
+  CreatedBy: z.string().optional(),
+});
+export type LaboratoryPipeline = z.infer<typeof LaboratoryPipelineSchema>;
+
+export const UpdateLaboratoryPipelinesSchema = z.object({
+  AwsHealthOmicsWorkflows: AwsHealthOmicsWorkflowsSchema,
+  NextFlowTowerPipelines: NextFlowTowerPipelinesSchema,
+  CreatedAt: z.string().optional(),
+  CreatedBy: z.string().optional(),
+});
+export type UpdateLaboratoryPipelines = z.infer<typeof UpdateLaboratoryPipelinesSchema>;

--- a/packages/shared-lib/src/app/schema/easy-genomics/laboratory.ts
+++ b/packages/shared-lib/src/app/schema/easy-genomics/laboratory.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
 
+export const AwsHealthOmicsWorkflowsSchema = z.record(z.string(), z.boolean());
+
+export const NextFlowTowerPipelinesSchema = z.record(z.string(), z.boolean());
+
 export const LaboratorySchema = z
   .object({
     OrganizationId: z.string().uuid(),
@@ -9,9 +13,11 @@ export const LaboratorySchema = z
     S3Bucket: z.string().optional(),
     Status: z.enum(['Active', 'Inactive']),
     AwsHealthOmicsEnabled: z.boolean().optional(),
+    AwsHealthOmicsWorkflows: AwsHealthOmicsWorkflowsSchema.optional(),
     NextFlowTowerEnabled: z.boolean().optional(),
     NextFlowTowerApiBaseUrl: z.string().optional(),
     NextFlowTowerWorkspaceId: z.string().optional(),
+    NextFlowTowerPipelines: NextFlowTowerPipelinesSchema.optional(),
     CreatedAt: z.string().optional(),
     CreatedBy: z.string().optional(),
     ModifiedAt: z.string().optional(),
@@ -44,9 +50,11 @@ export const ReadLaboratorySchema = z
     S3Bucket: z.string().optional(),
     Status: z.enum(['Active', 'Inactive']),
     AwsHealthOmicsEnabled: z.boolean().optional(),
+    AwsHealthOmicsWorkflows: AwsHealthOmicsWorkflowsSchema.optional(),
     NextFlowTowerEnabled: z.boolean().optional(),
     NextFlowTowerApiBaseUrl: z.string().optional(),
     NextFlowTowerWorkspaceId: z.string().optional(),
+    NextFlowTowerPipelines: NextFlowTowerPipelinesSchema.optional(),
     HasNextFlowTowerAccessToken: z.boolean().optional(), // Return boolean indicator instead of actual NextFlowTowerAccessToken
     CreatedAt: z.string().optional(),
     CreatedBy: z.string().optional(),

--- a/packages/shared-lib/src/app/types/easy-genomics/laboratory.d.ts
+++ b/packages/shared-lib/src/app/types/easy-genomics/laboratory.d.ts
@@ -17,9 +17,11 @@
  *   Status: <string>,
  *   S3Bucket?: <string>,
  *   AwsHealthOmicsEnabled?: <boolean>,
+ *   AwsHealthOmicsWorkflows?: <AwsHealthOmicsWorkflows>,
  *   NextFlowTowerEnabled?: <boolean>,
  *   NextFlowTowerApiBaseUrl?: <string>,
  *   NextFlowTowerWorkspaceId?: <string>,
+ *   NextFlowTowerPipelines?: <NextFlowTowerPipelines>,
  *   HasNextFlowTowerAccessToken?: <boolean>,
  *   CreatedAt?: <string>,
  *   CreatedBy?: <string>,
@@ -37,8 +39,14 @@ export interface Laboratory extends BaseAttributes {
   Status: Status;
   S3Bucket?: string; // S3 Bucket Full Name
   AwsHealthOmicsEnabled?: boolean;
+  AwsHealthOmicsWorkflows?: AwsHealthOmicsWorkflows;
   NextFlowTowerEnabled?: boolean;
   NextFlowTowerApiBaseUrl?: string;
   NextFlowTowerWorkspaceId?: string;
+  NextFlowTowerPipelines?: NextFlowTowerPipelines;
   HasNextFlowTowerAccessToken?: boolean;
 }
+
+export type AwsHealthOmicsWorkflows = Record<string, boolean>;
+
+export type NextFlowTowerPipelines = Record<string, boolean>;


### PR DESCRIPTION
## Title*
BE support for lab pipeline/workflow restrictions

## Type of Change*
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
This PR adds a new BE API `/easy-genomics/laboratory/pipeline/update-laboratory-pipelines/:id` to enable an OrganizationAdmin to restrict the Seqera Cloud pipelines / AWS HealthOmics workflows for a specific Laboratory.

The API expects the UpdateLaboratoryPipelines DTO which is of the following example structure:
```
{
    "AwsHealthOmicsWorkflows": {
        "1873109": true,
        "5073962": true
    },
    "NextFlowTowerPipelines": {
        "8098098309890": true,
       "12321989789789": true
    }
}
```

Both the `AwsHealthOmicsWorkflows` and `NextFlowTowerPipelines` details are updated directly into the Laboratory dynamodb record.

The FE EGFormLabDetails has also been updated to call this API to save the changes.

## Testing*
See associated JIRA ticket for testing instructions.

## Impact
None.

## Additional Information
None.

## Checklist*
- [X] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.