### PR TITLE
fix: workflow status update not updating final status

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.ts
@@ -14,7 +14,7 @@ import { SQSEvent } from 'aws-lambda/trigger/sqs';
 //import { v4 as uuidv4 } from 'uuid';
 import { LaboratoryRunService } from '@BE/services/easy-genomics/laboratory-run-service';
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
-import { OmicsService } from '@BE/services/omics-service';
+import { createOmicsServiceForLab } from '@BE/services/omics-lab-factory';
 import { SsmService } from '@BE/services/ssm-service';
 import {
   calculateExpiresAtEpochSeconds,
@@ -28,7 +28,6 @@ import { getNextFlowApiQueryParameters, httpRequest, REST_API_METHOD } from '@BE
 const laboratoryService = new LaboratoryService();
 const laboratoryRunService = new LaboratoryRunService();
 const ssmService = new SsmService();
-const omicsService = new OmicsService();
 
 export const handler: Handler = async (event: SQSEvent): Promise<APIGatewayProxyResult> => {
   console.log('EVENT: \n' + JSON.stringify(event, null, 2));
@@ -133,6 +132,13 @@ export async function processStatusCheckEvent(operation: SnsProcessingOperation,
 
 export async function getAWSHealthOmicsStatus(laboratoryRun: LaboratoryRun): Promise<string> {
   console.log('Fetching AWS Health Omics status for run: ', laboratoryRun.RunId);
+
+  const omicsUserId = laboratoryRun.UserId || 'status-check';
+  const omicsService = await createOmicsServiceForLab(
+    laboratoryRun.LaboratoryId,
+    laboratoryRun.OrganizationId,
+    omicsUserId,
+  );
 
   const response = await omicsService.getRun(<GetRunCommandInput>{
     id: laboratoryRun.ExternalRunId,

--- a/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.test.ts
@@ -13,12 +13,12 @@ import {
 jest.mock('../../../../../../src/app/services/easy-genomics/laboratory-service');
 jest.mock('../../../../../../src/app/services/easy-genomics/laboratory-run-service');
 jest.mock('../../../../../../src/app/services/ssm-service');
-jest.mock('../../../../../../src/app/services/omics-service');
+jest.mock('../../../../../../src/app/services/omics-lab-factory');
 jest.mock('../../../../../../src/app/utils/rest-api-utils');
 
 import { LaboratoryRunService } from '../../../../../../src/app/services/easy-genomics/laboratory-run-service';
 import { LaboratoryService } from '../../../../../../src/app/services/easy-genomics/laboratory-service';
-import { OmicsService } from '../../../../../../src/app/services/omics-service';
+import { createOmicsServiceForLab } from '../../../../../../src/app/services/omics-lab-factory';
 import { SsmService } from '../../../../../../src/app/services/ssm-service';
 import { getNextFlowApiQueryParameters, httpRequest } from '../../../../../../src/app/utils/rest-api-utils';
 
@@ -26,7 +26,6 @@ describe('process-update-laboratory-run.lambda', () => {
   let mockLabService: jest.MockedClass<typeof LaboratoryService>;
   let mockRunService: jest.MockedClass<typeof LaboratoryRunService>;
   let mockSsmService: jest.MockedClass<typeof SsmService>;
-  let mockOmicsService: jest.MockedClass<typeof OmicsService>;
 
   let mockQueryByRunId: jest.Mock;
   let mockUpdateRun: jest.Mock;
@@ -62,7 +61,6 @@ describe('process-update-laboratory-run.lambda', () => {
     mockLabService = LaboratoryService as jest.MockedClass<typeof LaboratoryService>;
     mockRunService = LaboratoryRunService as jest.MockedClass<typeof LaboratoryRunService>;
     mockSsmService = SsmService as jest.MockedClass<typeof SsmService>;
-    mockOmicsService = OmicsService as jest.MockedClass<typeof OmicsService>;
 
     mockQueryByRunId = jest.fn();
     mockUpdateRun = jest.fn();
@@ -74,7 +72,7 @@ describe('process-update-laboratory-run.lambda', () => {
     mockRunService.prototype.update = mockUpdateRun;
     mockLabService.prototype.queryByLaboratoryId = mockQueryByLaboratoryId;
     mockSsmService.prototype.getParameter = mockGetParameter;
-    mockOmicsService.prototype.getRun = mockGetRun;
+    (createOmicsServiceForLab as jest.Mock).mockResolvedValue({ getRun: mockGetRun });
 
     mockQueryByLaboratoryId.mockResolvedValue({
       LaboratoryId: 'lab-1',
@@ -118,7 +116,8 @@ describe('process-update-laboratory-run.lambda', () => {
     const result = await handler(event, createContext(), () => {});
 
     expect(result.statusCode).toBe(200);
-    expect(mockOmicsService.prototype.getRun).toHaveBeenCalledWith(<GetRunCommandInput>{ id: 'ext-1' });
+    expect(createOmicsServiceForLab as jest.Mock).toHaveBeenCalledWith('lab-1', 'org-1', 'status-check');
+    expect(mockGetRun).toHaveBeenCalledWith(<GetRunCommandInput>{ id: 'ext-1' });
     expect(mockRunService.prototype.update).toHaveBeenCalled();
   });
 
@@ -145,7 +144,7 @@ describe('process-update-laboratory-run.lambda', () => {
     const result = await handler(event, createContext(), () => {});
 
     expect(result.statusCode).toBe(200);
-    expect(mockOmicsService.prototype.getRun).not.toHaveBeenCalled();
+    expect(mockGetRun).not.toHaveBeenCalled();
     expect(mockRunService.prototype.update).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## fix: workflow status update not updating final status

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Updated the run status polling lambda to use lab-scoped STS credentials (createOmicsServiceForLab) when calling HealthOmics GetRun, so terminal statuses (COMPLETED/FAILED) can be fetched and persisted correctly under tag-based access controls; updated tests accordingly.

## Testing*
Updated unit tests and tested locally.

## Impact
Impacts workflow runs statuses.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.