### PR TITLE
fix: allow laboratory to get run results from multiple s3 buckets

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/file/request-top-level-bucket-objects.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/file/request-top-level-bucket-objects.lambda.ts
@@ -107,10 +107,7 @@ export const handler: Handler = async (
         throw new InvalidRequestError('Invalid OutputS3Url for run');
       }
 
-      // Bucket must match the run output bucket (and, if configured, the laboratory bucket)
-      if (laboratory.S3Bucket && outputBucket !== laboratory.S3Bucket) {
-        throw new UnauthorizedAccessError();
-      }
+      // Bucket must match the run output bucket
       if (s3Bucket && outputBucket && s3Bucket !== outputBucket) {
         throw new UnauthorizedAccessError();
       }

--- a/packages/back-end/test/app/controllers/easy-genomics/file/request-top-level-bucket-objects.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/file/request-top-level-bucket-objects.lambda.test.ts
@@ -213,6 +213,40 @@ describe('request-top-level-bucket-objects Lambda', () => {
     expect(mockListBucketObjectsV2).not.toHaveBeenCalled();
   });
 
+  it('allows listing when RunId is provided and run OutputS3Url bucket differs from lab S3Bucket', async () => {
+    mockValidateOrgAdmin.mockReturnValue(true);
+    mockQueryByLaboratoryId.mockResolvedValue(mockLaboratory);
+    mockGetLaboratoryRun.mockResolvedValue({
+      ...mockRun,
+      OutputS3Url: 's3://another-bucket/custom/output/results/',
+    });
+    mockListBucketObjectsV2.mockResolvedValue({
+      Contents: [],
+      CommonPrefixes: [{ Prefix: 'custom/output/results/sub/' }],
+      IsTruncated: false,
+    });
+
+    const result = await handler(
+      createMockEvent({
+        LaboratoryId: 'test-lab-id',
+        RunId: 'run-123',
+        S3Bucket: 'another-bucket',
+        S3Prefix: 'custom/output/results/',
+      }),
+      createMockContext(),
+      () => {},
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(mockListBucketObjectsV2).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Bucket: 'another-bucket',
+        Prefix: 'custom/output/results/',
+        Delimiter: '/',
+      }),
+    );
+  });
+
   it('defaults to the run OutputS3Url prefix when RunId is provided and S3Prefix is omitted', async () => {
     mockValidateOrgAdmin.mockReturnValue(true);
     mockQueryByLaboratoryId.mockResolvedValue(mockLaboratory);


### PR DESCRIPTION
## fix: allow laboratory to get run results from multiple s3 buckets

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Removed check in request-top-level-object lambda function to allow a laboratory to get workflow run files from multiple s3 buckets. We still validate against the workflow run output s3 bucket saved in dynamo db.

## Testing*
Updated unit tests and tested manually on development environment.

## Impact
Impacts File Manager view allowing for more flexibility on s3 buckets.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.