### PR TITLE
feat: server-side pagination for runs table

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/list-laboratory-runs.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/list-laboratory-runs.lambda.ts
@@ -1,5 +1,9 @@
+import { AttributeValue } from '@aws-sdk/client-dynamodb';
 import { LaboratoryRunSchema } from '@easy-genomics/shared-lib/lib/app/schema/easy-genomics/laboratory-run';
-import { ReadLaboratoryRun } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/laboratory-run';
+import {
+  ListLaboratoryRunsPaginatedResponse,
+  ReadLaboratoryRun,
+} from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/laboratory-run';
 import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
 import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory-run';
 import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/src/app/utils/common';
@@ -20,6 +24,12 @@ import { getFilterResults, getFilters } from '@BE/utils/rest-api-utils';
 
 const laboratoryService = new LaboratoryService();
 const laboratoryRunService = new LaboratoryRunService();
+
+const SERVER_PAGE_DEFAULT_LIMIT = 25;
+const SERVER_PAGE_MAX_LIMIT = 100;
+const SERVER_MODE_TRUE = 'true';
+const MOCK_RUNS_COUNT = 150;
+const LOCAL_STAGE = 'local';
 
 export const handler: Handler = async (
   event: APIGatewayProxyWithCognitoAuthorizerEvent,
@@ -47,6 +57,61 @@ export const handler: Handler = async (
       )
     ) {
       throw new UnauthorizedAccessError();
+    }
+
+    const isServerMode = event.queryStringParameters?.serverMode === SERVER_MODE_TRUE;
+
+    if (isServerMode) {
+      const limit = parseLimit(event.queryStringParameters?.limit);
+      const sortBy = parseSortBy(event.queryStringParameters?.sortBy);
+      const sortDirection = parseSortDirection(event.queryStringParameters?.sortDirection);
+      const filters = parseServerFilters(event.queryStringParameters ?? undefined);
+      const nextToken = event.queryStringParameters?.nextToken;
+
+      if (shouldUseMockRuns(event)) {
+        const persistedRuns: LaboratoryRun[] = await laboratoryRunService.queryByLaboratoryId(laboratoryId);
+        const mockRuns = buildMockRuns(laboratoryId, laboratory.OrganizationId);
+        const mergedRuns = [...persistedRuns, ...mockRuns];
+        const filteredRuns = applyServerModeFilters(mergedRuns, filters);
+        const sortedRuns = sortRuns(filteredRuns, sortBy, sortDirection);
+        const offset = decodeMockOffsetToken(nextToken);
+        const pagedRuns = sortedRuns.slice(offset, offset + limit);
+        const nextOffset = offset + pagedRuns.length;
+        const hasMore = nextOffset < sortedRuns.length;
+
+        const payload: ListLaboratoryRunsPaginatedResponse = {
+          items: pagedRuns.map((laboratoryRun: LaboratoryRun) => ({
+            ...laboratoryRun,
+            Settings: JSON.parse(laboratoryRun.Settings || '{}'),
+          })),
+          hasMore,
+          nextToken: hasMore ? encodeMockOffsetToken(nextOffset) : undefined,
+        };
+
+        return buildResponse(200, JSON.stringify(payload), event);
+      }
+
+      const response = await laboratoryRunService.queryByLaboratoryIdPaginated({
+        laboratoryId,
+        limit,
+        sortBy,
+        sortDirection,
+        filters,
+        exclusiveStartKey: decodeToken(nextToken),
+      });
+
+      const results: ReadLaboratoryRun[] = response.items.map((laboratoryRun: LaboratoryRun) => ({
+        ...laboratoryRun,
+        Settings: JSON.parse(laboratoryRun.Settings || '{}'),
+      }));
+
+      const payload: ListLaboratoryRunsPaginatedResponse = {
+        items: results,
+        hasMore: !!response.lastEvaluatedKey,
+        nextToken: response.lastEvaluatedKey ? encodeToken(response.lastEvaluatedKey) : undefined,
+      };
+
+      return buildResponse(200, JSON.stringify(payload), event);
     }
 
     const laboratoryRuns: LaboratoryRun[] = await laboratoryRunService.queryByLaboratoryId(laboratoryId);
@@ -77,3 +142,194 @@ export const handler: Handler = async (
     return buildErrorResponse(err, event);
   }
 };
