### PR TITLE
fix: added correct policy to add tags to workflow run on creation

### DIFF
--- a/packages/back-end/src/infra/stacks/aws-healthomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/aws-healthomics-nested-stack.ts
@@ -400,7 +400,7 @@ export class AwsHealthOmicsNestedStack extends NestedStack {
           `arn:aws:omics:${this.props.env.region!}:${this.props.env.account!}:run/*`,
           `arn:aws:omics:${this.props.env.region!}:${this.props.env.account!}:workflow/*`,
         ],
-        actions: ['omics:StartRun'],
+        actions: ['omics:StartRun', 'omics:TagResource'],
         effect: Effect.ALLOW,
       }),
       new PolicyStatement({


### PR DESCRIPTION
## fix: added correct policy to add tags to workflow run on creation

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Added policy to allow for tagging health omics workflow on creation.

## Testing*
Tested manually on development, verified that policy worked correctly.

## Impact
This fixes current implementation, no impact on existing features.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.