### PR TITLE
fix: organization written in british english in some places

### DIFF
--- a/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
@@ -288,7 +288,7 @@ export class EasyGenomicsNestedStack extends NestedStack {
       [
         {
           id: 'AwsSolutions-IAM5',
-          reason: 'Need access to all organisation and laboratory nf token parameters',
+          reason: 'Need access to all organization and laboratory nf token parameters',
           appliesTo: [
             `Resource::arn:aws:ssm:${this.props.env.region!}:${this.props.env.account!}:parameter/easy-genomics/organization/*/laboratory/*/nf-access-token`,
           ], // optional

--- a/packages/back-end/src/infra/stacks/nf-tower-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/nf-tower-nested-stack.ts
@@ -44,7 +44,7 @@ export class NFTowerNestedStack extends NestedStack {
       [
         {
           id: 'AwsSolutions-IAM5',
-          reason: 'Need access to all organisation and laboratory nf token parameters',
+          reason: 'Need access to all organization and laboratory nf token parameters',
           appliesTo: [
             `Resource::arn:aws:ssm:${this.props.env.region!}:${this.props.env.account!}:parameter/easy-genomics/organization/*/laboratory/*/nf-access-token`,
           ], // optional

--- a/packages/front-end/src/app/components/EGDashboard.vue
+++ b/packages/front-end/src/app/components/EGDashboard.vue
@@ -441,7 +441,7 @@
       <div>
         <button class="text-primary mb-2 flex items-center gap-1 text-sm font-medium" @click="navigateBack">
           <UIcon name="i-heroicons-arrow-left" class="h-4 w-4" />
-          Back to organisation
+          Back to organization
         </button>
         <EGText tag="h1" class="mb-0">Laboratory of {{ labName }}</EGText>
       </div>


### PR DESCRIPTION
## fix: organization written in british english in some places

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Fixed typo in organization strings written in British english instead of American.

## Testing*
Tested manually on local environment.

## Impact
This only changes string in a few places, no functional change.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.