+
+function parseLimit(limit?: string): number {
+  if (!limit) {
+    return SERVER_PAGE_DEFAULT_LIMIT;
+  }
+
+  const parsedLimit = parseInt(limit, 10);
+  if (Number.isNaN(parsedLimit) || parsedLimit <= 0) {
+    throw new InvalidRequestError();
+  }
+
+  return Math.min(parsedLimit, SERVER_PAGE_MAX_LIMIT);
+}
+
+function parseSortBy(sortBy?: string): 'CreatedAt' | 'ModifiedAt' {
+  if (!sortBy || sortBy === 'CreatedAt') {
+    return 'CreatedAt';
+  }
+  if (sortBy === 'lastUpdated' || sortBy === 'ModifiedAt') {
+    return 'ModifiedAt';
+  }
+
+  throw new InvalidRequestError();
+}
+
+function parseSortDirection(sortDirection?: string): 'asc' | 'desc' {
+  if (!sortDirection || sortDirection.toLowerCase() === 'desc') {
+    return 'desc';
+  }
+  if (sortDirection.toLowerCase() === 'asc') {
+    return 'asc';
+  }
+
+  throw new InvalidRequestError();
+}
+
+function parseServerFilters(queryStringParameters?: Record<string, string | undefined>): {
+  UserId?: string;
+  Status?: string;
+} {
+  const filters: { UserId?: string; Status?: string } = {};
+
+  if (queryStringParameters?.UserId) {
+    filters.UserId = queryStringParameters.UserId;
+  }
+
+  if (queryStringParameters?.search) {
+    const parsed = parseStructuredSearch(queryStringParameters.search);
+    if (parsed.field === 'status') {
+      filters.Status = parsed.value.toUpperCase();
+    } else {
+      throw new InvalidRequestError();
+    }
+  }
+
+  return filters;
+}
+
+function parseStructuredSearch(search: string): { field: string; value: string } {
+  const normalized = search.trim();
+  const equalsIndex = normalized.indexOf('=');
+  if (equalsIndex <= 0) {
+    throw new InvalidRequestError();
+  }
+
+  const fieldRaw = normalized
+    .slice(0, equalsIndex)
+    .replace(/^"+|"+$/g, '')
+    .trim()
+    .toLowerCase();
+  const valueRaw = normalized
+    .slice(equalsIndex + 1)
+    .replace(/^"+|"+$/g, '')
+    .trim();
+  if (!fieldRaw || !valueRaw) {
+    throw new InvalidRequestError();
+  }
+
+  return {
+    field: fieldRaw,
+    value: valueRaw,
+  };
+}
+
+function encodeToken(lastEvaluatedKey: Record<string, AttributeValue>): string {
+  return Buffer.from(JSON.stringify(lastEvaluatedKey)).toString('base64');
+}
+
+function decodeToken(token?: string): Record<string, AttributeValue> | undefined {
+  if (!token) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(Buffer.from(token, 'base64').toString('utf8'));
+  } catch (_err) {
+    throw new InvalidRequestError();
+  }
+}
+
+function shouldUseMockRuns(event: APIGatewayProxyWithCognitoAuthorizerEvent): boolean {
+  const envType = (process.env.ENV_TYPE || '').toLowerCase();
+  const nodeEnv = (process.env.NODE_ENV || '').toLowerCase();
+  const stage = (event.requestContext?.stage || '').toLowerCase();
+
+  return (
+    envType === 'dev' ||
+    envType === 'development' ||
+    envType === 'local' ||
+    nodeEnv === 'development' ||
+    stage === LOCAL_STAGE
+  );
+}
+
+function buildMockRuns(laboratoryId: string, organizationId: string): LaboratoryRun[] {
+  const statuses = ['SUBMITTED', 'STARTING', 'RUNNING', 'COMPLETED', 'FAILED', 'CANCELLED'];
+  const platforms: ('AWS HealthOmics' | 'Seqera Cloud')[] = ['AWS HealthOmics', 'Seqera Cloud'];
+  const now = new Date();
+
+  return Array.from({ length: MOCK_RUNS_COUNT }, (_value, idx) => {
+    const runNumber = idx + 1;
+    const createdAt = new Date(now.getTime() - runNumber * 60 * 60 * 1000);
+    const modifiedAt = new Date(createdAt.getTime() + (runNumber % 5) * 10 * 60 * 1000);
+
+    return {
+      LaboratoryId: laboratoryId,
+      OrganizationId: organizationId,
+      RunId: makeDeterministicUuid(`run-${runNumber}`),
+      UserId: makeDeterministicUuid(`user-${(runNumber % 8) + 1}`),
+      RunName: `Mock Run ${String(runNumber).padStart(3, '0')}`,
+      Platform: platforms[runNumber % platforms.length],
+      Status: statuses[runNumber % statuses.length],
+      Owner: `mock-user-${(runNumber % 8) + 1}@example.com`,
+      WorkflowName: `Workflow ${(runNumber % 12) + 1}`,
+      ExternalRunId: `mock-external-run-${runNumber}`,
+      CreatedAt: createdAt.toISOString(),
+      ModifiedAt: modifiedAt.toISOString(),
+      Settings: JSON.stringify({ mock: true, runNumber }),
+    };
+  });
+}
+
+function makeDeterministicUuid(seed: string): string {
+  const hex = Buffer.from(seed).toString('hex').padEnd(32, '0').slice(0, 32);
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-4${hex.slice(13, 16)}-8${hex.slice(17, 20)}-${hex.slice(20, 32)}`;
+}
+
+function applyServerModeFilters(runs: LaboratoryRun[], filters: { UserId?: string; Status?: string }): LaboratoryRun[] {
+  return runs.filter((run) => {
+    if (filters.UserId && run.UserId !== filters.UserId) {
+      return false;
+    }
+    if (filters.Status && run.Status !== filters.Status) {
+      return false;
+    }
+    return true;
+  });
+}
+
+function sortRuns(
+  runs: LaboratoryRun[],
+  sortBy: 'CreatedAt' | 'ModifiedAt',
+  sortDirection: 'asc' | 'desc',
+): LaboratoryRun[] {
+  const sortedRuns = [...runs].sort((a, b) => {
+    const left = (a[sortBy] || '').toString();
+    const right = (b[sortBy] || '').toString();
+    return left.localeCompare(right);
+  });
+  return sortDirection === 'asc' ? sortedRuns : sortedRuns.reverse();
+}
+
+function encodeMockOffsetToken(offset: number): string {
+  return Buffer.from(JSON.stringify({ type: 'mock-offset', offset })).toString('base64');
+}
+
+function decodeMockOffsetToken(token?: string): number {
+  if (!token) {
+    return 0;
+  }
+
+  try {
+    const parsed = JSON.parse(Buffer.from(token, 'base64').toString('utf8'));
+    if (parsed?.type !== 'mock-offset' || typeof parsed.offset !== 'number' || parsed.offset < 0) {
+      throw new InvalidRequestError();
+    }
+    return parsed.offset;
+  } catch (_err) {
+    throw new InvalidRequestError();
+  }
+}

--- a/packages/back-end/src/app/services/easy-genomics/laboratory-run-service.ts
+++ b/packages/back-end/src/app/services/easy-genomics/laboratory-run-service.ts
@@ -1,7 +1,9 @@
 import {
+  AttributeValue,
   DeleteItemCommandOutput,
   GetItemCommandOutput,
   PutItemCommandOutput,
+  QueryCommandInput,
   QueryCommandOutput,
   UpdateItemCommandOutput,
 } from '@aws-sdk/client-dynamodb';
@@ -91,6 +93,83 @@ export class LaboratoryRunService extends DynamoDBService implements Service<Lab
     } else {
       throw new Error(`${logRequestMessage} unsuccessful: HTTP Status Code=${response.$metadata.httpStatusCode}`);
     }
+  };
+
+  public queryByLaboratoryIdPaginated = async ({
+    laboratoryId,
+    limit,
+    sortBy,
+    sortDirection,
+    filters,
+    exclusiveStartKey,
+  }: {
+    laboratoryId: string;
+    limit: number;
+    sortBy: 'CreatedAt' | 'ModifiedAt';
+    sortDirection: 'asc' | 'desc';
+    filters: { UserId?: string; Status?: string };
+    exclusiveStartKey?: Record<string, AttributeValue>;
+  }): Promise<{
+    items: LaboratoryRun[];
+    lastEvaluatedKey?: Record<string, AttributeValue>;
+  }> => {
+    const logRequestMessage = `Query LaboratoryRuns paginated by LaboratoryId=${laboratoryId} request`;
+    console.info(logRequestMessage);
+
+    const expressionAttributeNames: Record<string, string> = {
+      '#LaboratoryId': 'LaboratoryId',
+    };
+    const expressionAttributeValues: Record<string, AttributeValue> = {
+      ':laboratoryId': { S: laboratoryId },
+    };
+    const filterExpressionParts: string[] = [];
+
+    if (filters.UserId) {
+      expressionAttributeNames['#UserId'] = 'UserId';
+      expressionAttributeValues[':userId'] = { S: filters.UserId };
+      filterExpressionParts.push('#UserId = :userId');
+    }
+
+    if (filters.Status) {
+      expressionAttributeNames['#Status'] = 'Status';
+      expressionAttributeValues[':status'] = { S: filters.Status };
+      filterExpressionParts.push('#Status = :status');
+    }
+
+    const queryInput: QueryCommandInput = {
+      TableName: this.LABORATORY_RUN_TABLE_NAME,
+      KeyConditionExpression: '#LaboratoryId = :laboratoryId',
+      ExpressionAttributeNames: expressionAttributeNames,
+      ExpressionAttributeValues: expressionAttributeValues,
+      ScanIndexForward: sortDirection === 'asc',
+      IndexName: `${sortBy}_Index`,
+      Limit: limit,
+      ExclusiveStartKey: exclusiveStartKey,
+      ...(filterExpressionParts.length > 0 ? { FilterExpression: filterExpressionParts.join(' AND ') } : {}),
+    };
+
+    const items: LaboratoryRun[] = [];
+    let queryResponse: QueryCommandOutput = await this.queryItems(queryInput);
+
+    if (queryResponse.Items) {
+      items.push(...queryResponse.Items.map((item) => <LaboratoryRun>unmarshall(item)));
+    }
+
+    // FilterExpression is applied after reads. Continue querying until page is filled or no more results.
+    while (items.length < limit && queryResponse.LastEvaluatedKey) {
+      const remaining = limit - items.length;
+      queryInput.Limit = remaining;
+      queryInput.ExclusiveStartKey = queryResponse.LastEvaluatedKey;
+      queryResponse = await this.queryItems(queryInput);
+      if (queryResponse.Items) {
+        items.push(...queryResponse.Items.map((item) => <LaboratoryRun>unmarshall(item)));
+      }
+    }
+
+    return {
+      items,
+      lastEvaluatedKey: queryResponse.LastEvaluatedKey,
+    };
   };
 
   public queryByRunId = async (runId: string): Promise<LaboratoryRun> => {

--- a/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/list-laboratory-runs.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/list-laboratory-runs.lambda.test.ts
@@ -26,6 +26,7 @@ describe('list-laboratory-runs.lambda', () => {
 
   let mockQueryByLaboratoryIdForLab: jest.Mock;
   let mockQueryByLaboratoryIdForRuns: jest.Mock;
+  let mockQueryByLaboratoryIdPaginatedForRuns: jest.Mock;
 
   const createEvent = (
     query: Record<string, string | undefined>,
@@ -81,8 +82,10 @@ describe('list-laboratory-runs.lambda', () => {
 
     mockQueryByLaboratoryIdForLab = jest.fn();
     mockQueryByLaboratoryIdForRuns = jest.fn();
+    mockQueryByLaboratoryIdPaginatedForRuns = jest.fn();
     mockLabService.prototype.queryByLaboratoryId = mockQueryByLaboratoryIdForLab;
     mockRunService.prototype.queryByLaboratoryId = mockQueryByLaboratoryIdForRuns;
+    mockRunService.prototype.queryByLaboratoryIdPaginated = mockQueryByLaboratoryIdPaginatedForRuns;
 
     mockValidateOrgAdmin.mockReturnValue(true);
     mockValidateLabManager.mockReturnValue(false);
@@ -91,6 +94,11 @@ describe('list-laboratory-runs.lambda', () => {
     // Default filter behaviour: no-op and return original runs
     (getFilters as jest.Mock).mockReturnValue([]);
     (getFilterResults as jest.Mock).mockImplementation((runs: any[]) => runs);
+  });
+
+  afterEach(() => {
+    delete process.env.ENV_TYPE;
+    delete process.env.NODE_ENV;
   });
 
   it('returns 400 when LaboratoryId query parameter is missing', async () => {
@@ -174,5 +182,123 @@ describe('list-laboratory-runs.lambda', () => {
     expect(body[0].Status).toBe('FAILED');
     expect(getFilters).toHaveBeenCalled();
     expect(getFilterResults).toHaveBeenCalled();
+  });
+
+  it('returns paginated payload in server mode for non-dev environments', async () => {
+    process.env.ENV_TYPE = 'prod';
+    mockQueryByLaboratoryIdForLab.mockResolvedValue({
+      OrganizationId: 'org-1',
+      LaboratoryId: LAB_ID,
+    });
+    mockQueryByLaboratoryIdPaginatedForRuns.mockResolvedValue({
+      items: [{ RunId: 'run-1', LaboratoryId: LAB_ID, OrganizationId: 'org-1', Settings: '{}' }],
+      lastEvaluatedKey: { LaboratoryId: { S: LAB_ID }, RunId: { S: 'run-2' } },
+    });
+
+    const result = await handler(
+      createEvent({
+        LaboratoryId: LAB_ID,
+        serverMode: 'true',
+        limit: '10',
+        sortBy: 'CreatedAt',
+        sortDirection: 'desc',
+      }),
+      createContext(),
+      () => {},
+    );
+
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(Array.isArray(body.items)).toBe(true);
+    expect(body.items).toHaveLength(1);
+    expect(body.hasMore).toBe(true);
+    expect(typeof body.nextToken).toBe('string');
+    expect(mockQueryByLaboratoryIdPaginatedForRuns).toHaveBeenCalled();
+  });
+
+  it('returns 400 for unsupported server mode sortBy value', async () => {
+    process.env.ENV_TYPE = 'prod';
+    mockQueryByLaboratoryIdForLab.mockResolvedValue({
+      OrganizationId: 'org-1',
+      LaboratoryId: LAB_ID,
+    });
+
+    const result = await handler(
+      createEvent({
+        LaboratoryId: LAB_ID,
+        serverMode: 'true',
+        sortBy: 'Owner',
+      }),
+      createContext(),
+      () => {},
+    );
+
+    expect(result.statusCode).toBe(400);
+    expect(mockQueryByLaboratoryIdPaginatedForRuns).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for invalid server mode search field', async () => {
+    process.env.ENV_TYPE = 'prod';
+    mockQueryByLaboratoryIdForLab.mockResolvedValue({
+      OrganizationId: 'org-1',
+      LaboratoryId: LAB_ID,
+    });
+
+    const result = await handler(
+      createEvent({
+        LaboratoryId: LAB_ID,
+        serverMode: 'true',
+        search: '"owner"=user@example.com',
+      }),
+      createContext(),
+      () => {},
+    );
+
+    expect(result.statusCode).toBe(400);
+    expect(mockQueryByLaboratoryIdPaginatedForRuns).not.toHaveBeenCalled();
+  });
+
+  it('uses local/dev mock mode and paginates synthetic data', async () => {
+    process.env.ENV_TYPE = 'dev';
+    mockQueryByLaboratoryIdForLab.mockResolvedValue({
+      OrganizationId: 'org-1',
+      LaboratoryId: LAB_ID,
+    });
+    mockQueryByLaboratoryIdForRuns.mockResolvedValue([]);
+
+    const firstPageResult = await handler(
+      createEvent({
+        LaboratoryId: LAB_ID,
+        serverMode: 'true',
+        limit: '10',
+        sortBy: 'CreatedAt',
+      }),
+      createContext(),
+      () => {},
+    );
+
+    expect(firstPageResult.statusCode).toBe(200);
+    const firstPageBody = JSON.parse(firstPageResult.body);
+    expect(firstPageBody.items).toHaveLength(10);
+    expect(firstPageBody.hasMore).toBe(true);
+    expect(typeof firstPageBody.nextToken).toBe('string');
+    expect(mockQueryByLaboratoryIdPaginatedForRuns).not.toHaveBeenCalled();
+
+    const secondPageResult = await handler(
+      createEvent({
+        LaboratoryId: LAB_ID,
+        serverMode: 'true',
+        limit: '10',
+        sortBy: 'CreatedAt',
+        nextToken: firstPageBody.nextToken,
+      }),
+      createContext(),
+      () => {},
+    );
+
+    expect(secondPageResult.statusCode).toBe(200);
+    const secondPageBody = JSON.parse(secondPageResult.body);
+    expect(secondPageBody.items).toHaveLength(10);
+    expect(secondPageBody.items[0].RunId).not.toBe(firstPageBody.items[0].RunId);
   });
 });

--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -15,6 +15,8 @@
   import { Pipeline as SeqeraPipeline } from '@easy-genomics/shared-lib/src/app/types/nf-tower/nextflow-tower-api';
   import { WorkflowListItem as OmicsWorkflow } from '@aws-sdk/client-omics';
   import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory-run';
+  import { ListLaboratoryRunsPaginatedResponse } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/laboratory-run';
+  import { useDebounceFn } from '@vueuse/core';
   import { TableSort } from './EGTable.vue';
 
   const props = defineProps<{
@@ -118,125 +120,131 @@
 
   // Lab Runs Tab
 
-  type LaboratoryRunTableItem = LaboratoryRun & { lastUpdated: string; searchIndex: string };
+  type LaboratoryRunTableItem = LaboratoryRun & { lastUpdated: string };
 
   const runsTableColumns = [
-    { key: 'RunName', label: 'Run Name', sortable: true },
+    { key: 'RunName', label: 'Run Name' },
     { key: 'CreatedAt', label: 'Created At', sortable: true },
     { key: 'lastUpdated', label: 'Last Updated', sortable: true },
-    { key: 'Status', label: 'Status', sortable: true },
-    { key: 'Owner', label: 'Owner', sortable: true },
+    { key: 'Status', label: 'Status' },
+    { key: 'Owner', label: 'Owner' },
     { key: 'actions', label: 'Actions' },
   ];
 
   const runsTableSort = ref<TableSort>({ column: 'CreatedAt', direction: 'desc' });
+  const runsServerModeLimit = 10;
+  const runsPageTokenStack = ref<(string | undefined)[]>([undefined]);
+  const runsServerHasMore = ref<boolean>(false);
+  const runsServerNextToken = ref<string | undefined>(undefined);
 
   const runsTableFilterMyRunsOnly = ref<boolean>(false);
-  const runsSearchQuery = ref<string>('');
+  const runsStructuredSearch = ref<string>('');
 
   const runsTableItems = ref<LaboratoryRunTableItem[]>([]);
-
-  function matchesRunSearch(run: LaboratoryRunTableItem, rawQuery: string): boolean {
-    const query = rawQuery.trim().toLowerCase();
-
-    if (!query) {
-      return true;
+  const runsCurrentPage = computed<number>(() => runsPageTokenStack.value.length);
+  const runsServerPageLabel = computed<string>(() => {
+    if (!runsTableItems.value.length) {
+      return '';
     }
-
-    const equalsIndex = query.indexOf('=');
-
-    if (equalsIndex > -1) {
-      const fieldRaw = query.slice(0, equalsIndex);
-      const valueRaw = query.slice(equalsIndex + 1);
-
-      const field = fieldRaw.replace(/^"+|"+$/g, '').trim();
-      const value = valueRaw.replace(/^"+|"+$/g, '').trim();
-
-      if (field && value) {
-        const fieldMap: Record<string, keyof LaboratoryRunTableItem> = {
-          status: 'Status',
-          runname: 'RunName',
-          name: 'RunName',
-          owner: 'Owner',
-          workflow: 'WorkflowName' as keyof LaboratoryRunTableItem,
-          workflowname: 'WorkflowName' as keyof LaboratoryRunTableItem,
-          id: 'RunId' as keyof LaboratoryRunTableItem,
-          runid: 'RunId' as keyof LaboratoryRunTableItem,
-          platform: 'Platform' as keyof LaboratoryRunTableItem,
-        };
-
-        const mappedKey = fieldMap[field] ?? (field as keyof LaboratoryRunTableItem);
-        const runValue = (run as any)[mappedKey];
-
-        if (runValue != null) {
-          return String(runValue).toLowerCase().includes(value);
-        }
-      }
-      // if parsing fails or field is unknown, fall back to full-text search below
-    }
-
-    const haystack = run.searchIndex;
-
-    return haystack.includes(query);
-  }
-
-  const filteredRunsTableItems = computed<LaboratoryRunTableItem[]>(() => {
-    if (!runsSearchQuery.value.trim()) {
-      return runsTableItems.value;
-    }
-
-    return runsTableItems.value.filter((run) => matchesRunSearch(run, runsSearchQuery.value));
+    return `Page ${runsCurrentPage.value}`;
   });
 
-  // fetch the runs with BE filtering any time any of the inputs change
-  watchEffect(async () => {
+  function parseServerSearch(input: string): string {
+    const trimmed = input.trim();
+    if (!trimmed) {
+      return '';
+    }
+
+    const equalsIndex = trimmed.indexOf('=');
+    if (equalsIndex <= 0) {
+      return '';
+    }
+
+    const fieldRaw = trimmed
+      .slice(0, equalsIndex)
+      .replace(/^"+|"+$/g, '')
+      .trim()
+      .toLowerCase();
+    const valueRaw = trimmed
+      .slice(equalsIndex + 1)
+      .replace(/^"+|"+$/g, '')
+      .trim();
+
+    if (fieldRaw !== 'status' || !valueRaw) {
+      return '';
+    }
+
+    return `"status"=${valueRaw}`;
+  }
+
+  const applyRunsSearchDebounced = useDebounceFn((newVal: string) => {
+    runsStructuredSearch.value = parseServerSearch(newVal);
+  }, 350);
+
+  function resetRunsPagination() {
+    runsPageTokenStack.value = [undefined];
+    runsServerNextToken.value = undefined;
+    runsServerHasMore.value = false;
+  }
+
+  async function loadRunsPage() {
     uiStore.setRequestPending('loadLabRuns');
-
-    // without this following line, watchEffect doesn't pick up runsTableSort as a reactive dependency...
-    runsTableSort.value;
-
-    // laboratory run polling refresh key
-    runsTableRefreshKey.value;
-
-    const filters: any = {};
-    if (runsTableFilterMyRunsOnly.value) filters.UserId = userStore.currentUserDetails.id!;
-
     try {
-      runsTableItems.value = (await $api.labs.listLabRuns(props.labId, filters))
-        .map((labRun) => {
-          const lastUpdated = labRun.ModifiedAt ?? labRun.CreatedAt ?? '';
-          const searchIndex = [
-            labRun.RunName,
-            (labRun as any).WorkflowName,
-            labRun.Status,
-            labRun.Owner,
-            (labRun as any).RunId,
-            (labRun as any).Platform,
-            labRun.CreatedAt,
-            labRun.ModifiedAt,
-            lastUpdated,
-          ]
-            .filter(Boolean)
-            .join(' ')
-            .toLowerCase();
+      const filters: { UserId?: string; search?: string } = {};
+      if (runsTableFilterMyRunsOnly.value) filters.UserId = userStore.currentUserDetails.id!;
+      if (runsStructuredSearch.value) filters.search = runsStructuredSearch.value;
 
-          return {
-            ...labRun,
-            lastUpdated,
-            searchIndex,
-          };
-        })
-        .sort((a: any, b: any) =>
-          stringSortCompare(
-            a[runsTableSort.value.column],
-            b[runsTableSort.value.column],
-            runsTableSort.value.direction,
-          ),
-        );
+      const response: ListLaboratoryRunsPaginatedResponse = await $api.labs.listLabRunsPaginated(props.labId, {
+        limit: runsServerModeLimit,
+        nextToken: runsPageTokenStack.value[runsPageTokenStack.value.length - 1],
+        sortBy: runsTableSort.value.column,
+        sortDirection: runsTableSort.value.direction,
+        filters,
+      });
+
+      runsTableItems.value = response.items.map((labRun) => ({
+        ...labRun,
+        lastUpdated: labRun.ModifiedAt ?? labRun.CreatedAt ?? '',
+      }));
+      runsServerHasMore.value = response.hasMore;
+      runsServerNextToken.value = response.nextToken;
     } finally {
       uiStore.setRequestComplete('loadLabRuns');
     }
-  });
+  }
+
+  watch(
+    [runsTableSort, runsTableFilterMyRunsOnly, runsStructuredSearch],
+    async () => {
+      resetRunsPagination();
+      await loadRunsPage();
+    },
+    { immediate: true },
+  );
+
+  watch(
+    runsTableRefreshKey,
+    async () => {
+      await loadRunsPage();
+    },
+    { immediate: false },
+  );
+
+  async function onRunsNextPage() {
+    if (!runsServerHasMore.value || !runsServerNextToken.value) {
+      return;
+    }
+    runsPageTokenStack.value.push(runsServerNextToken.value);
+    await loadRunsPage();
+  }
+
+  async function onRunsPrevPage() {
+    if (runsPageTokenStack.value.length <= 1) {
+      return;
+    }
+    runsPageTokenStack.value.pop();
+    await loadRunsPage();
+  }
 
   function runsActionItems(run: LaboratoryRun): object[] {
     const buttons: object[][] = [
@@ -524,7 +532,7 @@
   }
 
   function updateRunsSearchQuery(newVal: string) {
-    runsSearchQuery.value = newVal;
+    applyRunsSearchDebounced(newVal);
   }
 
   async function handleUserAddedToLab() {
@@ -710,19 +718,27 @@
             <UCheckbox label="My runs only" :ui="{ base: 'size-[24px]' }" v-model="runsTableFilterMyRunsOnly" />
           </div>
           <p class="text-muted mt-1 text-xs">
-            Search by all run fields or use queries like
+            Search currently supports only the
+            <span class="font-mono">status</span>
+            column in server-side mode (for example,
             <span class="font-mono">"status"=completed</span>
-            .
+            ). Other columns are not supported.
           </p>
         </div>
 
         <EGTable
           :row-click-action="viewRunDetails"
-          :table-data="filteredRunsTableItems"
+          :table-data="runsTableItems"
           :columns="runsTableColumns"
           v-model:sort="runsTableSort"
           :is-loading="useUiStore().anyRequestPending(['loadLabData', 'loadLabRuns'])"
           :show-pagination="!useUiStore().anyRequestPending(['loadLabData', 'loadLabRuns'])"
+          pagination-mode="server"
+          :server-has-next="runsServerHasMore"
+          :server-can-go-back="runsCurrentPage > 1"
+          :server-page-label="runsServerPageLabel"
+          @next-page="onRunsNextPage"
+          @prev-page="onRunsPrevPage"
         >
           <template #RunName-data="{ row: run }">
             <div v-if="run.RunName" class="text-body text-sm font-medium">{{ run.RunName }}</div>

--- a/packages/front-end/src/app/components/EGTable.vue
+++ b/packages/front-end/src/app/components/EGTable.vue
@@ -17,12 +17,25 @@
       noResultsMsg?: string;
       canSelect?: boolean;
       rowClasses?: (row: any) => string;
+      paginationMode?: 'client' | 'server';
+      serverHasNext?: boolean;
+      serverCanGoBack?: boolean;
+      serverPageLabel?: string;
     }>(),
     {
       showPagination: true,
       noResultsMsg: 'No results found',
+      paginationMode: 'client',
+      serverHasNext: false,
+      serverCanGoBack: false,
+      serverPageLabel: '',
     },
   );
+
+  const emit = defineEmits<{
+    (e: 'next-page'): void;
+    (e: 'prev-page'): void;
+  }>();
 
   const sort = defineModel<TableSort>('sort');
 
@@ -30,10 +43,16 @@
   const rowsPerPage = ref(10);
   const selected = props.canSelect ? ref([]) : ref(null);
 
+  const isClientMode = computed(() => props.paginationMode === 'client');
   const end = computed(() => Math.min(start.value + rowsPerPage.value, totalRows.value));
   const rows = computed(() => {
-    if (totalRows.value > 0) return props.tableData.slice(start.value, end.value);
-    return [];
+    if (!totalRows.value) {
+      return [];
+    }
+    if (isClientMode.value) {
+      return props.tableData.slice(start.value, end.value);
+    }
+    return props.tableData;
   });
   const showingResultsMsg = computed(() => {
     if (totalRows.value > 0) {
@@ -48,6 +67,9 @@
   watch(
     page,
     (newPage) => {
+      if (!isClientMode.value) {
+        return;
+      }
       if (newPage < 1) page.value = 1;
       else if (totalPages.value > 0 && newPage > totalPages.value) page.value = totalPages.value;
     },
@@ -57,8 +79,10 @@
   watch(
     () => props.tableData,
     (_newTableData: any) => {
-      // when table data changes, reset to page 1
-      page.value = 1;
+      // when table data changes, reset to page 1 for client pagination only
+      if (isClientMode.value) {
+        page.value = 1;
+      }
     },
     { immediate: true },
   );
@@ -107,13 +131,15 @@
     </UTable>
   </UCard>
 
-  <div
-    class="text-muted flex h-16 flex-wrap items-center justify-between"
-    v-if="showPagination && rowsPerPage > 1 && !isLoading"
-  >
-    <div class="text-xs leading-5">{{ showingResultsMsg }}</div>
-    <div class="flex justify-end px-3" v-if="totalRows > rowsPerPage">
+  <div class="text-muted flex h-16 flex-wrap items-center justify-between" v-if="showPagination && !isLoading">
+    <div class="text-xs leading-5" v-if="isClientMode">{{ showingResultsMsg }}</div>
+    <div class="text-xs leading-5" v-else>{{ serverPageLabel }}</div>
+    <div class="flex justify-end px-3" v-if="isClientMode && totalRows > rowsPerPage">
       <UPagination v-model="page" :page-count="rowsPerPage" :total="totalRows" />
+    </div>
+    <div class="flex justify-end gap-2 px-3" v-else-if="!isClientMode">
+      <EGButton label="Previous" :disabled="!serverCanGoBack" @click="emit('prev-page')" />
+      <EGButton label="Next" :disabled="!serverHasNext" @click="emit('next-page')" />
     </div>
   </div>
 </template>

--- a/packages/front-end/src/app/repository/modules/labs.ts
+++ b/packages/front-end/src/app/repository/modules/labs.ts
@@ -1,5 +1,9 @@
 import { CreateLaboratory, UpdateLaboratory } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/laboratory';
-import { LaboratoryRunSchema } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/laboratory-run';
+import {
+  LaboratoryRunSchema,
+  ListLaboratoryRunsPaginatedResponse,
+  ListLaboratoryRunsPaginatedResponseSchema,
+} from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/laboratory-run';
 import { RemoveLaboratoryUserSchema } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/laboratory-user';
 import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
 import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory-run';
@@ -211,6 +215,56 @@ class LabsModule extends HttpFactory {
 
     const LaboratoryRunArraySchema = z.array(LaboratoryRunSchema); // Define an array schema
     validateApiResponse(LaboratoryRunArraySchema, res);
+    return res;
+  }
+
+  async listLabRunsPaginated(
+    labId: string,
+    options: {
+      limit?: number;
+      nextToken?: string;
+      sortBy?: string;
+      sortDirection?: 'asc' | 'desc';
+      filters?: {
+        UserId?: string;
+        search?: string;
+      };
+    } = {},
+  ): Promise<ListLaboratoryRunsPaginatedResponse> {
+    const queryParameters = new URLSearchParams({
+      LaboratoryId: labId,
+      serverMode: 'true',
+    });
+
+    if (options.limit) {
+      queryParameters.set('limit', String(options.limit));
+    }
+    if (options.nextToken) {
+      queryParameters.set('nextToken', options.nextToken);
+    }
+    if (options.sortBy) {
+      queryParameters.set('sortBy', options.sortBy);
+    }
+    if (options.sortDirection) {
+      queryParameters.set('sortDirection', options.sortDirection);
+    }
+    if (options.filters?.UserId) {
+      queryParameters.set('UserId', options.filters.UserId);
+    }
+    if (options.filters?.search) {
+      queryParameters.set('search', options.filters.search);
+    }
+
+    const res = await this.call<ListLaboratoryRunsPaginatedResponse>(
+      'GET',
+      `/laboratory/run/list-laboratory-runs?${queryParameters.toString()}`,
+    );
+
+    if (!res) {
+      throw new Error('Failed to retrieve paginated Laboratory runs');
+    }
+
+    validateApiResponse(ListLaboratoryRunsPaginatedResponseSchema, res);
     return res;
   }
 

--- a/packages/front-end/test/app/repository/modules/labs.test.ts
+++ b/packages/front-end/test/app/repository/modules/labs.test.ts
@@ -1,0 +1,91 @@
+const mockCall = jest.fn();
+const mockValidateApiResponse = jest.fn();
+
+jest.mock(
+  'nuxt/app',
+  () => ({
+    useRuntimeConfig: () => ({
+      public: {
+        BASE_API_URL: 'http://localhost:3001',
+      },
+    }),
+  }),
+  { virtual: true },
+);
+
+jest.mock(
+  '@FE/repository/factory',
+  () => {
+    return {
+      __esModule: true,
+      default: class MockHttpFactory {
+        call = mockCall;
+      },
+    };
+  },
+  { virtual: true },
+);
+
+jest.mock(
+  '@FE/utils/api-utils',
+  () => {
+    return {
+      validateApiResponse: mockValidateApiResponse,
+    };
+  },
+  { virtual: true },
+);
+
+describe('LabsModule.listLabRunsPaginated', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (global as any).useAuth = () => ({
+      getToken: jest.fn().mockResolvedValue('token'),
+      getRefreshedToken: jest.fn().mockResolvedValue('token'),
+    });
+  });
+
+  it('builds paginated query string and returns response', async () => {
+    const { default: LabsModule } = await import('../../../../src/app/repository/modules/labs');
+    mockCall.mockResolvedValue({
+      items: [],
+      hasMore: true,
+      nextToken: 'abc-token',
+    });
+
+    const module = new LabsModule();
+    const response = await module.listLabRunsPaginated('lab-123', {
+      limit: 10,
+      nextToken: 'cursor-token',
+      sortBy: 'CreatedAt',
+      sortDirection: 'desc',
+      filters: {
+        UserId: 'user-1',
+        search: '"status"=completed',
+      },
+    });
+
+    expect(response.hasMore).toBe(true);
+    expect(mockCall).toHaveBeenCalledWith('GET', expect.stringContaining('/laboratory/run/list-laboratory-runs?'));
+
+    const calledUrl = mockCall.mock.calls[0][1] as string;
+    expect(calledUrl).toContain('LaboratoryId=lab-123');
+    expect(calledUrl).toContain('serverMode=true');
+    expect(calledUrl).toContain('limit=10');
+    expect(calledUrl).toContain('nextToken=cursor-token');
+    expect(calledUrl).toContain('sortBy=CreatedAt');
+    expect(calledUrl).toContain('sortDirection=desc');
+    expect(calledUrl).toContain('UserId=user-1');
+    expect(calledUrl).toContain('search=%22status%22%3Dcompleted');
+  });
+
+  it('throws when API returns empty response', async () => {
+    const { default: LabsModule } = await import('../../../../src/app/repository/modules/labs');
+    mockCall.mockResolvedValue(undefined);
+
+    const module = new LabsModule();
+    await expect(module.listLabRunsPaginated('lab-123')).rejects.toThrow(
+      'Failed to retrieve paginated Laboratory runs',
+    );
+  });
+});

--- a/packages/shared-lib/src/app/schema/easy-genomics/laboratory-run.ts
+++ b/packages/shared-lib/src/app/schema/easy-genomics/laboratory-run.ts
@@ -54,6 +54,15 @@ export const ReadLaboratoryRunSchema = z
   .strict();
 export type ReadLaboratoryRun = z.infer<typeof ReadLaboratoryRunSchema>;
 
+export const ListLaboratoryRunsPaginatedResponseSchema = z
+  .object({
+    items: z.array(ReadLaboratoryRunSchema),
+    hasMore: z.boolean(),
+    nextToken: z.string().optional(),
+  })
+  .strict();
+export type ListLaboratoryRunsPaginatedResponse = z.infer<typeof ListLaboratoryRunsPaginatedResponseSchema>;
+
 export const AddLaboratoryRunSchema = z
   .object({
     LaboratoryId: z.string().uuid(),


### PR DESCRIPTION
## Use Server-Side Pagination for Pipeline Runs Table

## Type of Change*
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [X] UI/UX improvement

## Description

Implements server-side cursor pagination for the Pipeline Runs table on the lab view (EGLabView), replacing client-side slicing of the full runs list so the browser no longer loads hundreds of rows at once.

### Backend

- Extends GET /laboratory/run/list-laboratory-runs with a serverMode=true path that returns { items, hasMore, nextToken }.
- Uses DynamoDB Query on the lab partition with CreatedAt_Index / ModifiedAt_Index for sort, Limit, and ExclusiveStartKey (cursor encoded in nextToken).
- Supports UserId (e.g. “My runs only”) and structured search for status only ("status"=...).
- In local/dev, optionally merges deterministic mock runs and paginates in-memory so pagination can be tested without launching real Omics runs. Non-dev continues to use Dynamo pagination.

### Frontend

- Adds listLabRunsPaginated on the labs repository and wires the Runs tab to fetch pages with sort, filters, and cursor stack for Previous / Next.
- Extends EGTable with paginationMode="server" (Prev/Next) while keeping default client pagination for other tables.
- Updates search helper text to reflect status-only search; “My runs only” still filters by `UserId`, not `Owner`.
- Reduces default page size to 10 rows per request.

## Testing*

- Manual: Pipeline Runs tab with local server — verify Next/Previous, sort (CreatedAt / Last Updated), “My runs only”, and "status"=... search; confirm non-status search is rejected or ignored per current UX.
- Automated:
pnpm --prefix packages/back-end exec jest test/app/controllers/easy-genomics/laboratory/run/list-laboratory-runs.lambda.test.ts --runInBand
pnpm --prefix packages/front-end exec jest test/app/repository/modules/labs.test.ts --runInBand
- Regression: Other EGTable usages remain on client pagination unless pagination-mode="server" is set.

## Impact

- Performance: Smaller payloads and less work in the browser for large labs; Dynamo still does bounded reads per page in prod (not full-table fetch for the paginated path).
- API contract: Legacy callers that omit serverMode still receive the array response; the UI now uses the paginated object when serverMode=true.
- Behavior: No exact total page count; navigation is cursor-based (Previous/Next). Status polling still uses runs visible on the current page (acceptable per current product decision).
- Dev-only: Mock runs in dev/local can inflate list size for QA; prod behavior unchanged aside from the new server-mode endpoint usage from the UI.

## Additional Information

- Sortable columns on the Runs table are limited to what the backend supports (CreatedAt / ModifiedAt via LSIs); other columns are not server-sorted in this iteration.
- Search in server mode is intentionally `status`-only via structured query; use “My runs only” for user-scoped filtering (UserId).
- If we want component tests for EGTable server mode or EGLabView, we can add them in a follow-up (would likely need Vue test utils / similar).

## Screenshots


https://github.com/user-attachments/assets/0d26a212-d2c2-40c5-b415-3476401ce26f



## Checklist*
- [ ] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [ ] Code adheres to the coding and style guidelines of the project.
- [ ] Code has been commented in particularly hard-to-understand areas.