### PR TITLE
fix: release v1.2.2

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/file/request-top-level-bucket-objects.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/file/request-top-level-bucket-objects.lambda.ts
@@ -5,6 +5,7 @@ import { RequestTopLevelBucketObjectsSchema } from '@easy-genomics/shared-lib/sr
 import { RequestTopLevelBucketObjects } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/file/request-top-level-bucket-objects';
 import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
 import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
+import { LaboratoryRunService } from '@BE/services/easy-genomics/laboratory-run-service';
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
 import { S3Service } from '@BE/services/s3-service';
 import {
@@ -14,6 +15,7 @@ import {
 } from '@BE/utils/auth-utils';
 
 const laboratoryService = new LaboratoryService();
+const laboratoryRunService = new LaboratoryRunService();
 const s3Service = new S3Service();
 
 const parseS3Uri = (value: string): { bucket: string; prefix: string } | null => {
@@ -29,6 +31,15 @@ const parseS3Uri = (value: string): { bucket: string; prefix: string } | null =>
   }
 };
 
+const getParentPrefix = (prefix: string): string | null => {
+  const normalized = prefix.endsWith('/') ? prefix : `${prefix}/`;
+  const trimmed = normalized.replace(/\/+$/, '');
+  const lastSlashIdx = trimmed.lastIndexOf('/');
+  if (lastSlashIdx < 0) return null;
+  const parent = trimmed.slice(0, lastSlashIdx);
+  return parent ? `${parent}/` : null;
+};
+
 /**
  * This API enables the Easy Genomics FE to request only the top-level (direct children)
  * objects and prefixes at a given S3 path for lazy-loading in the File Manager UI.
@@ -42,7 +53,7 @@ const parseS3Uri = (value: string): { bucket: string; prefix: string } | null =>
  * - CommonPrefixes: ALL directories (folders) at this level
  *
  * @param event APIGatewayProxyWithCognitoAuthorizerEvent
- *   Body: { LaboratoryId, S3Bucket?, S3Prefix?, MaxKeys? }
+ *   Body: { LaboratoryId, RunId?, S3Bucket?, S3Prefix?, MaxKeys? }
  */
 export const handler: Handler = async (
   event: APIGatewayProxyWithCognitoAuthorizerEvent,
@@ -74,21 +85,61 @@ export const handler: Handler = async (
 
     const prefixFromUri = request.S3Prefix ? parseS3Uri(request.S3Prefix) : null;
     const providedPrefix = prefixFromUri?.prefix || request.S3Prefix;
-    const s3Bucket: string = request.S3Bucket || prefixFromUri?.bucket || laboratory.S3Bucket || '';
-    const s3Prefix: string = providedPrefix || `${laboratory.OrganizationId}/${laboratory.LaboratoryId}/`;
+    const requestBucket: string = request.S3Bucket || prefixFromUri?.bucket || laboratory.S3Bucket || '';
+    let s3Bucket: string = requestBucket;
+    let s3Prefix: string = providedPrefix || `${laboratory.OrganizationId}/${laboratory.LaboratoryId}/`;
 
     if (request.S3Bucket && prefixFromUri?.bucket && request.S3Bucket !== prefixFromUri.bucket) {
       throw new InvalidRequestError('S3 bucket mismatch between S3Bucket and S3Prefix URI');
     }
 
-    if (laboratory.S3Bucket && s3Bucket !== laboratory.S3Bucket) {
-      throw new UnauthorizedAccessError();
-    }
+    // If a RunId is provided, authorize the requested S3 prefix against the run OutputS3Url (supports custom output dirs).
+    // Otherwise, fall back to the original lab-owned prefix constraint.
+    let normalizedPrefix = s3Prefix.endsWith('/') ? s3Prefix : `${s3Prefix}/`;
+    if (request.RunId) {
+      const run = await laboratoryRunService.get(laboratoryId, request.RunId);
+      const outputFromUri = run.OutputS3Url ? parseS3Uri(run.OutputS3Url) : null;
+      const outputBucket = outputFromUri?.bucket || laboratory.S3Bucket || requestBucket;
+      const outputPrefix = outputFromUri?.prefix || run.OutputS3Url || '';
+      const normalizedOutputPrefix = outputPrefix.endsWith('/') ? outputPrefix : `${outputPrefix}/`;
 
-    const normalizedPrefix = s3Prefix.endsWith('/') ? s3Prefix : `${s3Prefix}/`;
-    const laboratoryOwnedPrefix = `${laboratory.OrganizationId}/${laboratory.LaboratoryId}/`;
-    if (!normalizedPrefix.startsWith(laboratoryOwnedPrefix)) {
-      throw new UnauthorizedAccessError();
+      if (!normalizedOutputPrefix || normalizedOutputPrefix === '/') {
+        throw new InvalidRequestError('Invalid OutputS3Url for run');
+      }
+
+      // Bucket must match the run output bucket (and, if configured, the laboratory bucket)
+      if (laboratory.S3Bucket && outputBucket !== laboratory.S3Bucket) {
+        throw new UnauthorizedAccessError();
+      }
+      if (s3Bucket && outputBucket && s3Bucket !== outputBucket) {
+        throw new UnauthorizedAccessError();
+      }
+      s3Bucket = outputBucket;
+
+      // If client didn't pass S3Prefix, list from the run output root.
+      if (!providedPrefix) {
+        s3Prefix = normalizedOutputPrefix;
+        normalizedPrefix = normalizedOutputPrefix;
+      }
+
+      // Allow listing:
+      // - within the run OutputS3Url prefix (the most restricted case), OR
+      // - exactly at its immediate parent (so UI can show the run root when OutputS3Url points to e.g. ".../results/").
+      const outputParentPrefix = getParentPrefix(normalizedOutputPrefix);
+      const isWithinOutput = normalizedPrefix.startsWith(normalizedOutputPrefix);
+      const isImmediateParent = outputParentPrefix ? normalizedPrefix === outputParentPrefix : false;
+      if (!isWithinOutput && !isImmediateParent) {
+        throw new UnauthorizedAccessError();
+      }
+    } else {
+      if (laboratory.S3Bucket && s3Bucket !== laboratory.S3Bucket) {
+        throw new UnauthorizedAccessError();
+      }
+
+      const laboratoryOwnedPrefix = `${laboratory.OrganizationId}/${laboratory.LaboratoryId}/`;
+      if (!normalizedPrefix.startsWith(laboratoryOwnedPrefix)) {
+        throw new UnauthorizedAccessError();
+      }
     }
 
     // Fetch ALL top-level objects at this prefix level using Delimiter for lazy-loading

--- a/packages/back-end/src/app/controllers/easy-genomics/file/request-top-level-bucket-objects.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/file/request-top-level-bucket-objects.lambda.ts
@@ -107,10 +107,7 @@ export const handler: Handler = async (
         throw new InvalidRequestError('Invalid OutputS3Url for run');
       }
 
-      // Bucket must match the run output bucket (and, if configured, the laboratory bucket)
-      if (laboratory.S3Bucket && outputBucket !== laboratory.S3Bucket) {
-        throw new UnauthorizedAccessError();
-      }
+      // Bucket must match the run output bucket
       if (s3Bucket && outputBucket && s3Bucket !== outputBucket) {
         throw new UnauthorizedAccessError();
       }

--- a/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
@@ -1308,6 +1308,13 @@ export class EasyGenomicsNestedStack extends NestedStack {
         actions: ['dynamodb:Query'],
       }),
       new PolicyStatement({
+        resources: [
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-run-table`,
+        ],
+        actions: ['dynamodb:GetItem'],
+        effect: Effect.ALLOW,
+      }),
+      new PolicyStatement({
         resources: ['arn:aws:s3:::*'],
         actions: ['s3:ListBucket'],
         effect: Effect.ALLOW,

--- a/packages/back-end/test/app/controllers/easy-genomics/file/request-top-level-bucket-objects.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/file/request-top-level-bucket-objects.lambda.test.ts
@@ -1,0 +1,262 @@
+import { APIGatewayProxyWithCognitoAuthorizerEvent, Context } from 'aws-lambda';
+import { handler } from '../../../../../src/app/controllers/easy-genomics/file/request-top-level-bucket-objects.lambda';
+
+jest.mock('../../../../../src/app/services/easy-genomics/laboratory-service');
+jest.mock('../../../../../src/app/services/easy-genomics/laboratory-run-service');
+jest.mock('../../../../../src/app/services/s3-service');
+jest.mock('../../../../../src/app/utils/auth-utils');
+
+import { LaboratoryRunService } from '../../../../../src/app/services/easy-genomics/laboratory-run-service';
+import { LaboratoryService } from '../../../../../src/app/services/easy-genomics/laboratory-service';
+import { S3Service } from '../../../../../src/app/services/s3-service';
+import {
+  validateLaboratoryManagerAccess,
+  validateLaboratoryTechnicianAccess,
+  validateOrganizationAdminAccess,
+} from '../../../../../src/app/utils/auth-utils';
+
+describe('request-top-level-bucket-objects Lambda', () => {
+  let mockValidateOrgAdmin: jest.MockedFunction<typeof validateOrganizationAdminAccess>;
+  let mockValidateLabManager: jest.MockedFunction<typeof validateLaboratoryManagerAccess>;
+  let mockValidateLabTechnician: jest.MockedFunction<typeof validateLaboratoryTechnicianAccess>;
+  let mockQueryByLaboratoryId: jest.Mock;
+  let mockGetLaboratoryRun: jest.Mock;
+  let mockListBucketObjectsV2: jest.Mock;
+
+  const mockLaboratory = {
+    OrganizationId: 'test-org-id',
+    LaboratoryId: 'test-lab-id',
+    S3Bucket: 'test-bucket',
+  };
+
+  const mockRun = {
+    LaboratoryId: 'test-lab-id',
+    RunId: 'run-123',
+    OutputS3Url: 's3://test-bucket/custom/output/',
+  };
+
+  const createMockEvent = (body: any): APIGatewayProxyWithCognitoAuthorizerEvent => ({
+    body: JSON.stringify(body),
+    isBase64Encoded: false,
+    httpMethod: 'POST',
+    path: '/file/request-top-level-bucket-objects',
+    headers: {},
+    requestContext: {
+      requestId: 'request-id',
+      extendedRequestId: 'extended-request-id',
+      authorizer: { claims: { email: 'test@example.com' } },
+    } as any,
+    resource: '',
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    pathParameters: null,
+    stageVariables: null,
+    multiValueHeaders: {},
+  });
+
+  const createMockContext = (): Context => ({
+    functionName: 'request-top-level-bucket-objects',
+    functionVersion: '$LATEST',
+    invokedFunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:request-top-level-bucket-objects',
+    memoryLimitInMB: '128',
+    awsRequestId: 'test-request-id',
+    logGroupName: '/aws/lambda/request-top-level-bucket-objects',
+    logStreamName: '2026/03/17/[$LATEST]test',
+    identity: undefined,
+    clientContext: undefined,
+    callbackWaitsForEmptyEventLoop: true,
+    getRemainingTimeInMillis: () => 30000,
+    done: jest.fn(),
+    fail: jest.fn(),
+    succeed: jest.fn(),
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockValidateOrgAdmin = validateOrganizationAdminAccess as jest.MockedFunction<
+      typeof validateOrganizationAdminAccess
+    >;
+    mockValidateLabManager = validateLaboratoryManagerAccess as jest.MockedFunction<
+      typeof validateLaboratoryManagerAccess
+    >;
+    mockValidateLabTechnician = validateLaboratoryTechnicianAccess as jest.MockedFunction<
+      typeof validateLaboratoryTechnicianAccess
+    >;
+
+    mockValidateOrgAdmin.mockReturnValue(false);
+    mockValidateLabManager.mockReturnValue(false);
+    mockValidateLabTechnician.mockReturnValue(false);
+
+    const mockLaboratoryServiceInstance = LaboratoryService as jest.MockedClass<typeof LaboratoryService>;
+    mockQueryByLaboratoryId = jest.fn();
+    mockLaboratoryServiceInstance.prototype.queryByLaboratoryId = mockQueryByLaboratoryId;
+
+    const mockLaboratoryRunServiceInstance = LaboratoryRunService as jest.MockedClass<typeof LaboratoryRunService>;
+    mockGetLaboratoryRun = jest.fn();
+    mockLaboratoryRunServiceInstance.prototype.get = mockGetLaboratoryRun;
+
+    const mockS3ServiceInstance = S3Service as jest.MockedClass<typeof S3Service>;
+    mockListBucketObjectsV2 = jest.fn();
+    mockS3ServiceInstance.prototype.listBucketObjectsV2 = mockListBucketObjectsV2;
+  });
+
+  it('allows listing when RunId is provided and requested prefix is under OutputS3Url (custom output dir)', async () => {
+    mockValidateOrgAdmin.mockReturnValue(true);
+    mockQueryByLaboratoryId.mockResolvedValue(mockLaboratory);
+    mockGetLaboratoryRun.mockResolvedValue(mockRun);
+    mockListBucketObjectsV2.mockResolvedValue({
+      Contents: [
+        {
+          Key: 'custom/output/subdir/file.txt',
+          Size: 1,
+          LastModified: '2026-01-01',
+          ETag: '',
+          StorageClass: 'STANDARD',
+        },
+      ],
+      CommonPrefixes: [{ Prefix: 'custom/output/subdir/nested/' }],
+      IsTruncated: false,
+    });
+
+    const result = await handler(
+      createMockEvent({
+        LaboratoryId: 'test-lab-id',
+        RunId: 'run-123',
+        S3Bucket: 'test-bucket',
+        S3Prefix: 'custom/output/subdir',
+      }),
+      createMockContext(),
+      () => {},
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(mockListBucketObjectsV2).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Bucket: 'test-bucket',
+        Prefix: 'custom/output/subdir/',
+        Delimiter: '/',
+      }),
+    );
+  });
+
+  it('allows listing at the immediate parent of OutputS3Url (e.g. run root when OutputS3Url points to results/)', async () => {
+    mockValidateOrgAdmin.mockReturnValue(true);
+    mockQueryByLaboratoryId.mockResolvedValue(mockLaboratory);
+    mockGetLaboratoryRun.mockResolvedValue({
+      ...mockRun,
+      OutputS3Url: 's3://test-bucket/custom/output/results/',
+    });
+    mockListBucketObjectsV2.mockResolvedValue({
+      Contents: [],
+      CommonPrefixes: [{ Prefix: 'custom/output/results/' }],
+      IsTruncated: false,
+    });
+
+    const result = await handler(
+      createMockEvent({
+        LaboratoryId: 'test-lab-id',
+        RunId: 'run-123',
+        S3Bucket: 'test-bucket',
+        S3Prefix: 'custom/output/',
+      }),
+      createMockContext(),
+      () => {},
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(mockListBucketObjectsV2).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Bucket: 'test-bucket',
+        Prefix: 'custom/output/',
+      }),
+    );
+  });
+
+  it('denies listing when RunId is provided but requested prefix is outside OutputS3Url', async () => {
+    mockValidateOrgAdmin.mockReturnValue(true);
+    mockQueryByLaboratoryId.mockResolvedValue(mockLaboratory);
+    mockGetLaboratoryRun.mockResolvedValue(mockRun);
+
+    const result = await handler(
+      createMockEvent({
+        LaboratoryId: 'test-lab-id',
+        RunId: 'run-123',
+        S3Bucket: 'test-bucket',
+        S3Prefix: 'other/prefix/',
+      }),
+      createMockContext(),
+      () => {},
+    );
+
+    expect(result.statusCode).toBe(403);
+    expect(mockListBucketObjectsV2).not.toHaveBeenCalled();
+  });
+
+  it('denies listing when RunId is provided but S3Bucket mismatches run OutputS3Url bucket', async () => {
+    mockValidateOrgAdmin.mockReturnValue(true);
+    mockQueryByLaboratoryId.mockResolvedValue(mockLaboratory);
+    mockGetLaboratoryRun.mockResolvedValue(mockRun);
+
+    const result = await handler(
+      createMockEvent({
+        LaboratoryId: 'test-lab-id',
+        RunId: 'run-123',
+        S3Bucket: 'another-bucket',
+        S3Prefix: 'custom/output/',
+      }),
+      createMockContext(),
+      () => {},
+    );
+
+    expect(result.statusCode).toBe(403);
+    expect(mockListBucketObjectsV2).not.toHaveBeenCalled();
+  });
+
+  it('defaults to the run OutputS3Url prefix when RunId is provided and S3Prefix is omitted', async () => {
+    mockValidateOrgAdmin.mockReturnValue(true);
+    mockQueryByLaboratoryId.mockResolvedValue(mockLaboratory);
+    mockGetLaboratoryRun.mockResolvedValue(mockRun);
+    mockListBucketObjectsV2.mockResolvedValue({
+      Contents: [],
+      CommonPrefixes: [{ Prefix: 'custom/output/subdir/' }],
+      IsTruncated: false,
+    });
+
+    const result = await handler(
+      createMockEvent({
+        LaboratoryId: 'test-lab-id',
+        RunId: 'run-123',
+        S3Bucket: 'test-bucket',
+      }),
+      createMockContext(),
+      () => {},
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(mockListBucketObjectsV2).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Bucket: 'test-bucket',
+        Prefix: 'custom/output/',
+      }),
+    );
+  });
+
+  it('keeps legacy behavior when RunId is omitted (prefix must be under org/lab)', async () => {
+    mockValidateOrgAdmin.mockReturnValue(true);
+    mockQueryByLaboratoryId.mockResolvedValue(mockLaboratory);
+
+    const result = await handler(
+      createMockEvent({
+        LaboratoryId: 'test-lab-id',
+        S3Bucket: 'test-bucket',
+        S3Prefix: 'custom/output/',
+      }),
+      createMockContext(),
+      () => {},
+    );
+
+    expect(result.statusCode).toBe(403);
+    expect(mockListBucketObjectsV2).not.toHaveBeenCalled();
+  });
+});

--- a/packages/back-end/test/app/controllers/easy-genomics/file/request-top-level-bucket-objects.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/file/request-top-level-bucket-objects.lambda.test.ts
@@ -213,6 +213,40 @@ describe('request-top-level-bucket-objects Lambda', () => {
     expect(mockListBucketObjectsV2).not.toHaveBeenCalled();
   });
 
+  it('allows listing when RunId is provided and run OutputS3Url bucket differs from lab S3Bucket', async () => {
+    mockValidateOrgAdmin.mockReturnValue(true);
+    mockQueryByLaboratoryId.mockResolvedValue(mockLaboratory);
+    mockGetLaboratoryRun.mockResolvedValue({
+      ...mockRun,
+      OutputS3Url: 's3://another-bucket/custom/output/results/',
+    });
+    mockListBucketObjectsV2.mockResolvedValue({
+      Contents: [],
+      CommonPrefixes: [{ Prefix: 'custom/output/results/sub/' }],
+      IsTruncated: false,
+    });
+
+    const result = await handler(
+      createMockEvent({
+        LaboratoryId: 'test-lab-id',
+        RunId: 'run-123',
+        S3Bucket: 'another-bucket',
+        S3Prefix: 'custom/output/results/',
+      }),
+      createMockContext(),
+      () => {},
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(mockListBucketObjectsV2).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Bucket: 'another-bucket',
+        Prefix: 'custom/output/results/',
+        Delimiter: '/',
+      }),
+    );
+  });
+
   it('defaults to the run OutputS3Url prefix when RunId is provided and S3Prefix is omitted', async () => {
     mockValidateOrgAdmin.mockReturnValue(true);
     mockQueryByLaboratoryId.mockResolvedValue(mockLaboratory);

--- a/packages/front-end/src/app/components/EGFileExplorer.vue
+++ b/packages/front-end/src/app/components/EGFileExplorer.vue
@@ -38,6 +38,7 @@
   const props = withDefaults(
     defineProps<{
       labId: string;
+      runId?: string;
       s3Bucket: string;
       s3Prefix: string;
       s3Contents?: S3Response | null;
@@ -116,6 +117,7 @@
           $api.file
             .requestTopLevelBucketObjects({
               LaboratoryId: props.labId,
+              RunId: props.runId,
               S3Bucket: s3Bucket,
               S3Prefix: childPrefix,
             } as RequestTopLevelBucketObjects)
@@ -139,6 +141,7 @@
     try {
       const response: S3TopLevelResponse = await $api.file.requestTopLevelBucketObjects({
         LaboratoryId: props.labId,
+        RunId: props.runId,
         S3Bucket: s3Bucket,
         S3Prefix: prefixPath,
       } as RequestTopLevelBucketObjects);

--- a/packages/front-end/src/app/pages/labs/[labId]/run/[labRunId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/run/[labRunId].vue
@@ -18,24 +18,40 @@
 
   const lab = computed<Laboratory | null>(() => labsStore.labs[labId] ?? null);
   const labRun = computed<LaboratoryRun | null>(() => runStore.labRuns[labRunId] ?? null);
-  // The LaboratoryRun's InputS3Url is the authoritative reference to obtain S3Bucket & S3Prefix for the File Manager
+  // Prefer OutputS3Url as the authoritative reference for the File Manager root when available (supports custom output dirs).
+  // Fall back to InputS3Url for legacy runs where OutputS3Url was not set.
   const inputS3Url = computed<string | null>(() => labRun.value?.InputS3Url ?? null);
+  const outputS3Url = computed<string | null>(() => labRun.value?.OutputS3Url ?? null);
+  const effectiveRootS3Url = computed<string | null>(() => outputS3Url.value ?? inputS3Url.value);
   const s3Bucket = computed<string | null>(
-    () => inputS3Url.value?.match(/(?<=^s3:\/\/)([a-z0-9][a-z0-9-]{1,61}[a-z0-9])(?=\/*)/g)?.toString() ?? null,
+    () => effectiveRootS3Url.value?.match(/(?<=^s3:\/\/)([a-z0-9][a-z0-9-]{1,61}[a-z0-9])(?=\/*)/g)?.toString() ?? null,
   );
   const s3Prefix = computed<string | null>(
-    () => inputS3Url.value?.match(/(?<=^s3:\/\/[a-z0-9][a-z0-9-]{1,61}[a-z0-9]\/)(.*)/g)?.toString() ?? null,
+    () => effectiveRootS3Url.value?.match(/(?<=^s3:\/\/[a-z0-9][a-z0-9-]{1,61}[a-z0-9]\/)(.*)/g)?.toString() ?? null,
   );
 
   const outputPath = computed<string[] | null>(() => {
-    const outputS3Url = labRun.value?.OutputS3Url ?? null;
-    if (inputS3Url.value === null || outputS3Url === null) return null;
+    const run = labRun.value;
+    const outputUrl = run?.OutputS3Url ?? null;
+    const inputUrl = inputS3Url.value;
+
+    // If we have an explicit OutputS3Url, the File Manager root is that location.
+    // For AWS HealthOmics runs, Omics generates an additional sub-folder with the ExternalRunId
+    // which we still want to auto-descend into.
+    if (outputUrl) {
+      if (run?.Platform === 'AWS HealthOmics' && !!run.ExternalRunId) {
+        return [run.ExternalRunId];
+      }
+      return null;
+    }
+
+    if (!inputUrl) return null;
 
     // get length of shared prefix
     let i = 0;
-    while (inputS3Url.value[i] === outputS3Url[i]) i++;
+    while (inputUrl[i] === outputUrl[i]) i++;
 
-    let outputRelativeLocation = outputS3Url.slice(i);
+    let outputRelativeLocation = (run?.OutputS3Url ?? '').slice(i);
     if (!outputRelativeLocation.match(/^(\/[^\/]+)+$/)) return null;
 
     // omics generates an additional sub-folder with the omics run id which we also want to descend into
@@ -231,7 +247,13 @@
 
       <!-- File Manager -->
       <div v-if="item.key === 'fileManager'" class="space-y-3">
-        <EGFileExplorer :lab-id="labId" :s3-bucket="s3Bucket" :s3-prefix="s3Prefix" :start-path="outputPath" />
+        <EGFileExplorer
+          :lab-id="labId"
+          :run-id="labRunId"
+          :s3-bucket="s3Bucket"
+          :s3-prefix="s3Prefix"
+          :start-path="outputPath"
+        />
       </div>
     </template>
   </UTabs>

--- a/packages/front-end/src/app/pages/labs/[labId]/seqera-run/[seqeraRunId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/seqera-run/[seqeraRunId].vue
@@ -131,7 +131,13 @@
   <UTabs :ui="EGTabsStyles" v-model="tabIndex" :items="tabItems" @update:model-value="handleTabChange">
     <template #item="{ item }">
       <div v-show="item.key === 'fileManager'" class="space-y-3">
-        <EGFileExplorer v-if="labRunId && s3Bucket" :lab-id="labId" :s3-bucket="s3Bucket" :s3-prefix="s3Prefix" />
+        <EGFileExplorer
+          v-if="labRunId && s3Bucket"
+          :lab-id="labId"
+          :run-id="labRunId"
+          :s3-bucket="s3Bucket"
+          :s3-prefix="s3Prefix"
+        />
       </div>
       <div v-if="item.key === 'runDetails'" class="space-y-3">
         <section

--- a/packages/shared-lib/src/app/schema/easy-genomics/file/request-top-level-bucket-objects.ts
+++ b/packages/shared-lib/src/app/schema/easy-genomics/file/request-top-level-bucket-objects.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 export const RequestTopLevelBucketObjectsSchema = z
   .object({
     LaboratoryId: z.string(),
+    RunId: z.string().optional(),
     S3Bucket: z.string().optional(),
     S3Prefix: z.string().optional(),
     MaxKeys: z.number().optional(),

--- a/packages/shared-lib/src/app/types/easy-genomics/file/request-top-level-bucket-objects.d.ts
+++ b/packages/shared-lib/src/app/types/easy-genomics/file/request-top-level-bucket-objects.d.ts
@@ -1,6 +1,7 @@
 // request-top-level-bucket-objects API type definition
 export type RequestTopLevelBucketObjects = {
   LaboratoryId: string;
+  RunId?: string;
   S3Bucket?: string;
   S3Prefix?: string;
   MaxKeys?: number;


### PR DESCRIPTION
## fix: release v1.2.2

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [x] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Pull request for release version 1.2.2 of easy-genomics. This release fixes issue with workflows with custom output directories are not showing files in the File Manager view.

### 🔧 Bug fixes:
- fix: workflow result files access for custom output directories
  - https://github.com/dept/easy-genomics/pull/676
- fix: allow laboratory to get run results from multiple s3 buckets
  - https://github.com/dept/easy-genomics/pull/679/changes

## Testing*
QA tested all changes in UAT environment.

## Impact
This impacts the file manager view for workflow runs.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.