### PR TITLE
feat: run status update redesign

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.ts
@@ -15,14 +15,14 @@ import { SQSEvent } from 'aws-lambda/trigger/sqs';
 import { LaboratoryRunService } from '@BE/services/easy-genomics/laboratory-run-service';
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
 import { OmicsService } from '@BE/services/omics-service';
-import { SnsService } from '@BE/services/sns-service';
+//import { SnsService } from '@BE/services/sns-service';
 import { SsmService } from '@BE/services/ssm-service';
 import { getNextFlowApiQueryParameters, httpRequest, REST_API_METHOD } from '@BE/utils/rest-api-utils';
 
 const laboratoryService = new LaboratoryService();
 const laboratoryRunService = new LaboratoryRunService();
 const ssmService = new SsmService();
-const snsService = new SnsService();
+//const snsService = new SnsService();
 const omicsService = new OmicsService();
 
 export const handler: Handler = async (event: SQSEvent): Promise<APIGatewayProxyResult> => {
@@ -52,35 +52,36 @@ export const handler: Handler = async (event: SQSEvent): Promise<APIGatewayProxy
 
 async function processStatusCheckEvent(operation: SnsProcessingOperation, laboratoryRun: LaboratoryRun) {
   if (operation === 'UPDATE') {
-    try {
-      console.log('Processing LaboratoryRun Status Update: ', laboratoryRun);
-      const existingRun: LaboratoryRun = await laboratoryRunService.queryByRunId(laboratoryRun.RunId);
+    //try {
+    console.log('Processing LaboratoryRun Status Update: ', laboratoryRun);
+    const existingRun: LaboratoryRun = await laboratoryRunService.queryByRunId(laboratoryRun.RunId);
 
-      if (!existingRun.ExternalRunId) {
-        console.log('Missing ExternalRunID from laboratory run: skipping');
-        return false;
-      }
+    if (!existingRun.ExternalRunId) {
+      console.log('Missing ExternalRunID from laboratory run: skipping');
+      return false;
+    }
 
-      let currentStatus = existingRun.Status;
+    let currentStatus = existingRun.Status;
 
-      if (existingRun.Platform === 'AWS HealthOmics') {
-        currentStatus = await getAWSHealthOmicsStatus(existingRun);
-      } else if (existingRun.Platform === 'Seqera Cloud') {
-        currentStatus = await getSeqeraCloudStatus(existingRun);
-      }
+    if (existingRun.Platform === 'AWS HealthOmics') {
+      currentStatus = await getAWSHealthOmicsStatus(existingRun);
+    } else if (existingRun.Platform === 'Seqera Cloud') {
+      currentStatus = await getSeqeraCloudStatus(existingRun);
+    }
 
-      // Has status changed?
-      if (existingRun.Status.toUpperCase() != currentStatus.toUpperCase()) {
-        console.log('status change', existingRun.Status, currentStatus);
+    // Has status changed?
+    if (existingRun.Status.toUpperCase() != currentStatus.toUpperCase()) {
+      console.log('status change', existingRun.Status, currentStatus);
 
-        laboratoryRun = await laboratoryRunService.update({
-          ...existingRun,
-          Status: currentStatus.toUpperCase(),
-          ModifiedAt: new Date().toISOString(),
-          ModifiedBy: 'Status Check',
-        });
-      }
+      laboratoryRun = await laboratoryRunService.update({
+        ...existingRun,
+        Status: currentStatus.toUpperCase(),
+        ModifiedAt: new Date().toISOString(),
+        ModifiedBy: 'Status Check',
+      });
+    }
 
+    /* Disabling periodic status check in-favor of front end triggers
       // Do we need to queue up another check?
       // NOTE: we don't have unified Easy Genomics statuses yet, so the list of status here
       //       is a mix of both Seqera and Omics
@@ -104,6 +105,7 @@ async function processStatusCheckEvent(operation: SnsProcessingOperation, labora
       console.error(err);
 
       //TODO: should have something to prevent endless loops
+
       console.log('Queueing another status check due to error checking status');
       const record: SnsProcessingEvent = {
         Operation: 'UPDATE',
@@ -116,7 +118,9 @@ async function processStatusCheckEvent(operation: SnsProcessingOperation, labora
         MessageGroupId: `update-laboratory-run-${laboratoryRun.RunId}`,
         MessageDeduplicationId: laboratoryRun.RunId, //uuidv4(),
       });
+
     }
+  */
   } else {
     console.error(`Unsupported SNS Processing Event Operation: ${operation}`);
   }

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.ts
@@ -15,14 +15,12 @@ import { SQSEvent } from 'aws-lambda/trigger/sqs';
 import { LaboratoryRunService } from '@BE/services/easy-genomics/laboratory-run-service';
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
 import { OmicsService } from '@BE/services/omics-service';
-//import { SnsService } from '@BE/services/sns-service';
 import { SsmService } from '@BE/services/ssm-service';
 import { getNextFlowApiQueryParameters, httpRequest, REST_API_METHOD } from '@BE/utils/rest-api-utils';
 
 const laboratoryService = new LaboratoryService();
 const laboratoryRunService = new LaboratoryRunService();
 const ssmService = new SsmService();
-//const snsService = new SnsService();
 const omicsService = new OmicsService();
 
 export const handler: Handler = async (event: SQSEvent): Promise<APIGatewayProxyResult> => {
@@ -52,7 +50,6 @@ export const handler: Handler = async (event: SQSEvent): Promise<APIGatewayProxy
 
 async function processStatusCheckEvent(operation: SnsProcessingOperation, laboratoryRun: LaboratoryRun) {
   if (operation === 'UPDATE') {
-    //try {
     console.log('Processing LaboratoryRun Status Update: ', laboratoryRun);
     const existingRun: LaboratoryRun = await laboratoryRunService.queryByRunId(laboratoryRun.RunId);
 
@@ -80,47 +77,6 @@ async function processStatusCheckEvent(operation: SnsProcessingOperation, labora
         ModifiedBy: 'Status Check',
       });
     }
-
-    /* Disabling periodic status check in-favor of front end triggers
-      // Do we need to queue up another check?
-      // NOTE: we don't have unified Easy Genomics statuses yet, so the list of status here
-      //       is a mix of both Seqera and Omics
-      if (['FAILED', 'SUCCEEDED', 'CANCELLED', 'COMPLETED', 'DELETED'].includes(currentStatus)) {
-        console.log('run finished with status:', currentStatus);
-      } else {
-        console.log('Queueing another status check:', currentStatus);
-        const record: SnsProcessingEvent = {
-          Operation: 'UPDATE',
-          Type: 'LaboratoryRun',
-          Record: laboratoryRun,
-        };
-        await snsService.publish({
-          TopicArn: process.env.SNS_LABORATORY_RUN_UPDATE_TOPIC,
-          Message: JSON.stringify(record),
-          MessageGroupId: `update-laboratory-run-${laboratoryRun.RunId}`,
-          MessageDeduplicationId: laboratoryRun.RunId, //uuidv4(),
-        });
-      }
-    } catch (err: any) {
-      console.error(err);
-
-      //TODO: should have something to prevent endless loops
-
-      console.log('Queueing another status check due to error checking status');
-      const record: SnsProcessingEvent = {
-        Operation: 'UPDATE',
-        Type: 'LaboratoryRun',
-        Record: laboratoryRun,
-      };
-      await snsService.publish({
-        TopicArn: process.env.SNS_LABORATORY_RUN_UPDATE_TOPIC,
-        Message: JSON.stringify(record),
-        MessageGroupId: `update-laboratory-run-${laboratoryRun.RunId}`,
-        MessageDeduplicationId: laboratoryRun.RunId, //uuidv4(),
-      });
-
-    }
-  */
   } else {
     console.error(`Unsupported SNS Processing Event Operation: ${operation}`);
   }

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/request-laboratory-run-status-check.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/request-laboratory-run-status-check.lambda.ts
@@ -1,0 +1,98 @@
+import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory-run';
+import { SnsProcessingEvent } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/sns-processing-event';
+import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/src/app/utils/common';
+import {
+  InvalidRequestError,
+  LaboratoryNotFoundError,
+  UnauthorizedAccessError,
+} from '@easy-genomics/shared-lib/src/app/utils/HttpError';
+import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
+import { v4 as uuidv4 } from 'uuid';
+import { LaboratoryRunService } from '@BE/services/easy-genomics/laboratory-run-service';
+import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
+import { SnsService } from '@BE/services/sns-service';
+import {
+  validateLaboratoryManagerAccess,
+  validateLaboratoryTechnicianAccess,
+  validateOrganizationAdminAccess,
+} from '@BE/utils/auth-utils';
+
+const laboratoryRunService = new LaboratoryRunService();
+const laboratoryService = new LaboratoryService();
+const snsService = new SnsService();
+
+const TERMINAL_STATUSES = ['FAILED', 'SUCCEEDED', 'CANCELLED', 'COMPLETED', 'DELETED'];
+
+export const handler: Handler = async (
+  event: APIGatewayProxyWithCognitoAuthorizerEvent,
+): Promise<APIGatewayProxyResult> => {
+  try {
+    const laboratoryId: string = event.queryStringParameters?.laboratoryId || '';
+    if (!laboratoryId) throw new InvalidRequestError('Missing laboratoryId');
+
+    // Authorization: check lab exists and user has access
+    const laboratory = await laboratoryService.queryByLaboratoryId(laboratoryId);
+    if (!laboratory) throw new LaboratoryNotFoundError();
+    if (
+      !(
+        validateOrganizationAdminAccess(event, laboratory.OrganizationId) ||
+        validateLaboratoryManagerAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId) ||
+        validateLaboratoryTechnicianAccess(event, laboratory.OrganizationId, laboratory.LaboratoryId)
+      )
+    ) {
+      throw new UnauthorizedAccessError();
+    }
+
+    // Parse runIds from body (required)
+    let runIds: string[] | undefined = undefined;
+    if (event.body) {
+      try {
+        const body = JSON.parse(event.body);
+        if (Array.isArray(body.runIds)) {
+          runIds = body.runIds;
+        }
+      } catch (e) {
+        // Ignore parse error, treat as no runIds
+      }
+    }
+    if (!runIds || runIds.length === 0) {
+      throw new InvalidRequestError('No runIds provided');
+    }
+
+    // For each runId, fetch and process if not terminal
+    const runsToProcess: LaboratoryRun[] = [];
+    for (const runId of runIds) {
+      try {
+        const run = await laboratoryRunService.queryByRunId(runId);
+        if (run.LaboratoryId !== laboratoryId || TERMINAL_STATUSES.includes(run.Status)) {
+          continue;
+        }
+        runsToProcess.push(run);
+      } catch (e) {
+        // Optionally log missing runs, but skip
+        continue;
+      }
+    }
+
+    // Publish SNS event for each run to process
+    const publishPromises = runsToProcess.map((run) => {
+      const record: SnsProcessingEvent = {
+        Operation: 'UPDATE',
+        Type: 'LaboratoryRun',
+        Record: run,
+      };
+      return snsService.publish({
+        TopicArn: process.env.SNS_LABORATORY_RUN_UPDATE_TOPIC,
+        Message: JSON.stringify(record),
+        MessageGroupId: `update-laboratory-run-${run.RunId}`,
+        MessageDeduplicationId: uuidv4(),
+      });
+    });
+
+    await Promise.all(publishPromises);
+
+    return buildResponse(200, JSON.stringify({ Status: 'Requested', Count: publishPromises.length }), event);
+  } catch (err: any) {
+    return buildErrorResponse(err, event);
+  }
+};

--- a/packages/back-end/src/app/controllers/easy-genomics/upload/create-file-upload-sample-sheet.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/upload/create-file-upload-sample-sheet.lambda.ts
@@ -198,9 +198,9 @@ async function generateSingleReadSampleSheetCsv(
             throw new InvalidRequestError(`Single read sample file not found: ${r1.Key}`);
           }
 
-          return `${uploadedFilePair.SampleId}, s3://${r1.Bucket}/${r1.Key}, `; // CSV Sample-Sheet row
+          return `${uploadedFilePair.SampleId},s3://${r1.Bucket}/${r1.Key},`; // CSV Sample-Sheet row
         } else {
-          return `${uploadedFilePair.SampleId}, s3://${r1.Bucket}/${r1.Key}, `; // CSV Sample-Sheet row
+          return `${uploadedFilePair.SampleId},s3://${r1.Bucket}/${r1.Key},`; // CSV Sample-Sheet row
         }
       }),
     )
