### PR TITLE
fix(EG-1099): update FE EGLabView.vue filter by current User to use UserId instead of email string

### DIFF
--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -135,12 +135,12 @@
   // fetch the runs with BE filtering any time any of the inputs change
   watchEffect(async () => {
     uiStore.setRequestPending('loadLabRuns');
-    
+
     // without this following line, watchEffect doesn't pick up runsTableSort as a reactive dependency...
     runsTableSort.value;
 
     const filters: any = {};
-    if (runsTableFilterMyRunsOnly.value) filters.Owner = userStore.currentUserDetails.email!;
+    if (runsTableFilterMyRunsOnly.value) filters.UserId = userStore.currentUserDetails.id!;
 
     try {
       runsTableItems.value = (await $api.labs.listLabRuns(props.labId, filters))


### PR DESCRIPTION
## Title*
Update FE EGLabView.vue filter by current User to use UserId instead of email string

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
This PR improves the reliability of the LaboratoryRun listing's filtering by the current User. 

This is done by switching from the filtering parameter from:
- `/easy-genomics/laboratory/run/list-laboratory-runs?LaboratoryId={Lab ID}&Owner={User Email}` 
to 
- `/easy-genomics/laboratory/run/list-laboratory-runs?LaboratoryId={Lab ID}&UserId={User ID}`

## Testing*
See associated JIRA ticket for testing instructions.

## Impact
None.

## Additional Information
None.

## Checklist*
- [X] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.