### PR TITLE
fix: number fields to allow for version like numbers

### DIFF
--- a/packages/front-end/src/app/components/EGRunWorkflowFormEditParameters.vue
+++ b/packages/front-end/src/app/components/EGRunWorkflowFormEditParameters.vue
@@ -125,6 +125,11 @@
   const shouldSaveAsDefaults = ref(false);
   const fieldErrors = reactive<Record<string, string>>({});
 
+  function isVersionLike(value: unknown): boolean {
+    if (typeof value !== 'string') return false;
+    return /^\d+(?:\.\d+)+$/.test(value.trim());
+  }
+
   function validateField(field: SchemaItem, value: any): string | null {
     const isEmpty = value === '' || value === undefined || value === null;
 
@@ -137,12 +142,14 @@
     }
 
     if (field.type === 'integer') {
-      if (!Number.isInteger(Number(value)) || isNaN(Number(value))) {
-        return 'Must be a whole number';
+      const supportsVersionLikeValue = isVersionLike(value);
+      if (!supportsVersionLikeValue && (!Number.isInteger(Number(value)) || isNaN(Number(value)))) {
+        return 'Must be a whole number or version (e.g. 5.3.7)';
       }
     } else if (field.type === 'number') {
-      if (isNaN(Number(value))) {
-        return 'Must be a valid number';
+      const supportsVersionLikeValue = isVersionLike(value);
+      if (!supportsVersionLikeValue && isNaN(Number(value))) {
+        return 'Must be a valid number or version (e.g. 5.3.7)';
       }
     }
 
@@ -392,13 +399,12 @@
               :model-value="!!localProps.params[schemaField.name]"
               @update:model-value="(val) => (localProps.params[schemaField.name] = val)"
             />
-            <!-- Integer / number: numeric input -->
-            <EGParametersNumberField
+            <!-- Integer / number: text input to support dotted versions like 5.3.7 -->
+            <EGParametersStringField
               v-else-if="schemaField.type === 'integer' || schemaField.type === 'number'"
               :description="schemaField.description"
               :help-text="schemaField.helpText"
-              :model-value="Number(localProps.params[schemaField.name]) || 0"
-              @update:model-value="(val) => (localProps.params[schemaField.name] = val)"
+              v-model="localProps.params[schemaField.name]"
             />
             <!-- Enum: searchable select -->
             <EGParametersSelectField


### PR DESCRIPTION
## fix: number fields to allow for version like numbers

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Fixed parameters types inputs for health omics workflows to allow for version like numbers and not only natural numbers in the fields of type number.

## Testing*
Tested manually on local environment.

## Impact
This impacts workflow run parameters form.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.