### PR TITLE
fix: add sts:TagSession to IAM policy

### DIFF
--- a/packages/back-end/src/infra/stacks/aws-healthomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/aws-healthomics-nested-stack.ts
@@ -338,7 +338,7 @@ export class AwsHealthOmicsNestedStack extends NestedStack {
         resources: [
           `arn:aws:iam::${this.props.env.account!}:role/${this.props.namePrefix}-easy-genomics-omics-access-role`,
         ],
-        actions: ['sts:AssumeRole'],
+        actions: ['sts:AssumeRole', 'sts:TagSession'],
         effect: Effect.ALLOW,
       }),
     ]);
@@ -360,7 +360,7 @@ export class AwsHealthOmicsNestedStack extends NestedStack {
         resources: [
           `arn:aws:iam::${this.props.env.account!}:role/${this.props.namePrefix}-easy-genomics-omics-access-role`,
         ],
-        actions: ['sts:AssumeRole'],
+        actions: ['sts:AssumeRole', 'sts:TagSession'],
         effect: Effect.ALLOW,
       }),
     ]);
@@ -382,7 +382,7 @@ export class AwsHealthOmicsNestedStack extends NestedStack {
         resources: [
           `arn:aws:iam::${this.props.env.account!}:role/${this.props.namePrefix}-easy-genomics-omics-access-role`,
         ],
-        actions: ['sts:AssumeRole'],
+        actions: ['sts:AssumeRole', 'sts:TagSession'],
         effect: Effect.ALLOW,
       }),
     ]);
@@ -414,7 +414,7 @@ export class AwsHealthOmicsNestedStack extends NestedStack {
         resources: [
           `arn:aws:iam::${this.props.env.account!}:role/${this.props.namePrefix}-easy-genomics-omics-access-role`,
         ],
-        actions: ['sts:AssumeRole'],
+        actions: ['sts:AssumeRole', 'sts:TagSession'],
         effect: Effect.ALLOW,
       }),
     ]);


### PR DESCRIPTION
## Fix Browser Console Error Re: TagSession IAM Policy

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
The app was throwing an error in the browser (`Error retrieving Omics runs`). This was due to the new lab-scoped omics access controls that use AWS STS to tag a user's session with their orgId and labId, and tag their workflow runs with the same metadata. The `sts:AssumeRole` permission had been granted to the AWS account used by the API, but `sts:TagSession` had not been granted.

## Testing*
Deployed the IAM changes, ran locally and did not see the error anymore.

## Impact
This should fix any remaining issues with the lab-scoped access controls work.

## Additional Information
N/A

## Checklist*
- [ ] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [ ] Code adheres to the coding and style guidelines of the project.
- [ ] Code has been commented in particularly hard-to-understand areas.