### PR TITLE
fix: workflow run default parameters only saved if checkbox is checked

### DIFF
--- a/packages/front-end/src/app/components/EGRunWorkflowFormEditParameters.vue
+++ b/packages/front-end/src/app/components/EGRunWorkflowFormEditParameters.vue
@@ -9,9 +9,10 @@
     workflowId: string;
     omicsRunTempId: string;
     nfSchema?: object | null;
+    hasSavedDefaults: boolean;
   }>();
 
-  const emit = defineEmits(['next-step', 'previous-step', 'step-validated']);
+  const emit = defineEmits(['next-step', 'previous-step', 'step-validated', 'defaults-cleared']);
 
   const runStore = useRunStore();
   const labsStore = useLabsStore();
@@ -106,7 +107,8 @@
     },
   });
 
-  const shouldSaveAsDefaults = ref(false);
+  const shouldSaveAsDefaults = ref(props.hasSavedDefaults);
+  let paramsReady = false;
 
   // Auto-populate runname/run_name parameter with the run name from Run Details
   function autoPopulateRunName() {
@@ -121,8 +123,12 @@
     }
   }
 
+  // Auto-populate when component mounts, then enable param change detection
   onMounted(() => {
     autoPopulateRunName();
+    nextTick(() => {
+      paramsReady = true;
+    });
   });
 
   watch(
@@ -170,6 +176,28 @@
     }
   }
 
+  async function clearDefaultsForWorkflow() {
+    try {
+      const { $api } = useNuxtApp();
+      const userStore = useUserStore();
+      const userId = userStore.currentUserDetails.id;
+      if (!userId) return false;
+
+      const user = await $api.users.getUser();
+      const existingDefaults = user.OmicsWorkflowDefaultParams || {};
+      const { [props.workflowId]: _, ...remainingDefaults } = existingDefaults;
+
+      await $api.users.updateUser(userId, {
+        OmicsWorkflowDefaultParams: remainingDefaults,
+      });
+      emit('defaults-cleared');
+      return true;
+    } catch (error) {
+      console.error('Failed to clear workflow defaults', error);
+      return false;
+    }
+  }
+
   async function onSubmit() {
     const paramsRequired = wipOmicsRun.value?.paramsRequired || [];
     const missingParams = paramsRequired.filter((paramName: string) => !wipOmicsRun.value?.params[paramName]);
@@ -190,6 +218,11 @@
           if (success) {
             useToastStore().success('Saved defaults for this workflow.');
           }
+        } else if (props.hasSavedDefaults) {
+          const cleared = await clearDefaultsForWorkflow();
+          if (cleared) {
+            useToastStore().success('Cleared saved defaults for this workflow.');
+          }
         }
         emit('next-step');
       } catch (error) {
@@ -203,6 +236,9 @@
     () => localProps.params,
     (val) => {
       if (val) runStore.updateWipOmicsRunParams(props.omicsRunTempId, val);
+      if (paramsReady) {
+        shouldSaveAsDefaults.value = false;
+      }
     },
     { deep: true },
   );

--- a/packages/front-end/src/app/pages/labs/[labId]/run-workflow/[workflowId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/run-workflow/[workflowId].vue
@@ -32,6 +32,7 @@
   const hasLaunched = ref<boolean>(false);
   const exitConfirmed = ref<boolean>(false);
   const nextRoute = ref<string | null>(null);
+  const hasSavedDefaults = ref<boolean>(false);
 
   const selectedStepIndex = ref(0);
   const steps = ref([
@@ -179,6 +180,8 @@
         ),
       );
     }
+
+    hasSavedDefaults.value = Object.keys(workflowDefaultParams).length > 0;
 
     // initialize wip run in store
     runStore.updateWipOmicsRun(omicsRunTempId.value, {
@@ -362,8 +365,10 @@
               :lab-id="labId"
               :workflow-id="workflowId"
               :omics-run-temp-id="omicsRunTempId"
+              :has-saved-defaults="hasSavedDefaults"
               @next-step="() => nextStep('review')"
               @previous-step="() => previousStep()"
+              @defaults-cleared="hasSavedDefaults = false"
             />
           </template>
 


### PR DESCRIPTION
## fix: workflow run default parameters only saved if checkbox is checked

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Made change after feedback from QA and product teams to remove saved values if checkbox is unchecked, and show it checked if the values are the same as the ones saved on the DB.

## Testing*
Tested manually on local.

## Impact
This improves the default values feature.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.