### PR TITLE
feat: Data Tagging - Sample batch assignment

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/data-collections/edit-batch.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/data-collections/edit-batch.lambda.ts
@@ -1,6 +1,6 @@
 import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/lib/app/utils/common';
 import { InvalidRequestError, UnauthorizedAccessError } from '@easy-genomics/shared-lib/lib/app/utils/HttpError';
-import { CreateLaboratoryDataTagSchema } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/data-collections/create-tag';
+import { AssignBatchSchema } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/data-collections/assign-batch';
 import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
 import { LaboratoryDataTaggingService } from '@BE/services/easy-genomics/laboratory-data-tagging-service';
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
@@ -19,7 +19,7 @@ export const handler: Handler = async (
   console.log('EVENT: \n' + JSON.stringify(event, null, 2));
   try {
     const body = event.isBase64Encoded ? JSON.parse(atob(event.body!)) : JSON.parse(event.body!);
-    if (!CreateLaboratoryDataTagSchema.safeParse(body).success) {
+    if (!AssignBatchSchema.safeParse(body).success) {
       throw new InvalidRequestError();
     }
 
@@ -35,13 +35,36 @@ export const handler: Handler = async (
     }
 
     const userId: string = event.requestContext.authorizer.claims['cognito:username'];
-    const kind = body.Kind ?? 'standard';
-    const tag = await taggingService.createTag(laboratory, userId, body.Name, body.ColorHex, kind);
-    return buildResponse(200, JSON.stringify(tag), event);
+    taggingService.assertBucketMatchesLab(laboratory, body.S3Bucket);
+    for (const key of body.Keys) {
+      taggingService.assertKeyUnderLabPrefix(laboratory, key);
+    }
+
+    if (body.ClearBatch) {
+      await taggingService.setBatchForFiles(laboratory, userId, body.S3Bucket, body.Keys, { type: 'clear' });
+    } else if (body.BatchTagId) {
+      await taggingService.setBatchForFiles(laboratory, userId, body.S3Bucket, body.Keys, {
+        type: 'existing',
+        batchTagId: body.BatchTagId,
+      });
+    } else if (body.NewBatchName) {
+      await taggingService.setBatchForFiles(laboratory, userId, body.S3Bucket, body.Keys, {
+        type: 'new',
+        name: body.NewBatchName.trim(),
+      });
+    }
+
+    return buildResponse(200, JSON.stringify({ ok: true }), event);
   } catch (err: any) {
     console.error(err);
     if (err instanceof InvalidRequestError || err instanceof UnauthorizedAccessError) {
       return buildErrorResponse(err, event);
+    }
+    if (typeof err?.message === 'string' && err.message.includes('not a batch')) {
+      return buildResponse(400, JSON.stringify({ message: err.message }), event);
+    }
+    if (typeof err?.message === 'string' && err.message.startsWith('Unknown batch')) {
+      return buildResponse(404, JSON.stringify({ message: err.message }), event);
     }
     if (err?.message === 'A tag with this name already exists') {
       return buildResponse(409, JSON.stringify({ message: err.message }), event);

--- a/packages/back-end/src/app/services/easy-genomics/laboratory-data-tagging-service.ts
+++ b/packages/back-end/src/app/services/easy-genomics/laboratory-data-tagging-service.ts
@@ -4,6 +4,7 @@ import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
 import {
   FileTagAssignment,
   LaboratoryDataTag,
+  LaboratoryDataTagKind,
   ListFilesByTagResponse,
   ListLaboratoryDataTagsResponse,
   S3TaggedObjectRef,
@@ -69,10 +70,12 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
 
     const tags: LaboratoryDataTag[] = (response.Items || []).map((item) => {
       const row = unmarshall(item) as Record<string, unknown>;
+      const kind: LaboratoryDataTagKind = row.Kind === 'batch' ? 'batch' : 'standard';
       return {
         TagId: row.TagId as string,
         Name: row.Name as string,
         ColorHex: row.ColorHex as string,
+        ...(kind === 'batch' ? { Kind: 'batch' as const } : {}),
         FileCount: Number(row.FileCount ?? 0),
         CreatedAt: row.CreatedAt as string | undefined,
         CreatedBy: row.CreatedBy as string | undefined,
@@ -89,6 +92,7 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
     userId: string,
     name: string,
     colorHex: string,
+    kind: LaboratoryDataTagKind = 'standard',
   ): Promise<LaboratoryDataTag> {
     const laboratoryId = laboratory.LaboratoryId;
     const existing = await this.listTags(laboratoryId);
@@ -105,6 +109,7 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
       TagId: tagId,
       Name: name.trim(),
       ColorHex: colorHex,
+      ...(kind === 'batch' ? { Kind: 'batch' as const } : {}),
       FileCount: 0,
       CreatedAt: now,
       CreatedBy: userId,
@@ -126,6 +131,7 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
       TagId: tagId,
       Name: name.trim(),
       ColorHex: colorHex,
+      ...(kind === 'batch' ? { Kind: 'batch' as const } : {}),
       FileCount: 0,
       CreatedAt: now,
       CreatedBy: userId,
@@ -175,6 +181,7 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
           TagId: tagId,
           Name: updated.Name,
           ColorHex: updated.ColorHex,
+          ...(existingRow.Kind === 'batch' ? { Kind: 'batch' as const } : {}),
           FileCount: updated.FileCount,
           CreatedAt: existingRow.CreatedAt,
           CreatedBy: existingRow.CreatedBy,
@@ -268,6 +275,7 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
 
   public async listFileTags(laboratoryId: string, bucket: string, keys: string[]): Promise<FileTagAssignment[]> {
     const out: FileTagAssignment[] = [];
+    const batchTagIds = await this.getBatchTagIdSet(laboratoryId);
 
     for (let i = 0; i < keys.length; i += 100) {
       const batchKeys = keys.slice(i, i + 100);
@@ -294,7 +302,17 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
       for (let j = 0; j < batchKeys.length; j++) {
         const key = batchKeys[j];
         const sk = dynamoKeys[j].Sk;
-        out.push({ Key: key, TagIds: bySk.get(sk) || [] });
+        const rawIds = bySk.get(sk) || [];
+        const standard: string[] = [];
+        let batchTagId: string | undefined;
+        for (const id of rawIds) {
+          if (batchTagIds.has(id)) {
+            batchTagId = id;
+          } else {
+            standard.push(id);
+          }
+        }
+        out.push({ Key: key, TagIds: standard, ...(batchTagId ? { BatchTagId: batchTagId } : {}) });
       }
     }
 
@@ -346,6 +364,12 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
     const add = addTagIds || [];
     const remove = removeTagIds || [];
 
+    const batchTagIds = await this.getBatchTagIdSet(laboratoryId);
+    const batchAdds = add.filter((id) => batchTagIds.has(id));
+    if (batchAdds.length > 1) {
+      throw new Error('Cannot add more than one batch tag at a time');
+    }
+
     for (const tagId of add) {
       const t = await this.getTagRow(laboratoryId, tagId);
       if (!t) throw new Error(`Unknown tag: ${tagId}`);
@@ -365,6 +389,16 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
         if (tagIds.delete(rid)) {
           await this.deleteMapIfExists(laboratoryId, rid, ref);
           await this.adjustTagFileCount(laboratoryId, rid, -1);
+        }
+      }
+
+      if (batchAdds.length === 1) {
+        for (const bid of [...tagIds]) {
+          if (batchTagIds.has(bid)) {
+            tagIds.delete(bid);
+            await this.deleteMapIfExists(laboratoryId, bid, ref);
+            await this.adjustTagFileCount(laboratoryId, bid, -1);
+          }
         }
       }
 
@@ -402,6 +436,87 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
         });
       }
     }
+  }
+
+  /**
+   * Sets batch assignment for files: at most one batch per file. Does not modify standard tags.
+   */
+  public async setBatchForFiles(
+    laboratory: Laboratory,
+    userId: string,
+    bucket: string,
+    keys: string[],
+    mode: { type: 'clear' } | { type: 'existing'; batchTagId: string } | { type: 'new'; name: string },
+  ): Promise<void> {
+    const laboratoryId = laboratory.LaboratoryId;
+    this.assertBucketMatchesLab(laboratory, bucket);
+
+    let targetBatchId: string | undefined;
+    if (mode.type === 'new') {
+      const created = await this.createTag(laboratory, userId, mode.name, '#5B4FD4', 'batch');
+      targetBatchId = created.TagId;
+    } else if (mode.type === 'existing') {
+      const row = await this.getTagRow(laboratoryId, mode.batchTagId);
+      if (!row) throw new Error(`Unknown batch: ${mode.batchTagId}`);
+      if ((row.Kind ?? 'standard') !== 'batch') throw new Error('Tag is not a batch');
+      targetBatchId = mode.batchTagId;
+    }
+
+    const batchTagIds = await this.getBatchTagIdSet(laboratoryId);
+
+    for (const key of keys) {
+      this.assertKeyUnderLabPrefix(laboratory, key);
+      const ref = encodeS3ObjectRef(bucket, key);
+      const existing = await this.getFileRow(laboratoryId, ref);
+      const tagIds = new Set<string>(existing?.TagIds || []);
+
+      for (const bid of [...tagIds]) {
+        if (batchTagIds.has(bid)) {
+          tagIds.delete(bid);
+          await this.deleteMapIfExists(laboratoryId, bid, ref);
+          await this.adjustTagFileCount(laboratoryId, bid, -1);
+        }
+      }
+
+      if (targetBatchId) {
+        if (!tagIds.has(targetBatchId)) {
+          tagIds.add(targetBatchId);
+          await this.putMapRow(laboratoryId, targetBatchId, ref, bucket, key);
+          await this.adjustTagFileCount(laboratoryId, targetBatchId, 1);
+        }
+      }
+
+      const now = new Date().toISOString();
+      if (tagIds.size === 0) {
+        if (existing) {
+          await this.deleteItem({
+            TableName: TABLE_NAME,
+            Key: marshall({ LaboratoryId: laboratoryId, Sk: skFile(ref) }),
+          });
+        }
+      } else {
+        await this.putItem({
+          TableName: TABLE_NAME,
+          Item: marshall(
+            {
+              LaboratoryId: laboratoryId,
+              Sk: skFile(ref),
+              S3Bucket: bucket,
+              ObjectKey: key,
+              TagIds: [...tagIds],
+              ModifiedAt: now,
+              ModifiedBy: userId,
+            },
+            { removeUndefinedValues: true },
+          ),
+        });
+      }
+    }
+  }
+
+  private async getBatchTagIdSet(laboratoryId: string): Promise<Set<string>> {
+    const { Tags } = await this.listTags(laboratoryId);
+    return new Set(Tags.filter((t) => (t.Kind ?? 'standard') === 'batch').map((t) => t.TagId));
   }
 
   private async putMapRow(
@@ -450,6 +565,7 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
           TagId: row.TagId,
           Name: row.Name,
           ColorHex: row.ColorHex,
+          ...(row.Kind === 'batch' ? { Kind: 'batch' as const } : {}),
           FileCount: next,
           CreatedAt: row.CreatedAt,
           CreatedBy: row.CreatedBy,
@@ -472,6 +588,7 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
       TagId: row.TagId as string,
       Name: row.Name as string,
       ColorHex: row.ColorHex as string,
+      ...(row.Kind === 'batch' ? { Kind: 'batch' as const } : {}),
       FileCount: Number(row.FileCount ?? 0),
       CreatedAt: row.CreatedAt as string | undefined,
       CreatedBy: row.CreatedBy as string | undefined,

--- a/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
@@ -1630,6 +1630,15 @@ export class EasyGenomicsNestedStack extends NestedStack {
       }),
     ]);
 
+    // /easy-genomics/data-collections/edit-batch
+    this.iam.addPolicyStatements('/easy-genomics/data-collections/edit-batch', [
+      ...laboratoryReadForDataCollections,
+      new PolicyStatement({
+        resources: laboratoryDataTaggingDynamoResources,
+        actions: laboratoryDataTaggingDynamoActions,
+      }),
+    ]);
+
     // /easy-genomics/data-collections/list-files-by-tag
     this.iam.addPolicyStatements('/easy-genomics/data-collections/list-files-by-tag', [
       ...laboratoryReadForDataCollections,

--- a/packages/back-end/test/app/services/easy-genomics/laboratory-data-tagging-service.test.ts
+++ b/packages/back-end/test/app/services/easy-genomics/laboratory-data-tagging-service.test.ts
@@ -52,6 +52,7 @@ describe('LaboratoryDataTaggingService.applyTagsToFiles', () => {
   let mockGetItem: jest.Mock;
   let mockPutItem: jest.Mock;
   let mockDeleteItem: jest.Mock;
+  let mockQueryItems: jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -59,9 +60,11 @@ describe('LaboratoryDataTaggingService.applyTagsToFiles', () => {
     mockGetItem = jest.fn();
     mockPutItem = jest.fn().mockResolvedValue({});
     mockDeleteItem = jest.fn().mockResolvedValue({});
+    mockQueryItems = jest.fn().mockResolvedValue({ Items: [] });
     (svc as unknown as { getItem: typeof mockGetItem }).getItem = mockGetItem;
     (svc as unknown as { putItem: typeof mockPutItem }).putItem = mockPutItem;
     (svc as unknown as { deleteItem: typeof mockDeleteItem }).deleteItem = mockDeleteItem;
+    (svc as unknown as { queryItems: typeof mockQueryItems }).queryItems = mockQueryItems;
   });
 
   it('does not create duplicate MAP rows when re-applying the same tag to a file', async () => {
@@ -157,5 +160,71 @@ describe('LaboratoryDataTaggingService.applyTagsToFiles', () => {
     expect(filePuts.length).toBeGreaterThanOrEqual(1);
     const fileRow = unmarshall(filePuts[0][0].Item) as { TagIds: string[] };
     expect(fileRow.TagIds).toContain(tagId);
+  });
+
+  it('rejects adding more than one batch tag in a single request', async () => {
+    const lab = labFixture();
+    const bucket = lab.S3Bucket!;
+    const key = 'org-1/lab-1/a.txt';
+    const b1 = 'batch-1';
+    const b2 = 'batch-2';
+
+    mockQueryItems.mockResolvedValue({
+      Items: [
+        marshall({
+          LaboratoryId: lab.LaboratoryId,
+          Sk: `TAG#${b1}`,
+          TagId: b1,
+          Name: 'B1',
+          ColorHex: '#111111',
+          Kind: 'batch',
+          FileCount: 0,
+        }),
+        marshall({
+          LaboratoryId: lab.LaboratoryId,
+          Sk: `TAG#${b2}`,
+          TagId: b2,
+          Name: 'B2',
+          ColorHex: '#222222',
+          Kind: 'batch',
+          FileCount: 0,
+        }),
+      ],
+    });
+
+    mockGetItem.mockImplementation(async (input: { Key?: Record<string, AttributeValue> }) => {
+      const k = unmarshall(input.Key as Record<string, AttributeValue>) as { Sk?: string };
+      if (k.Sk === `TAG#${b1}`) {
+        return {
+          Item: marshall({
+            LaboratoryId: lab.LaboratoryId,
+            Sk: k.Sk,
+            TagId: b1,
+            Name: 'B1',
+            ColorHex: '#111111',
+            Kind: 'batch',
+            FileCount: 0,
+          }),
+        };
+      }
+      if (k.Sk === `TAG#${b2}`) {
+        return {
+          Item: marshall({
+            LaboratoryId: lab.LaboratoryId,
+            Sk: k.Sk,
+            TagId: b2,
+            Name: 'B2',
+            ColorHex: '#222222',
+            Kind: 'batch',
+            FileCount: 0,
+          }),
+        };
+      }
+      return {};
+    });
+
+    await expect(svc.applyTagsToFiles(lab, 'user-1', bucket, [key], [b1, b2], [])).rejects.toThrow(
+      'Cannot add more than one batch tag at a time',
+    );
   });
 });

--- a/packages/front-end/src/app/components/EGDataCollectionsExplorer.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsExplorer.vue
@@ -132,6 +132,40 @@
     return tag?.Name ?? bid;
   }
 
+  function batchSectionHeading(sec: {
+    batchId: string | null;
+    title: string;
+    files: readonly { Key: string }[];
+  }): string {
+    const n = sec.files.length;
+    const samples = n === 1 ? 'sample' : 'samples';
+    if (sec.batchId === null) {
+      return `Unbatched · ${n} ${samples}`;
+    }
+    return `Batch ${sec.title} · ${n} ${samples}`;
+  }
+
+  function batchSectionFullySelected(sec: { files: readonly { Key: string }[] }): boolean {
+    if (!sec.files.length) return false;
+    return sec.files.every((f) => props.selectedKeys.includes(f.Key));
+  }
+
+  /** Selects all files in the section, or clears them from the selection if already fully selected. */
+  function toggleBatchSection(sec: { files: readonly { Key: string }[] }): void {
+    const keys = sec.files.map((f) => f.Key);
+    if (batchSectionFullySelected(sec)) {
+      const remove = new Set(keys);
+      emit(
+        'update:selectedKeys',
+        props.selectedKeys.filter((k: string) => !remove.has(k)),
+      );
+    } else {
+      const merged = new Set(props.selectedKeys);
+      keys.forEach((k) => merged.add(k));
+      emit('update:selectedKeys', [...merged]);
+    }
+  }
+
   function onScrollHostMouseDown(e: MouseEvent): void {
     const t = e.target as HTMLElement;
     if (t.closest('[data-file-card]')) return;
@@ -285,8 +319,20 @@
     <div ref="scrollEl" class="relative flex-1 overflow-auto p-4" @mousedown="onScrollHostMouseDown">
       <div v-if="explorerView === 'cards'" class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
         <template v-for="(sec, secIdx) in fileSections" :key="sec.batchId ?? 'unbatched'">
-          <div class="border-border-muted col-span-full border-b pb-2" :class="secIdx === 0 ? 'mt-0' : 'mt-6'">
-            <h3 class="text-muted text-xs font-semibold uppercase tracking-wide">{{ sec.title }}</h3>
+          <div
+            class="border-border-muted col-span-full flex items-start justify-between gap-3 border-b pb-2"
+            :class="secIdx === 0 ? 'mt-0' : 'mt-6'"
+          >
+            <h3 class="text-muted min-w-0 flex-1 text-xs font-normal leading-snug tracking-wide">
+              {{ batchSectionHeading(sec) }}
+            </h3>
+            <button
+              type="button"
+              class="text-primary shrink-0 text-xs font-normal hover:underline"
+              @click.stop="toggleBatchSection(sec)"
+            >
+              {{ batchSectionFullySelected(sec) ? 'Deselect batch' : 'Select batch' }}
+            </button>
           </div>
           <div
             v-for="f in sec.files"
@@ -345,12 +391,19 @@
           <tbody>
             <template v-for="sec in fileSections" :key="sec.batchId ?? 'unbatched'">
               <tr class="bg-gray-50/95">
-                <td
-                  colspan="6"
-                  class="border-border-muted border-b px-3 py-2 text-xs font-semibold uppercase tracking-wide text-gray-600"
-                  scope="colgroup"
-                >
-                  {{ sec.title }}
+                <td colspan="6" class="border-border-muted border-b px-3 py-2.5" scope="colgroup">
+                  <div class="flex items-center justify-between gap-4">
+                    <span class="text-muted min-w-0 flex-1 truncate text-xs font-normal leading-snug tracking-wide">
+                      {{ batchSectionHeading(sec) }}
+                    </span>
+                    <button
+                      type="button"
+                      class="text-primary shrink-0 text-xs font-normal hover:underline"
+                      @click.stop="toggleBatchSection(sec)"
+                    >
+                      {{ batchSectionFullySelected(sec) ? 'Deselect batch' : 'Select batch' }}
+                    </button>
+                  </div>
                 </td>
               </tr>
               <tr

--- a/packages/front-end/src/app/components/EGDataCollectionsExplorer.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsExplorer.vue
@@ -9,6 +9,9 @@
     labRoot: string;
     visibleFiles: { Key: string; Size?: number; LastModified?: string }[];
     keyToTagIds: Record<string, string[]>;
+    /** Batch tag id per file key (optional until parent loads assignments). */
+    keyToBatchTagId?: Record<string, string | undefined>;
+    batchTags?: LaboratoryDataTag[];
     tags: LaboratoryDataTag[];
     selectedKeys: string[];
     loading: boolean;
@@ -84,6 +87,50 @@
   const allFilesHiddenByFilters = computed(
     () => !props.loading && props.listingFileCount > 0 && props.visibleFiles.length === 0,
   );
+
+  const batchTagsResolved = computed(() => props.batchTags ?? []);
+
+  const keyToBatchResolved = computed(() => props.keyToBatchTagId ?? {});
+
+  /** Group visible files by batch for section headers (single scroll, not nested folders). */
+  const fileSections = computed(() => {
+    type Row = (typeof props.visibleFiles)[number];
+    const nameById = new Map<string, string>(
+      batchTagsResolved.value.map((t: LaboratoryDataTag) => [t.TagId, t.Name] as [string, string]),
+    );
+    const groups = new Map<string | null, Row[]>();
+    for (const f of props.visibleFiles) {
+      const bid = keyToBatchResolved.value[f.Key] ?? null;
+      if (!groups.has(bid)) groups.set(bid, []);
+      groups.get(bid)!.push(f);
+    }
+    const batchEntries = [...groups.entries()].filter(([k]) => k !== null) as [string, Row[]][];
+    batchEntries.sort((a, b) => {
+      const na = nameById.get(a[0]) ?? a[0];
+      const nb = nameById.get(b[0]) ?? b[0];
+      return na.localeCompare(nb);
+    });
+    const sections: { batchId: string | null; title: string; files: Row[] }[] = [];
+    const unbatched = groups.get(null);
+    if (unbatched?.length) {
+      sections.push({ batchId: null, title: 'Unbatched', files: unbatched });
+    }
+    for (const [bid, files] of batchEntries) {
+      sections.push({
+        batchId: bid,
+        title: nameById.get(bid) ?? bid,
+        files,
+      });
+    }
+    return sections;
+  });
+
+  function batchDisplayName(key: string): string {
+    const bid = keyToBatchResolved.value[key];
+    if (!bid) return '—';
+    const tag = batchTagsResolved.value.find((b: LaboratoryDataTag) => b.TagId === bid);
+    return tag?.Name ?? bid;
+  }
 
   function onScrollHostMouseDown(e: MouseEvent): void {
     const t = e.target as HTMLElement;
@@ -237,45 +284,50 @@
 
     <div ref="scrollEl" class="relative flex-1 overflow-auto p-4" @mousedown="onScrollHostMouseDown">
       <div v-if="explorerView === 'cards'" class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-        <div
-          v-for="f in visibleFiles"
-          :key="f.Key"
-          data-file-card
-          :data-key="f.Key"
-          draggable="true"
-          class="border-border-muted relative cursor-pointer rounded-xl border bg-white p-3 shadow-sm transition"
-          :class="{ 'ring-primary ring-2': selectedKeys.includes(f.Key) }"
-          @click="emit('toggleKey', f.Key)"
-          @dragstart="onCardDragStart($event, f.Key)"
-          @dragover="onCardDragOver"
-          @dragleave="onCardDragLeave"
-          @drop="onCardDrop($event)"
-        >
-          <div class="absolute right-2 top-2" @mousedown.stop @click.stop>
-            <UCheckbox :model-value="selectedKeys.includes(f.Key)" @update:model-value="emit('toggleKey', f.Key)" />
+        <template v-for="(sec, secIdx) in fileSections" :key="sec.batchId ?? 'unbatched'">
+          <div class="border-border-muted col-span-full border-b pb-2" :class="secIdx === 0 ? 'mt-0' : 'mt-6'">
+            <h3 class="text-muted text-xs font-semibold uppercase tracking-wide">{{ sec.title }}</h3>
           </div>
-          <div class="pr-8 text-sm font-medium leading-snug">{{ fileName(f.Key) }}</div>
-          <div v-if="folderPathUnderLab(f.Key)" class="text-muted mt-0.5 truncate text-[11px]">
-            {{ folderPathUnderLab(f.Key) }}
+          <div
+            v-for="f in sec.files"
+            :key="f.Key"
+            data-file-card
+            :data-key="f.Key"
+            draggable="true"
+            class="border-border-muted relative cursor-pointer rounded-xl border bg-white p-3 shadow-sm transition"
+            :class="{ 'ring-primary ring-2': selectedKeys.includes(f.Key) }"
+            @click="emit('toggleKey', f.Key)"
+            @dragstart="onCardDragStart($event, f.Key)"
+            @dragover="onCardDragOver"
+            @dragleave="onCardDragLeave"
+            @drop="onCardDrop($event)"
+          >
+            <div class="absolute right-2 top-2" @mousedown.stop @click.stop>
+              <UCheckbox :model-value="selectedKeys.includes(f.Key)" @update:model-value="emit('toggleKey', f.Key)" />
+            </div>
+            <div class="pr-8 text-sm font-medium leading-snug">{{ fileName(f.Key) }}</div>
+            <div v-if="folderPathUnderLab(f.Key)" class="text-muted mt-0.5 truncate text-[11px]">
+              {{ folderPathUnderLab(f.Key) }}
+            </div>
+            <div class="text-muted mt-1 text-xs">{{ f.Size != null ? `${f.Size} bytes` : '' }}</div>
+            <div class="mt-2 flex flex-wrap gap-1">
+              <span
+                v-for="tid in keyToTagIds[f.Key] || []"
+                :key="tid"
+                class="inline-flex cursor-grab items-center rounded-full px-2 py-0.5 text-[10px] font-medium"
+                draggable="true"
+                :style="{
+                  background: tagById(tid)?.ColorHex || '#e2e2e8',
+                  color: pillTextColor(tagById(tid)?.ColorHex || '#e2e2e8'),
+                }"
+                @dragstart="onPillDragStart($event, tid, f.Key)"
+                @click.stop
+              >
+                {{ tagById(tid)?.Name || tid }}
+              </span>
+            </div>
           </div>
-          <div class="text-muted mt-1 text-xs">{{ f.Size != null ? `${f.Size} bytes` : '' }}</div>
-          <div class="mt-2 flex flex-wrap gap-1">
-            <span
-              v-for="tid in keyToTagIds[f.Key] || []"
-              :key="tid"
-              class="inline-flex cursor-grab items-center rounded-full px-2 py-0.5 text-[10px] font-medium"
-              draggable="true"
-              :style="{
-                background: tagById(tid)?.ColorHex || '#e2e2e8',
-                color: pillTextColor(tagById(tid)?.ColorHex || '#e2e2e8'),
-              }"
-              @dragstart="onPillDragStart($event, tid, f.Key)"
-              @click.stop
-            >
-              {{ tagById(tid)?.Name || tid }}
-            </span>
-          </div>
-        </div>
+        </template>
       </div>
 
       <div v-else class="overflow-x-auto rounded-lg border border-gray-200 bg-white">
@@ -291,54 +343,68 @@
             </tr>
           </thead>
           <tbody>
-            <tr
-              v-for="f in visibleFiles"
-              :key="f.Key"
-              data-file-card
-              :data-key="f.Key"
-              draggable="true"
-              class="border-border-muted cursor-pointer border-b transition last:border-b-0"
-              :class="{
-                'bg-primary-muted/50': selectedKeys.includes(f.Key),
-                'hover:bg-gray-50/80': !selectedKeys.includes(f.Key),
-              }"
-              @click="emit('toggleKey', f.Key)"
-              @dragstart="onCardDragStart($event, f.Key)"
-              @dragover="onCardDragOver"
-              @dragleave="onCardDragLeave"
-              @drop="onCardDrop($event)"
-            >
-              <td class="px-3 py-2 align-middle" @mousedown.stop @click.stop>
-                <UCheckbox :model-value="selectedKeys.includes(f.Key)" @update:model-value="emit('toggleKey', f.Key)" />
-              </td>
-              <td class="max-w-[14rem] px-3 py-2 align-middle">
-                <div class="font-medium text-gray-900">{{ fileName(f.Key) }}</div>
-                <div v-if="folderPathUnderLab(f.Key)" class="text-muted truncate text-xs">
-                  {{ folderPathUnderLab(f.Key) }}
-                </div>
-              </td>
-              <td class="text-muted px-3 py-2 align-middle">—</td>
-              <td class="px-3 py-2 align-middle text-gray-800">{{ fileAnalysisStatus(f.Key) }}</td>
-              <td class="px-3 py-2 align-middle">
-                <div class="flex flex-wrap gap-1">
-                  <span
-                    v-for="tid in keyToTagIds[f.Key] || []"
-                    :key="tid"
-                    class="inline-flex cursor-grab items-center rounded-full px-2 py-0.5 text-[10px] font-medium"
-                    draggable="true"
-                    :style="{
-                      background: tagById(tid)?.ColorHex || '#e2e2e8',
-                      color: pillTextColor(tagById(tid)?.ColorHex || '#e2e2e8'),
-                    }"
-                    @dragstart="onPillDragStart($event, tid, f.Key)"
-                    @click.stop
-                  >
-                    {{ tagById(tid)?.Name || tid }}
-                  </span>
-                </div>
-              </td>
-              <td class="text-muted px-3 py-2 align-middle">—</td>
-            </tr>
+            <template v-for="sec in fileSections" :key="sec.batchId ?? 'unbatched'">
+              <tr class="bg-gray-50/95">
+                <td
+                  colspan="6"
+                  class="border-border-muted border-b px-3 py-2 text-xs font-semibold uppercase tracking-wide text-gray-600"
+                  scope="colgroup"
+                >
+                  {{ sec.title }}
+                </td>
+              </tr>
+              <tr
+                v-for="f in sec.files"
+                :key="f.Key"
+                data-file-card
+                :data-key="f.Key"
+                draggable="true"
+                class="border-border-muted cursor-pointer border-b transition last:border-b-0"
+                :class="{
+                  'bg-primary-muted/50': selectedKeys.includes(f.Key),
+                  'hover:bg-gray-50/80': !selectedKeys.includes(f.Key),
+                }"
+                @click="emit('toggleKey', f.Key)"
+                @dragstart="onCardDragStart($event, f.Key)"
+                @dragover="onCardDragOver"
+                @dragleave="onCardDragLeave"
+                @drop="onCardDrop($event)"
+              >
+                <td class="px-3 py-2 align-middle" @mousedown.stop @click.stop>
+                  <UCheckbox
+                    :model-value="selectedKeys.includes(f.Key)"
+                    @update:model-value="emit('toggleKey', f.Key)"
+                  />
+                </td>
+                <td class="max-w-[14rem] px-3 py-2 align-middle">
+                  <div class="font-medium text-gray-900">{{ fileName(f.Key) }}</div>
+                  <div v-if="folderPathUnderLab(f.Key)" class="text-muted truncate text-xs">
+                    {{ folderPathUnderLab(f.Key) }}
+                  </div>
+                </td>
+                <td class="text-muted px-3 py-2 align-middle">{{ batchDisplayName(f.Key) }}</td>
+                <td class="px-3 py-2 align-middle text-gray-800">{{ fileAnalysisStatus(f.Key) }}</td>
+                <td class="px-3 py-2 align-middle">
+                  <div class="flex flex-wrap gap-1">
+                    <span
+                      v-for="tid in keyToTagIds[f.Key] || []"
+                      :key="tid"
+                      class="inline-flex cursor-grab items-center rounded-full px-2 py-0.5 text-[10px] font-medium"
+                      draggable="true"
+                      :style="{
+                        background: tagById(tid)?.ColorHex || '#e2e2e8',
+                        color: pillTextColor(tagById(tid)?.ColorHex || '#e2e2e8'),
+                      }"
+                      @dragstart="onPillDragStart($event, tid, f.Key)"
+                      @click.stop
+                    >
+                      {{ tagById(tid)?.Name || tid }}
+                    </span>
+                  </div>
+                </td>
+                <td class="text-muted px-3 py-2 align-middle">—</td>
+              </tr>
+            </template>
           </tbody>
         </table>
       </div>

--- a/packages/front-end/src/app/components/EGDataCollectionsPage.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsPage.vue
@@ -55,6 +55,23 @@
 
   const batchTags = computed(() => tags.value.filter((t) => (t.Kind ?? 'standard') === 'batch'));
 
+  function batchAssignmentLabelForKey(key: string): string {
+    const bid = keyToBatchTagId.value[key];
+    if (!bid) return 'Unbatched';
+    return tagById(bid)?.Name ?? bid;
+  }
+
+  /** Distinct batch names for the current selection (Change batch modal). */
+  const changeBatchCurrentlyInLine = computed(() => {
+    const sel = selectedKeys.value;
+    if (!sel.length) return '—';
+    const names = new Set<string>();
+    for (const key of sel) {
+      names.add(batchAssignmentLabelForKey(key));
+    }
+    return [...names].sort((a, b) => a.localeCompare(b)).join(', ');
+  });
+
   /** Tags present on the current selection, with count of selected files that have each tag. */
   const tagsOnSelection = computed(() => {
     const sel = selectedKeys.value;
@@ -343,6 +360,10 @@
 
   function closeChangeBatchModal(): void {
     showChangeBatchModal.value = false;
+  }
+
+  function clearExistingBatchSelection(): void {
+    changeBatchSelectedBatchId.value = undefined;
   }
 
   async function assignBatchInChunks(
@@ -634,8 +655,33 @@
         </template>
 
         <div class="space-y-4">
+          <div class="rounded-lg border border-gray-100 bg-gray-50 px-4 py-3">
+            <dl class="space-y-2.5 text-sm">
+              <div class="flex items-baseline justify-between gap-4">
+                <dt class="text-muted shrink-0">Samples to move</dt>
+                <dd class="font-medium tabular-nums text-gray-900">{{ selectedKeys.length }}</dd>
+              </div>
+              <div class="flex items-start justify-between gap-4">
+                <dt class="text-muted shrink-0 pt-0.5">Currently in</dt>
+                <dd class="min-w-0 flex-1 break-words text-right font-medium leading-snug text-gray-900">
+                  {{ changeBatchCurrentlyInLine }}
+                </dd>
+              </div>
+            </dl>
+          </div>
           <div>
-            <label class="text-muted mb-1 block text-xs font-semibold uppercase tracking-wide">Existing batch</label>
+            <div class="mb-1 flex items-center justify-between gap-2">
+              <label class="text-muted block text-xs font-semibold uppercase tracking-wide">Existing batch</label>
+              <button
+                v-if="changeBatchSelectedBatchId"
+                type="button"
+                class="text-primary shrink-0 text-xs font-normal hover:underline disabled:cursor-not-allowed disabled:opacity-50"
+                :disabled="bulkPanelBusy || !!changeBatchNewName.trim()"
+                @click="clearExistingBatchSelection"
+              >
+                Clear selection
+              </button>
+            </div>
             <USelectMenu
               v-model="changeBatchSelectedBatchId"
               :options="batchTags"
@@ -648,14 +694,17 @@
             />
           </div>
           <div>
-            <label class="text-muted mb-1 block text-xs font-semibold uppercase tracking-wide">New batch</label>
+            <label class="text-muted mb-1 block text-xs font-semibold uppercase tracking-wide">
+              Or create new batch
+            </label>
             <UInput
               v-model="changeBatchNewName"
-              placeholder="Create a new batch"
+              placeholder="e.g. Nov-2024-FluPanel"
               size="sm"
               class="w-full"
               :disabled="bulkPanelBusy || !!changeBatchSelectedBatchId"
             />
+            <p class="text-muted mt-1.5 text-xs leading-snug">Leave blank to use the existing batch selected above.</p>
           </div>
         </div>
 
@@ -664,7 +713,7 @@
           <UButton size="sm" variant="outline" :disabled="bulkPanelBusy" @click="clearBatchFromModal">
             Remove from batch
           </UButton>
-          <UButton size="sm" :loading="bulkPanelBusy" @click="applyChangeBatch">Apply</UButton>
+          <UButton size="sm" :loading="bulkPanelBusy" @click="applyChangeBatch">Move samples</UButton>
         </div>
       </UCard>
     </UModal>

--- a/packages/front-end/src/app/components/EGDataCollectionsPage.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsPage.vue
@@ -17,11 +17,15 @@
 
   const tags = ref<LaboratoryDataTag[]>([]);
   const keyToTagIds = ref<Record<string, string[]>>({});
+  /** Batch assignment per object key (tag ids with Kind batch are tracked separately from TagIds). */
+  const keyToBatchTagId = ref<Record<string, string | undefined>>({});
   const files = ref<{ Key: string; Size?: number; LastModified?: string }[]>([]);
   const listingTruncated = ref(false);
   const selectedKeys = ref<string[]>([]);
   const filterTagId = ref<string | null>(null);
   const search = ref('');
+
+  const KEYS_CHUNK = 100;
 
   /** Bottom bulk panel: closed | add | remove */
   const bulkPanelMode = ref<'closed' | 'add' | 'remove'>('closed');
@@ -46,6 +50,10 @@
   function tagById(id: string): LaboratoryDataTag | undefined {
     return tags.value.find((t) => t.TagId === id);
   }
+
+  const standardTags = computed(() => tags.value.filter((t) => (t.Kind ?? 'standard') !== 'batch'));
+
+  const batchTags = computed(() => tags.value.filter((t) => (t.Kind ?? 'standard') === 'batch'));
 
   /** Tags present on the current selection, with count of selected files that have each tag. */
   const tagsOnSelection = computed(() => {
@@ -95,17 +103,23 @@
       files.value = (res.Contents || []).filter((c) => !c.Key.endsWith('/'));
       const keys = files.value.map((f) => f.Key);
       const map: Record<string, string[]> = {};
+      const batchMap: Record<string, string | undefined> = {};
       if (keys.length) {
-        const tr = await $api.dataCollections.requestListFileTags({
-          LaboratoryId: props.labId,
-          S3Bucket: lab.value.S3Bucket,
-          Keys: keys,
-        });
-        for (const f of tr.Files) {
-          map[f.Key] = f.TagIds;
+        for (let i = 0; i < keys.length; i += KEYS_CHUNK) {
+          const chunk = keys.slice(i, i + KEYS_CHUNK);
+          const tr = await $api.dataCollections.requestListFileTags({
+            LaboratoryId: props.labId,
+            S3Bucket: lab.value.S3Bucket,
+            Keys: chunk,
+          });
+          for (const f of tr.Files) {
+            map[f.Key] = f.TagIds;
+            batchMap[f.Key] = f.BatchTagId;
+          }
         }
       }
       keyToTagIds.value = map;
+      keyToBatchTagId.value = batchMap;
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
       toast.error(`Failed to load files: ${msg}`);
@@ -186,8 +200,6 @@
     else s.add(tagId);
     bulkRemoveTagIds.value = [...s];
   }
-
-  const KEYS_CHUNK = 100;
 
   async function addTagsToFilesInChunks(keys: string[], addTagIds: string[], removeTagIds: string[]): Promise<void> {
     if (!lab.value?.S3Bucket) return;
@@ -311,6 +323,90 @@
     const keys: string[] = JSON.parse(raw) as string[];
     void applyTagToKeys(tagId, keys);
   }
+
+  const showChangeBatchModal = ref(false);
+  const changeBatchSelectedBatchId = ref<string | undefined>(undefined);
+  const changeBatchNewName = ref('');
+
+  watch(changeBatchNewName, (v) => {
+    if (v.trim()) changeBatchSelectedBatchId.value = undefined;
+  });
+  watch(changeBatchSelectedBatchId, (v) => {
+    if (v) changeBatchNewName.value = '';
+  });
+
+  function openChangeBatchModal(): void {
+    changeBatchSelectedBatchId.value = undefined;
+    changeBatchNewName.value = '';
+    showChangeBatchModal.value = true;
+  }
+
+  function closeChangeBatchModal(): void {
+    showChangeBatchModal.value = false;
+  }
+
+  async function assignBatchInChunks(
+    keys: string[],
+    body: { ClearBatch?: boolean; BatchTagId?: string; NewBatchName?: string },
+  ): Promise<void> {
+    if (!lab.value?.S3Bucket) return;
+    const bucket = lab.value.S3Bucket;
+    for (let i = 0; i < keys.length; i += KEYS_CHUNK) {
+      const chunk = keys.slice(i, i + KEYS_CHUNK);
+      await $api.dataCollections.assignBatch({
+        LaboratoryId: props.labId,
+        S3Bucket: bucket,
+        Keys: chunk,
+        ...body,
+      });
+    }
+  }
+
+  async function applyChangeBatch(): Promise<void> {
+    if (!lab.value?.S3Bucket || !selectedKeys.value.length) return;
+    const keys = [...selectedKeys.value];
+    const nn = changeBatchNewName.value.trim();
+    uiStore.setRequestPending('dataCollectionsMutate');
+    try {
+      if (nn) {
+        await assignBatchInChunks(keys, { NewBatchName: nn });
+      } else if (changeBatchSelectedBatchId.value) {
+        await assignBatchInChunks(keys, { BatchTagId: changeBatchSelectedBatchId.value });
+      } else {
+        toast.warning('Choose an existing batch or enter a new batch name.');
+        return;
+      }
+      await loadTags();
+      await loadListing();
+      await nextTick();
+      toast.success('Batch updated');
+      closeChangeBatchModal();
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      toast.error(`Batch update failed: ${msg}`);
+    } finally {
+      uiStore.setRequestComplete('dataCollectionsMutate');
+    }
+  }
+
+  async function clearBatchFromModal(): Promise<void> {
+    if (!lab.value?.S3Bucket || !selectedKeys.value.length) return;
+    const keys = [...selectedKeys.value];
+    uiStore.setRequestPending('dataCollectionsMutate');
+    try {
+      await assignBatchInChunks(keys, { ClearBatch: true });
+      await loadTags();
+      await loadListing();
+      await nextTick();
+      toast.success('Removed from batch');
+      closeChangeBatchModal();
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      toast.error(`Batch update failed: ${msg}`);
+    } finally {
+      uiStore.setRequestComplete('dataCollectionsMutate');
+    }
+  }
 </script>
 
 <template>
@@ -341,8 +437,8 @@
           >
             <span>Untagged</span>
           </button>
-          <div
-            v-for="t in tags"
+          <button
+            v-for="t in standardTags"
             :key="t.TagId"
             class="hover:bg-primary-muted flex w-full cursor-pointer items-center justify-between rounded-lg px-2 py-2 text-left text-sm"
             :class="{ 'bg-primary-muted font-medium': filterTagId === t.TagId }"
@@ -355,7 +451,7 @@
               {{ t.Name }}
             </span>
             <span class="text-muted text-xs">{{ t.FileCount }}</span>
-          </div>
+          </button>
         </div>
       </div>
 
@@ -364,7 +460,9 @@
         :lab-root="labRoot"
         :visible-files="visibleFiles"
         :key-to-tag-ids="keyToTagIds"
-        :tags="tags"
+        :key-to-batch-tag-id="keyToBatchTagId"
+        :batch-tags="batchTags"
+        :tags="standardTags"
         :selected-keys="selectedKeys"
         :loading="loading"
         :search="search"
@@ -383,13 +481,14 @@
       <div class="flex flex-wrap items-center gap-2 px-4 py-2">
         <span v-if="hasSelection" class="text-muted text-xs">{{ selectedKeys.length }} file(s) selected</span>
         <span v-else class="text-muted text-xs">Select files in the grid to add or remove tags in bulk.</span>
-        <div class="ml-auto flex flex-wrap items-center gap-2">
+        <div v-if="hasSelection" class="ml-auto flex flex-wrap items-center gap-2">
           <UIcon v-if="bulkPanelBusy" name="i-heroicons-arrow-path" class="text-muted h-5 w-5 shrink-0 animate-spin" />
-          <UButton size="sm" variant="soft" :disabled="!hasSelection || bulkPanelBusy" @click="openAddBulkPanel">
-            Add Tags
-          </UButton>
-          <UButton size="sm" variant="outline" :disabled="!hasSelection || bulkPanelBusy" @click="openRemoveBulkPanel">
+          <UButton size="sm" variant="soft" :disabled="bulkPanelBusy" @click="openAddBulkPanel">Add Tags</UButton>
+          <UButton size="sm" variant="outline" :disabled="bulkPanelBusy" @click="openRemoveBulkPanel">
             Remove Tags
+          </UButton>
+          <UButton size="sm" variant="outline" :disabled="bulkPanelBusy" @click="openChangeBatchModal">
+            Change Batch
           </UButton>
         </div>
       </div>
@@ -434,7 +533,7 @@
             <h3 class="text-muted mb-3 text-xs font-semibold uppercase tracking-wide">Add Tags</h3>
             <ul class="max-h-56 space-y-2 overflow-y-auto pr-1 text-sm">
               <li
-                v-for="t in tags"
+                v-for="t in standardTags"
                 :key="'add-' + t.TagId"
                 class="flex items-center gap-2 rounded-lg border border-transparent px-2 py-1.5 hover:bg-gray-50"
               >
@@ -508,5 +607,66 @@
         </div>
       </div>
     </div>
+
+    <UModal
+      v-model="showChangeBatchModal"
+      :ui="{
+        overlay: {
+          base: 'fixed inset-0 transition-opacity backdrop-blur-[5px]',
+          background: 'bg-gray-800/30',
+        },
+        rounded: 'rounded-3xl',
+        width: 'sm:max-w-lg',
+      }"
+    >
+      <UCard
+        :ui="{
+          base: 'p-8',
+          rounded: 'rounded-3xl',
+          header: { padding: '' },
+        }"
+      >
+        <template #header>
+          <div class="flex flex-col gap-1">
+            <h3 class="text-lg font-semibold text-gray-900">Change batch</h3>
+            <p class="text-muted text-sm">Reassign the selected samples to a different batch.</p>
+          </div>
+        </template>
+
+        <div class="space-y-4">
+          <div>
+            <label class="text-muted mb-1 block text-xs font-semibold uppercase tracking-wide">Existing batch</label>
+            <USelectMenu
+              v-model="changeBatchSelectedBatchId"
+              :options="batchTags"
+              option-attribute="Name"
+              value-attribute="TagId"
+              placeholder="Select a batch"
+              size="sm"
+              class="w-full"
+              :disabled="bulkPanelBusy || !!changeBatchNewName.trim()"
+            />
+          </div>
+          <div>
+            <label class="text-muted mb-1 block text-xs font-semibold uppercase tracking-wide">New batch</label>
+            <UInput
+              v-model="changeBatchNewName"
+              placeholder="Create a new batch"
+              size="sm"
+              class="w-full"
+              :disabled="bulkPanelBusy || !!changeBatchSelectedBatchId"
+            />
+          </div>
+        </div>
+
+        <div class="mt-8 flex flex-wrap justify-end gap-2 border-t border-gray-100 pt-4">
+          <UButton size="sm" variant="ghost" :disabled="bulkPanelBusy" @click="closeChangeBatchModal">Cancel</UButton>
+          <UButton size="sm" variant="outline" :disabled="bulkPanelBusy" @click="clearBatchFromModal">
+            Remove from batch
+          </UButton>
+          <UButton size="sm" :loading="bulkPanelBusy" @click="applyChangeBatch">Apply</UButton>
+        </div>
+      </UCard>
+    </UModal>
   </div>
 </template>

--- a/packages/front-end/src/app/repository/modules/data-collections.ts
+++ b/packages/front-end/src/app/repository/modules/data-collections.ts
@@ -84,6 +84,17 @@ class DataCollectionsModule extends HttpFactory {
     await this.call('POST', '/data-collections/add-tags-to-files', body);
   }
 
+  async assignBatch(body: {
+    LaboratoryId: string;
+    S3Bucket: string;
+    Keys: string[];
+    ClearBatch?: boolean;
+    BatchTagId?: string;
+    NewBatchName?: string;
+  }): Promise<void> {
+    await this.call('POST', '/data-collections/edit-batch', body);
+  }
+
   async listFilesByTag(
     laboratoryId: string,
     tagId: string,

--- a/packages/shared-lib/src/app/schema/easy-genomics/data-collections/assign-batch.ts
+++ b/packages/shared-lib/src/app/schema/easy-genomics/data-collections/assign-batch.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+/** Exactly one of ClearBatch, BatchTagId, or NewBatchName must be set. */
+export const AssignBatchSchema = z
+  .object({
+    LaboratoryId: z.string().min(1),
+    S3Bucket: z.string().min(1),
+    Keys: z.array(z.string().min(1)).min(1).max(100),
+    ClearBatch: z.boolean().optional(),
+    BatchTagId: z.string().min(1).optional(),
+    NewBatchName: z.string().trim().min(1).max(128).optional(),
+  })
+  .strict()
+  .refine(
+    (data) => {
+      const modes = [data.ClearBatch === true, !!data.BatchTagId, !!data.NewBatchName].filter(Boolean);
+      return modes.length === 1;
+    },
+    { message: 'Specify exactly one of ClearBatch, BatchTagId, or NewBatchName' },
+  );

--- a/packages/shared-lib/src/app/schema/easy-genomics/data-collections/create-tag.ts
+++ b/packages/shared-lib/src/app/schema/easy-genomics/data-collections/create-tag.ts
@@ -2,10 +2,13 @@ import { z } from 'zod';
 
 export const ColorHexSchema = z.string().regex(/^#[0-9A-Fa-f]{6}$/, 'Color must be a #RRGGBB hex value');
 
+export const LaboratoryDataTagKindSchema = z.enum(['standard', 'batch']);
+
 export const CreateLaboratoryDataTagSchema = z
   .object({
     LaboratoryId: z.string().min(1),
     Name: z.string().trim().min(1).max(128),
     ColorHex: ColorHexSchema,
+    Kind: LaboratoryDataTagKindSchema.optional(),
   })
   .strict();

--- a/packages/shared-lib/src/app/types/easy-genomics/data-collections.ts
+++ b/packages/shared-lib/src/app/types/easy-genomics/data-collections.ts
@@ -1,7 +1,11 @@
+export type LaboratoryDataTagKind = 'standard' | 'batch';
+
 export type LaboratoryDataTag = {
   TagId: string;
   Name: string;
   ColorHex: string;
+  /** Omitted or `standard` for legacy tag rows. */
+  Kind?: LaboratoryDataTagKind;
   FileCount: number;
   CreatedAt?: string;
   CreatedBy?: string;
@@ -15,7 +19,10 @@ export type ListLaboratoryDataTagsResponse = {
 
 export type FileTagAssignment = {
   Key: string;
+  /** Standard (non-batch) tags only. */
   TagIds: string[];
+  /** At most one batch tag id if the file is assigned to a batch. */
+  BatchTagId?: string;
 };
 
 export type ListFileTagsResponse = {


### PR DESCRIPTION
## Data collections: batch assignment, grouping, and Change batch modal

## Type of Change*
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
This PR adds **batch assignment** for lab data collections: batches are stored in the existing **`laboratory-data-tagging-table`** as tag rows with **`Kind: 'batch'`**, still using **`TagIds` + MAP/GSI** so deletes and “files by tag” stay consistent. Each file may have **at most one** batch; standard tags remain unchanged.

**Backend**
- Extended **`LaboratoryDataTag`** / Dynamo tag rows with optional **`Kind`** (`standard` | `batch`; omitted = standard).
- **`create-tag`** accepts optional **`Kind`**; batch tags persist `Kind: 'batch'` on the tag row.
- **`request-list-file-tags`** returns **`TagIds`** (standard only) and optional **`BatchTagId`** per file (derived from stored ids + batch metadata).
- **`applyTagsToFiles`**: rejects multiple batch ids in one request; when adding a batch tag, **strips existing batch tags** on that file first.
- **`setBatchForFiles`** + **`POST /easy-genomics/data-collections/edit-batch`** (Lambda: **`edit-batch.lambda.ts`** — verb **`edit`** required by CDK discovery; not `assign-*`) supports **`ClearBatch`**, **`BatchTagId`**, or **`NewBatchName`** (exactly one per request). IAM updated in **`easy-genomics-nested-stack.ts`**.
- Shared types/schemas: **`assign-batch`** schema, **`create-tag`** **`Kind`**, **`FileTagAssignment`** **`BatchTagId`**.

**Front-end**
- **Change batch** modal: summary card (**Samples to move**, **Currently in**), existing-batch **`USelectMenu`**, new batch **`UInput`** + helper text, **Clear selection** for the dropdown, **Remove from batch** / **Apply** / **Cancel**.
- **`assignBatch`** API module calls **`/data-collections/edit-batch`**; chunked like other mutations.
- Sidebar & bulk tag panels use **standard tags only**; **`list-file-tags`** requests chunked (100 keys).
- Explorer: **sections by batch** (cards + table), **Batch** column in table, batch headers (**Batch {name} · N samples** / **Unbatched · …**), **Select batch** / **Deselect batch** when fully selected.
- Bottom tray: **Add Tags**, **Remove Tags**, **Change Batch** only when there is a selection.

## Screenshots

https://github.com/user-attachments/assets/4bd97d80-07d1-4594-8ce0-c991899ca45d

## Testing*
- **Unit:** Extended **`laboratory-data-tagging-service.test.ts`** — mocks **`queryItems`** for `applyTagsToFiles`; asserts rejection when adding **two batch tags** in one call.
- **Manual:** Create/move/clear batches via modal; verify grouping, bulk tag panels exclude batches, **Select batch** / **Deselect batch**, and **Clear selection** in the modal without reopening.

## Impact
- **New API route:** `POST .../data-collections/edit-batch` (deploy with CDK).
- **Response shape:** list-file-tags **`Files[]`** now includes **`BatchTagId`** where applicable; **`TagIds`** are standard-only — callers must treat batch separately (this page is updated accordingly).
- **No new DynamoDB table**; existing tagging table and GSIs reused.
- Tag **`list-tags`** responses may include **`Kind`** for batch definitions; UI filters batches vs standard tags.

## Additional Information
- **Route naming:** The handler file is **`edit-batch.lambda.ts`** so the first path segment matches an allowed HTTP verb in **`LambdaConstruct`** (`edit` → POST). The repository API method is still named **`assignBatch`** but hits **`/data-collections/edit-batch`**.
- **`UInput`** in Nuxt UI v2 does **not** support a **`hint`** prop; helper copy under **Or create new batch** uses a plain **`<p>`** (or **`UFormGroup`** **`help`** could be used later for consistency).

## Checklist*
- [ ] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [ ] Code adheres to the coding and style guidelines of the project.
- [ ] Code has been commented in particularly hard-to-understand areas.