@@ -270,9 +270,9 @@ async function generatePairedReadsSampleSheetCsv(
             throw new InvalidRequestError(`Paired read R2 sample file not found: ${r2.Key}`);
           }
 
-          return `${uploadedFilePair.SampleId}, s3://${r1.Bucket}/${r1.Key}, s3://${r2.Bucket}/${r2.Key}`; // CSV Sample-Sheet row
+          return `${uploadedFilePair.SampleId},s3://${r1.Bucket}/${r1.Key},s3://${r2.Bucket}/${r2.Key}`; // CSV Sample-Sheet row
         } else {
-          return `${uploadedFilePair.SampleId}, s3://${r1.Bucket}/${r1.Key}, s3://${r2.Bucket}/${r2.Key}`; // CSV Sample-Sheet row
+          return `${uploadedFilePair.SampleId},s3://${r1.Bucket}/${r1.Key},s3://${r2.Bucket}/${r2.Key}`; // CSV Sample-Sheet row
         }
       }),
     )

--- a/packages/back-end/src/app/controllers/easy-genomics/upload/create-file-upload-sample-sheet.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/upload/create-file-upload-sample-sheet.lambda.ts
@@ -13,7 +13,7 @@ import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handl
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
 import { S3Service } from '@BE/services/s3-service';
 
