### PR TITLE
fix: cicd unit test failures re: shared lib imports

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -326,6 +326,10 @@ const backEndApp = new awscdk.AwsCdkTypeScriptApp({
         '@BE/*': ['src/app/*'],
         '@FE/*': ['../packages/front-end/src/app/*'],
         '@SharedLib/*': ['../packages/shared-lib/src/app/*'],
+        // Some packages import shared-lib via its compiled output path.
+        // During tests/ts-jest compilation in a workspace, `lib/` may not exist yet,
+        // so we map those deep imports to the source tree.
+        '@easy-genomics/shared-lib/lib/app/*': ['../packages/shared-lib/src/app/*'],
       },
     },
   },

--- a/packages/back-end/tsconfig.dev.json
+++ b/packages/back-end/tsconfig.dev.json
@@ -34,6 +34,9 @@
       ],
       "@SharedLib/*": [
         "../packages/shared-lib/src/app/*"
+      ],
+      "@easy-genomics/shared-lib/lib/app/*": [
+        "../packages/shared-lib/src/app/*"
       ]
     }
   },

--- a/packages/back-end/tsconfig.json
+++ b/packages/back-end/tsconfig.json
@@ -36,6 +36,9 @@
       ],
       "@SharedLib/*": [
         "../packages/shared-lib/src/app/*"
+      ],
+      "@easy-genomics/shared-lib/lib/app/*": [
+        "../packages/shared-lib/src/app/*"
       ]
     }
   },


### PR DESCRIPTION
## Fix Unit Tests During CICD - Shared Lib Import Errors

## Type of Change*
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
CICD kept failing because some shared-lib type imports were not found while back-end unit tests were running. This was because the shared-lib had not yet been built and the back-end unit tests were expecting that shared-lib compiled folder to be available. This has been fixed with a small addition to the `paths` tsconfig array for the entire project that points those imports to the shared-lib source tree.

## Testing*
N/A

## Impact
Fix CICD builds

## Additional Information
N/A

## Checklist*
- [ ] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [ ] Code adheres to the coding and style guidelines of the project.
- [ ] Code has been commented in particularly hard-to-understand areas.