### PR TITLE
fix: dashboard overview summary filtered by modified date instead of creation

### DIFF
--- a/packages/front-end/src/app/components/EGDashboard.vue
+++ b/packages/front-end/src/app/components/EGDashboard.vue
@@ -138,8 +138,8 @@
     const days = parseInt(overviewTimeFilter.value);
     const cutoff = now - days * 24 * 60 * 60 * 1000;
     return allRuns.value.filter((run) => {
-      const createdAt = run.CreatedAt ? new Date(run.CreatedAt).getTime() : 0;
-      return createdAt >= cutoff;
+      const modifiedAt = run.ModifiedAt ? new Date(run.ModifiedAt).getTime() : 0;
+      return modifiedAt >= cutoff;
     });
   });
 


### PR DESCRIPTION
## fix: dashboard overview summary filtered by modified date instead of creation

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
To be consistent with the recent runs table we are changing the dashboard overview filter to show summary based on modified at date instead of created at date.

## Testing*
Tested manually on local environment.

## Impact
This impacts the dashboard summary only.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.