### PR TITLE
fix: multiple downloads triggered issue by enforcing one doanload at a time

### DIFF
--- a/packages/front-end/src/app/components/EGFileExplorer.vue
+++ b/packages/front-end/src/app/components/EGFileExplorer.vue
@@ -47,7 +47,7 @@
     { isLoading: true },
   );
 
-  const { handleS3Download, downloadFolder } = useFileDownload();
+  const { handleS3Download, downloadFolder, isFolderZipInProgress } = useFileDownload();
   const { $api } = useNuxtApp();
 
   const uiStore = useUiStore();
@@ -620,6 +620,11 @@
               variant="secondary"
               :label="row?.type === 'file' ? 'Download' : 'Download as zip'"
               :loading="downloads[nodeUniqueString(row)] !== undefined && downloads[nodeUniqueString(row)] < 100"
+              :disabled="
+                row?.type === 'directory' &&
+                isFolderZipInProgress &&
+                !(downloads[nodeUniqueString(row)] !== undefined && downloads[nodeUniqueString(row)] < 100)
+              "
               @click.stop="async () => await downloadFileTreeNode(row)"
             />
           </template>

--- a/packages/front-end/src/app/composables/useFileDownload.ts
+++ b/packages/front-end/src/app/composables/useFileDownload.ts
@@ -7,6 +7,7 @@ import { Ref } from '.nuxt/imports';
 export default function useFileDownload() {
   const { $api } = useNuxtApp();
   const toast = useToastStore();
+  const isFolderZipInProgress = ref(false);
 
   const sleep = (milliseconds: number): Promise<void> =>
     new Promise((resolve) => {
@@ -75,6 +76,11 @@ export default function useFileDownload() {
     const pollIntervalMs = 5000;
 
     try {
+      if (isFolderZipInProgress.value) {
+        toast.error('A folder ZIP download is already in progress. Please wait for it to finish.');
+        return;
+      }
+      isFolderZipInProgress.value = true;
       progressVar && (progressVar.value = 10);
 
       const createJobResponse = await $api.file.requestFolderDownloadJob({
@@ -117,6 +123,8 @@ export default function useFileDownload() {
       } else {
         toast.error(errorMessage || 'Unable to prepare folder download');
       }
+    } finally {
+      isFolderZipInProgress.value = false;
     }
   }
 
@@ -137,5 +145,6 @@ export default function useFileDownload() {
     handleS3Download,
     downloadFolder,
     isSupportedFileType,
+    isFolderZipInProgress,
   };
 }


### PR DESCRIPTION
## fix: multiple downloads triggered issue by enforcing one doanload at a time

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Fixed error caused by multiple downloads triggered at the same time, only one would download due to s3 presigned url redirection. Fixed by preventing multiple downloads at once to reduce risk of failure.

## Testing*
Tested manually in local environment.

## Impact
Impacts download as zip functionality for workflow results.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.