### PR TITLE
fix: download progress overlay removed when finished

### DIFF
--- a/packages/front-end/src/app/components/EGFileExplorer.vue
+++ b/packages/front-end/src/app/components/EGFileExplorer.vue
@@ -307,6 +307,39 @@
   // key is the uniqueString of a file tree node
   // value is the ref containing the progress of the download out of 100
   const downloads = ref<Record<string, Ref<number>>>({});
+  // Tracks whether a given node is actively downloading (used for button loading state).
+  // We keep this separate from `downloads[...]` so we can fade the green overlay without
+  // showing the spinner forever.
+  const downloadActive = ref<Record<string, boolean>>({});
+
+  const fadeIntervals = new Map<string, ReturnType<typeof setInterval>>();
+
+  function startFadeOutAndCleanup(uniqueString: string, progressRef: Ref<number>) {
+    if (fadeIntervals.has(uniqueString)) return;
+
+    // Keep it short: we only want to visually fade the green overlay.
+    const fadeDurationMs = 700;
+    const intervalMs = 50;
+    const totalSteps = Math.ceil(fadeDurationMs / intervalMs);
+    let step = 0;
+
+    const timer = setInterval(() => {
+      step += 1;
+      const remainingSteps = Math.max(0, totalSteps - step);
+      progressRef.value = Math.round((remainingSteps / totalSteps) * 100);
+
+      if (step >= totalSteps) {
+        const handle = fadeIntervals.get(uniqueString);
+        if (handle) clearInterval(handle);
+        fadeIntervals.delete(uniqueString);
+
+        delete downloads.value[uniqueString];
+        delete downloadActive.value[uniqueString];
+      }
+    }, intervalMs);
+
+    fadeIntervals.set(uniqueString, timer);
+  }
 
   function formatFileSize(value?: number): string {
     if (!value) return '';
@@ -519,21 +552,40 @@
 
   async function downloadFileTreeNode(node: FileTreeNode): Promise<void> {
     const uniqueString = nodeUniqueString(node);
+    // If a fade-out is currently running for this node, stop it so the new download
+    // starts from a clean slate.
+    if (fadeIntervals.has(uniqueString)) {
+      const handle = fadeIntervals.get(uniqueString);
+      if (handle) clearInterval(handle);
+      fadeIntervals.delete(uniqueString);
+    }
+
+    delete downloads.value[uniqueString];
+    delete downloadActive.value[uniqueString];
+
     const progressRef: Ref<number> = ref(0);
     downloads.value[uniqueString] = progressRef;
+    downloadActive.value[uniqueString] = true;
 
     useToastStore().success('Your files have begun downloading');
 
-    if (node.type === 'file') {
-      const fileName = node.s3Key?.split('/').pop() || node.name!;
-      await handleS3Download(
-        props.labId,
-        fileName, // Filename
-        getNodeDirectoryPath(node), // s3://{S3 Bucket}/{S3 Prefix} Path
-        progressRef, // progress value ref to be updated by the function
-      );
-    } else {
-      await downloadFolder(props.labId, getNodeS3Uri(node), progressRef);
+    try {
+      if (node.type === 'file') {
+        const fileName = node.s3Key?.split('/').pop() || node.name!;
+        await handleS3Download(
+          props.labId,
+          fileName, // Filename
+          getNodeDirectoryPath(node), // s3://{S3 Bucket}/{S3 Prefix} Path
+          progressRef, // progress value ref to be updated by the function
+        );
+      } else {
+        await downloadFolder(props.labId, getNodeS3Uri(node), progressRef);
+      }
+    } finally {
+      // Ensure we briefly show "complete" and then fade the overlay out.
+      progressRef.value = 100;
+      downloadActive.value[uniqueString] = false;
+      startFadeOutAndCleanup(uniqueString, progressRef);
     }
   }
 
@@ -542,6 +594,11 @@
 
   watch(searchQuery, (value: string) => {
     onSearchInput(value);
+  });
+
+  onBeforeUnmount(() => {
+    fadeIntervals.forEach((handle) => clearInterval(handle));
+    fadeIntervals.clear();
   });
 </script>
 
@@ -632,7 +689,7 @@
                 <EGButton
                   variant="secondary"
                   :label="row?.type === 'file' ? 'Download' : 'Download as zip'"
-                  :loading="downloads[nodeUniqueString(row)] !== undefined && downloads[nodeUniqueString(row)] < 100"
+                  :loading="downloadActive[nodeUniqueString(row)] === true"
                   :disabled="
                     row?.type === 'directory' &&
                     isFolderZipInProgress &&

--- a/packages/front-end/src/app/composables/useFileDownload.ts
+++ b/packages/front-end/src/app/composables/useFileDownload.ts
@@ -65,8 +65,14 @@ export default function useFileDownload() {
 
       // Use FileSaver to save the blob to a file
       saveAs(blob, fileName);
+
+      // Ensure the UI reaches 100% at completion (axios sometimes ends at <100).
+      if (progressVar !== undefined) progressVar.value = 100;
     } catch (error) {
       console.error('Error during file download:', error);
+
+      // Still set completion so the UI can clean up the progress overlay.
+      if (progressVar !== undefined) progressVar.value = 100;
     }
   }
 


### PR DESCRIPTION
## fix: download progress overlay removed when finished

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Fixed issue of complete download overlay over rows with matching name by improving overlay functionality and removing it when download is finished.

## Testing*
Tested manually on develop environment.

## Impact
Only impacts the overlay, not the actual functionality of the download.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.