### PR TITLE
fix: duplicated record for workflow run in dynamo table

### DIFF
--- a/packages/back-end/src/app/controllers/aws-healthomics/run/create-run-execution.lambda.ts
+++ b/packages/back-end/src/app/controllers/aws-healthomics/run/create-run-execution.lambda.ts
@@ -10,8 +10,6 @@ import {
 import { CreateRunRequest } from '@easy-genomics/shared-lib/src/app/types/aws-healthomics/aws-healthomics-api';
 import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
 import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
-import { v4 as uuidv4 } from 'uuid';
-import { LaboratoryRunService } from '@BE/services/easy-genomics/laboratory-run-service';
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
 import { LaboratoryWorkflowAccessService } from '@BE/services/easy-genomics/laboratory-workflow-access-service';
 import { createOmicsServiceForLab } from '@BE/services/omics-lab-factory';
@@ -24,7 +22,6 @@ import { assertLaboratoryHasWorkflowAccess } from '@BE/utils/laboratory-workflow
 
 const laboratoryService = new LaboratoryService();
 const laboratoryWorkflowAccessService = new LaboratoryWorkflowAccessService();
-const laboratoryRunService = new LaboratoryRunService();
 
 /**
  * This POST /aws-healthomics/run/create-run-execution?laboratoryId={LaboratoryId}
@@ -119,32 +116,7 @@ export const handler: Handler = async (
       },
     });
 
-    // Create an internal run record keyed by UUID so the rest of Easy Genomics can list runs
-    // without calling HealthOmics ListRuns.
-    const now = new Date();
-    const internalRunId = uuidv4();
-    await laboratoryRunService.add({
-      LaboratoryId: laboratory.LaboratoryId,
-      RunId: internalRunId,
-      UserId: omicsUserId,
-      OrganizationId: laboratory.OrganizationId,
-      RunName: request.name ?? 'Omics run',
-      Platform: 'AWS HealthOmics',
-      Status: (response.status ?? 'PENDING').toString().toUpperCase(),
-      Owner: userEmail ?? 'unknown',
-      WorkflowName: request.workflowId,
-      WorkflowVersionName: workflowVersionName,
-      ExternalRunId: response.id,
-      Settings: JSON.stringify({ workflowId: request.workflowId, parameters }),
-      CreatedAt: now.toISOString(),
-      CreatedBy: omicsUserId,
-    });
-
-    const payload = {
-      ...response,
-      internalRunId,
-    };
-    return buildResponse(200, JSON.stringify(payload), event);
+    return buildResponse(200, JSON.stringify(response), event);
   } catch (err: any) {
     console.error(err);
     return buildErrorResponse(err, event);

--- a/packages/back-end/test/app/controllers/aws-healthomics/run/create-run-execution.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/aws-healthomics/run/create-run-execution.lambda.test.ts
@@ -1,17 +1,11 @@
 import { APIGatewayProxyWithCognitoAuthorizerEvent, Context } from 'aws-lambda';
 
 const mockListByLaboratoryId = jest.fn();
-const mockAddLaboratoryRun = jest.fn();
 
 jest.mock('../../../../../src/app/services/easy-genomics/laboratory-service');
 jest.mock('../../../../../src/app/services/easy-genomics/laboratory-workflow-access-service', () => ({
   LaboratoryWorkflowAccessService: jest.fn().mockImplementation(() => ({
     listByLaboratoryId: mockListByLaboratoryId,
-  })),
-}));
-jest.mock('../../../../../src/app/services/easy-genomics/laboratory-run-service', () => ({
-  LaboratoryRunService: jest.fn().mockImplementation(() => ({
-    add: mockAddLaboratoryRun,
   })),
 }));
 jest.mock('../../../../../src/app/services/omics-service');
@@ -123,9 +117,6 @@ describe('create-run-execution.lambda', () => {
       startRun: mockOmicsService.prototype.startRun,
     });
 
-    mockAddLaboratoryRun.mockReset();
-    mockAddLaboratoryRun.mockImplementation(async (run: any) => run);
-
     mockValidateOrgAdmin.mockReturnValue(true);
     mockValidateLabManager.mockReturnValue(false);
     mockValidateLabTechnician.mockReturnValue(false);
@@ -146,7 +137,8 @@ describe('create-run-execution.lambda', () => {
 
     expect(result.statusCode).toBe(200);
     const body = JSON.parse(result.body);
-    expect(body.internalRunId).toBeDefined();
+    expect(body.id).toBe('run-123');
+    expect(body.internalRunId).toBeUndefined();
     expect(mockOmicsService.prototype.startRun).toHaveBeenCalledTimes(1);
     const startRunInput = (mockOmicsService.prototype.startRun as jest.Mock).mock.calls[0][0];
 


### PR DESCRIPTION
## fix: duplicated record for workflow run in dynamo table

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Removed duplicated creation of dynamodb record for workflow run.

## Testing*
Updated unit tests

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.