### PR TITLE
fix: added tooltip to download button when disabled for another download

### DIFF
--- a/packages/front-end/src/app/components/EGFileExplorer.vue
+++ b/packages/front-end/src/app/components/EGFileExplorer.vue
@@ -616,17 +616,32 @@
             />
 
             <!-- download -->
-            <EGButton
-              variant="secondary"
-              :label="row?.type === 'file' ? 'Download' : 'Download as zip'"
-              :loading="downloads[nodeUniqueString(row)] !== undefined && downloads[nodeUniqueString(row)] < 100"
-              :disabled="
-                row?.type === 'directory' &&
-                isFolderZipInProgress &&
-                !(downloads[nodeUniqueString(row)] !== undefined && downloads[nodeUniqueString(row)] < 100)
-              "
-              @click.stop="async () => await downloadFileTreeNode(row)"
-            />
+            <UTooltip
+              :delay-duration="0"
+              :prevent="!isFolderZipInProgress"
+              :ui="{
+                base: 'h-full w-auto text-center',
+              }"
+            >
+              <template #text>
+                <span class="block text-balance">
+                  Another download is currently in progress. Please wait for it to finish before starting a new one.
+                </span>
+              </template>
+              <span class="inline-flex">
+                <EGButton
+                  variant="secondary"
+                  :label="row?.type === 'file' ? 'Download' : 'Download as zip'"
+                  :loading="downloads[nodeUniqueString(row)] !== undefined && downloads[nodeUniqueString(row)] < 100"
+                  :disabled="
+                    row?.type === 'directory' &&
+                    isFolderZipInProgress &&
+                    !(downloads[nodeUniqueString(row)] !== undefined && downloads[nodeUniqueString(row)] < 100)
+                  "
+                  @click.stop="async () => await downloadFileTreeNode(row)"
+                />
+              </span>
+            </UTooltip>
           </template>
         </div>
       </template>


### PR DESCRIPTION
## fix: added tooltip to download button when disabled for another download

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Added a tooltip over the Download button that is displayed when another download is in progress to let user know that only one download is accepted at the same time.

## Testing*
Tested manually in development environment.

## Impact
Only adds information text, it does not affect the feature.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.