### PR TITLE
fix(EG-1097): create lab prevented when seqera endpoint url not available but seqera is not enabled

### DIFF
--- a/packages/front-end/src/app/components/EGFormLabDetails.vue
+++ b/packages/front-end/src/app/components/EGFormLabDetails.vue
@@ -367,12 +367,7 @@
         />
       </EGFormGroup>
 
-      <EGFormGroup
-        v-if="useUserStore().isOrgAdmin()"
-        label="Default S3 bucket directory"
-        name="DefaultS3BucketDirectory"
-        required
-      >
+      <EGFormGroup v-if="useUserStore().isOrgAdmin()" label="Default S3 bucket directory" name="S3Bucket" required>
         <EGSelect
           :options="s3Directories"
           v-model="selectedS3Bucket"

--- a/packages/front-end/src/app/components/EGFormLabDetails.vue
+++ b/packages/front-end/src/app/components/EGFormLabDetails.vue
@@ -354,7 +354,6 @@
           v-model="state.Name"
           :disabled="!isEditing || isSubmittingFormData"
           placeholder="Enter lab name (required and must be unique)"
-          required
           autofocus
         />
       </EGFormGroup>
@@ -397,10 +396,10 @@
 
       <!-- Next Flow Tower: Endpoint -->
       <EGFormGroup
+        v-if="state.NextFlowTowerEnabled"
         label="Seqera Endpoint URL"
         name="NextFlowTowerApiBaseUrl"
         eager-validation
-        v-if="state.NextFlowTowerEnabled"
         :required="state.NextFlowTowerEnabled"
       >
         <EGInput v-model="state.NextFlowTowerApiBaseUrl" :disabled="!isEditing || isSubmittingFormData" />
@@ -408,10 +407,11 @@
 
       <!-- Next Flow Tower: Workspace ID -->
       <EGFormGroup
+        v-if="state.NextFlowTowerEnabled"
         label="Workspace ID"
         name="NextFlowTowerWorkspaceId"
         eager-validation
-        v-if="state.NextFlowTowerEnabled"
+        :required="state.NextFlowTowerEnabled"
       >
         <EGInput
           v-model="state.NextFlowTowerWorkspaceId"
@@ -435,7 +435,6 @@
           :password="true"
           :autocomplete="AutoCompleteOptionsEnum.enum.NewPassword"
           :disabled="!isEditing || isSubmittingFormData"
-          :required="formMode === LabDetailsFormModeEnum.enum.Create"
         />
         <!-- Next Flow Tower: Access Token: Edit  Mode -->
         <EGPasswordInput

