### PR TITLE
fix: clear saved parameters when user unchecks field

### DIFF
--- a/packages/front-end/src/app/components/EGRunWorkflowFormEditParameters.vue
+++ b/packages/front-end/src/app/components/EGRunWorkflowFormEditParameters.vue
@@ -122,7 +122,8 @@
     },
   });
 
-  const shouldSaveAsDefaults = ref(false);
+  const shouldSaveAsDefaults = ref(props.hasSavedDefaults);
+  let paramsReady = false;
   const fieldErrors = reactive<Record<string, string>>({});
 
   function isVersionLike(value: unknown): boolean {
@@ -333,6 +334,11 @@
         if (success) {
           useToastStore().success('Saved defaults for this workflow.');
         }
+      } else if (props.hasSavedDefaults) {
+        const cleared = await clearDefaultsForWorkflow();
+        if (cleared) {
+          useToastStore().success('Cleared saved defaults for this workflow.');
+        }
       }
       emit('next-step');
     } catch (error) {
@@ -345,6 +351,10 @@
     () => localProps.params,
     (val) => {
       if (val) runStore.updateWipOmicsRunParams(props.omicsRunTempId, val);
+
+      if (paramsReady) {
+        shouldSaveAsDefaults.value = false;
+      }
 
       // Re-validate fields that already have errors so they clear when fixed
       for (const fieldName of Object.keys(fieldErrors)) {


### PR DESCRIPTION
## fix: clear saved parameters when user unchecks field

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Added change to remove saved parameters for a workflow when the user unchecks the field. This change is re adding functionality overwritten by default parameters from github functionality.

## Testing*
Tested manually on local environment.

## Impact
This impacts parameters form for health omics workflows.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.