-const SAMPLE_SHEET_CSV_HEADER: string[] = ['sample, fastq_1, fastq_2'];
+const SAMPLE_SHEET_CSV_HEADER: string[] = ['sample,fastq_1,fastq_2'];
 
 const laboratoryService = new LaboratoryService();
 const s3Service = new S3Service();

--- a/packages/front-end/src/app/repository/modules/labs.ts
+++ b/packages/front-end/src/app/repository/modules/labs.ts
@@ -235,6 +235,23 @@ class LabsModule extends HttpFactory {
     validateApiResponse(LaboratoryRunSchema, res);
     return res;
   }
+
+  /**
+   *  Request status check on all runs not in a terminal state
+   *  @param labId
+   *  @param runIds
+   */
+  async requestLabRunStatusCheck(labId: string, runIds: string[]) {
+    const res = await this.call<any>(
+      'POST',
+      `/laboratory/run/request-laboratory-run-status-check?laboratoryId=${labId}`,
+      { runIds },
+    );
+    if (!res) {
+      throw new Error('Failed to request lab run status check');
+    }
+    return res;
+  }
 }
 
 export default LabsModule;


### PR DESCRIPTION
## feat: run status update redesign

## Type of Change
- [X] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
This PR includes a new lambda function that handles requests from the front-end to check the status of any run that is not in a terminal state. The lambda function publishes an message to the laboratory run update topic which eventually causes the process-update-laboratory-run to determine the status of the runs. A change was added to the front-end where a table refresh key was added and the fetchLaboratoryRuns() function was removed. This enables the table to be updated and refreshed without the user needing to manually reload the page.

I've also included an unrelated minor bug fix that removes the spaces from samplesheet, which causes problems in a number of pipelines.

## Testing
I have tested this with healthomics runs to see the status update changes. I am unsure if any built in validations or tests need to be changed.

## Impact
This change solves an issue where runs that take hours - days to complete would have incorrect statuses because AWS would halt the process-update-laboratory-run lambda function due to a recursion limit. This update circumvents this by removing the recursion from process-update-laboratory-run and moving the logic to the front-end to periodically check for status updates.

## Additional Information
I believe I have added this new functionality to be inline with the project design, however it is likely I overlooked something in this implementation. So please review with care.

## Checklist
- [X] No new errors or warnings have been introduced.
- [X] All tests pass successfully and new tests added as necessary.
- [X] Documentation has been updated accordingly.
- [X] Code adheres to the coding and style guidelines of the project.
- [X] Code has been commented in particularly hard-to-understand areas.