### PR TITLE
chore: Include untested backend files in lcov coverage report

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -303,6 +303,7 @@ const backEndApp = new awscdk.AwsCdkTypeScriptApp({
         '^@SharedLib/(.*)$': '<rootDir>/../shared-lib/src/app/$1',
         '^@FE/(.*)$': '<rootDir>/../front-end/src/app/$1',
       },
+      collectCoverageFrom: ['<rootDir>/src/app/**/*.ts', '!<rootDir>/src/app/**/*.d.ts'],
     },
   },
   lambdaAutoDiscover: false,

--- a/packages/back-end/package.json
+++ b/packages/back-end/package.json
@@ -101,6 +101,10 @@
       "^@SharedLib/(.*)$": "<rootDir>/../shared-lib/src/app/$1",
       "^@FE/(.*)$": "<rootDir>/../front-end/src/app/$1"
     },
+    "collectCoverageFrom": [
+      "<rootDir>/src/app/**/*.ts",
+      "!<rootDir>/src/app/**/*.d.ts"
+    ],
     "testMatch": [
       "<rootDir>/@(src|test)/**/*(*.)@(spec|test).ts?(x)",
       "<rootDir>/@(src|test)/**/__tests__/**/*.ts?(x)"


### PR DESCRIPTION
## Title*
chore: Include untested backend files in lcov coverage report

## Type of Change*
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Configure backend Jest (`collectCoverageFrom` via Projen) so the `lcov` report includes all `.ts` files under `src/app`, including files with no tests (shown as 0% coverage). This makes gaps visible for planning test coverage work.

Related: [EGV-106](https://dept-au.atlassian.net/browse/EGV-106)

## Testing*
Ran `pnpm test` in `packages/back-end` and verified `coverage/lcov.info` / HTML report list files with zero hits where appropriate.

## Impact
Coverage reporting only; no runtime behaviour change and no new dependencies.

## Additional Information
None.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully (no new tests required for this config-only change).
- [ ] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [ ] Code has been commented in particularly hard-to-understand areas.