--- a/packages/front-end/src/app/components/EGFormLabDetails.vue
+++ b/packages/front-end/src/app/components/EGFormLabDetails.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
   import {
     LabDetails,
-    LabDetailsSchema,
     LabNameSchema,
     LabDescriptionSchema,
+    NextFlowTowerApiBaseUrlSchema,
     NextFlowTowerAccessTokenSchema,
     NextFlowTowerWorkspaceIdSchema,
     LabDetailsFormModeEnum,
@@ -14,7 +14,6 @@
   import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
   import { ButtonSizeEnum, ButtonVariantEnum } from '@FE/types/buttons';
   import { useToastStore, useUiStore } from '@FE/stores';
-  import useUserStore from '@FE/stores/user';
   import { maybeAddFieldValidationErrors } from '@FE/utils/form-utils';
   import {
     CreateLaboratory,
@@ -281,19 +280,32 @@
     maybeAddFieldValidationErrors(errors, LabNameSchema, 'Name', state.Name);
     maybeAddFieldValidationErrors(errors, LabDescriptionSchema, 'Description', state.Description);
 
-    maybeAddFieldValidationErrors(
-      errors,
-      NextFlowTowerAccessTokenSchema,
-      'NextFlowTowerAccessToken',
-      state.NextFlowTowerAccessToken,
-    );
+    // Next Flow fields only required if Next Flow enabled
+    if (state.NextFlowTowerEnabled) {
+      maybeAddFieldValidationErrors(
+        errors,
+        NextFlowTowerApiBaseUrlSchema,
+        'NextFlowTowerApiBaseUrl',
+        state.NextFlowTowerApiBaseUrl,
+      );
 
-    maybeAddFieldValidationErrors(
-      errors,
-      NextFlowTowerWorkspaceIdSchema,
-      'NextFlowTowerWorkspaceId',
-      state.NextFlowTowerWorkspaceId,
-    );
+      maybeAddFieldValidationErrors(
+        errors,
+        NextFlowTowerWorkspaceIdSchema,
+        'NextFlowTowerWorkspaceId',
+        state.NextFlowTowerWorkspaceId,
+      );
+
+      // Access Token only required if creating lab
+      if (formMode.value === LabDetailsFormModeEnum.enum.Create) {
+        maybeAddFieldValidationErrors(
+          errors,
+          NextFlowTowerAccessTokenSchema,
+          'NextFlowTowerAccessToken',
+          state.NextFlowTowerAccessToken,
+        );
+      }
+    }
 
     checkCanSubmitFormData(errors.length);
 
@@ -346,7 +358,7 @@
 
 <template>
   <USkeleton v-if="isLoadingFormData" class="min-h-96 w-full" />
-  <UForm v-else :validate="validate" :schema="LabDetailsSchema" :state="state" @submit="onSubmit">
+  <UForm v-else :validate="validate" :state="state" @submit="onSubmit">
     <EGCard>
       <!-- Lab Name -->
       <EGFormGroup label="Lab Name" name="Name" eager-validation required>
@@ -406,7 +418,6 @@
         label="Workspace ID"
         name="NextFlowTowerWorkspaceId"
         eager-validation
-        required
       >
         <EGInput
           v-model="state.NextFlowTowerWorkspaceId"

--- a/packages/front-end/src/app/components/EGFormLabDetails.vue
+++ b/packages/front-end/src/app/components/EGFormLabDetails.vue
@@ -400,7 +400,7 @@
         label="Seqera Endpoint URL"
         name="NextFlowTowerApiBaseUrl"
         eager-validation
-        :required="state.NextFlowTowerEnabled"
+        required
       >
         <EGInput v-model="state.NextFlowTowerApiBaseUrl" :disabled="!isEditing || isSubmittingFormData" />
       </EGFormGroup>
@@ -411,7 +411,7 @@
         label="Workspace ID"
         name="NextFlowTowerWorkspaceId"
         eager-validation
-        :required="state.NextFlowTowerEnabled"
+        required
       >
         <EGInput
           v-model="state.NextFlowTowerWorkspaceId"
@@ -426,7 +426,7 @@
         label="Personal Access Token"
         name="NextFlowTowerAccessToken"
         eager-validation
-        :required="formMode === LabDetailsFormModeEnum.enum.Create && state.NextFlowTowerEnabled"
+        :required="formMode === LabDetailsFormModeEnum.enum.Create"
       >
         <!-- Next Flow Tower: Access Token: Create  Mode -->
         <EGPasswordInput

--- a/packages/front-end/src/app/components/EGFormLabDetails.vue
+++ b/packages/front-end/src/app/components/EGFormLabDetails.vue
@@ -426,7 +426,7 @@
         label="Personal Access Token"
         name="NextFlowTowerAccessToken"
         eager-validation
-        :required="formMode === LabDetailsFormModeEnum.enum.Create"
+        :required="formMode === LabDetailsFormModeEnum.enum.Create && state.NextFlowTowerEnabled"
       >
         <!-- Next Flow Tower: Access Token: Create  Mode -->
         <EGPasswordInput

--- a/packages/front-end/src/app/types/labs.ts
+++ b/packages/front-end/src/app/types/labs.ts
@@ -14,15 +14,11 @@ const LabDescriptionSchema = z.string().trim().max(500, 'Description must be no 
  * is validated in the EGFormLabDetails component as it handles special cases
  * for edit mode when the token value may or may not be updated by the user.
  */
-const NextFlowTowerAccessTokenSchema = z.string().trim().optional();
+const NextFlowTowerAccessTokenSchema = z.string().trim().min(1, 'Seqera access token is required');
 
-const NextFlowTowerWorkspaceIdSchema = z
-  .string()
-  .trim()
-  .max(128, 'Workspace ID must be no more than 128 characters')
-  .optional();
+const NextFlowTowerWorkspaceIdSchema = z.string().trim().max(128, 'Workspace ID must be no more than 128 characters');
 
-const NextFlowTowerApiBaseUrlSchema = z.string().trim().min(1, 'Seqera endpoint URL must not be empty').optional();
+const NextFlowTowerApiBaseUrlSchema = z.string().trim().min(1, 'Seqera endpoint URL is required');
 
 const S3BucketSchema = z
   .string()
@@ -57,6 +53,7 @@ export {
   LabDetailsFormModes,
   LabDetailsSchema,
   LabNameSchema,
+  NextFlowTowerApiBaseUrlSchema,
   NextFlowTowerAccessTokenSchema,
   NextFlowTowerWorkspaceIdSchema,
   S3BucketSchema,

--- a/packages/front-end/src/app/types/labs.ts
+++ b/packages/front-end/src/app/types/labs.ts
@@ -24,13 +24,17 @@ const NextFlowTowerWorkspaceIdSchema = z
 
 const NextFlowTowerApiBaseUrlSchema = z.string().trim().min(1, 'Seqera endpoint URL must not be empty').optional();
 
-const S3BucketSchema = z.string().trim().max(63, 'S3 bucket name must be no more than 63 characters').optional();
+const S3BucketSchema = z
+  .string()
+  .trim()
+  .min(1, 'S3 bucket is required')
+  .max(63, 'S3 bucket name must be no more than 63 characters');
 
 // Just the fields required for read-only display
 const LabDetailsSchema = z.object({
   Name: LabNameSchema,
   Description: LabDescriptionSchema,
-  S3Bucket: S3BucketSchema.optional(),
+  S3Bucket: S3BucketSchema,
   NextFlowTowerEnabled: z.boolean(),
   NextFlowTowerAccessToken: NextFlowTowerAccessTokenSchema,
   NextFlowTowerWorkspaceId: NextFlowTowerWorkspaceIdSchema,


### PR DESCRIPTION
## Title*

Fixed the lab creation bug Kelsey showed in the meeting.

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Worthy of note is that this bug only occurred due to the org not having a Seqera endpoint URL, which is due to an outdated backend or outdated data. This shouldn't persist but this patch fixes it anyway.

## Testing*

I couldn't replicate the issue myself but this is a common sense change and it works fine.

## Impact

## Additional Information

## Checklist*
- [X] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.