### PR TITLE
fix: api gateway urls in ci-cd pipeline build after migration

### DIFF
--- a/.github/workflows/cicd-release-quality-uat.yml
+++ b/.github/workflows/cicd-release-quality-uat.yml
@@ -141,13 +141,30 @@ jobs:
           role-duration-seconds: 3600
           aws-region: ${{ secrets.AWS_REGION }}
           audience: sts.amazonaws.com
-      - name: Derive Easy Genomics API URL (optional)
+      - name: Derive API URLs from stack outputs
         run: |-
           set -euo pipefail
-          STACK_NAME="${ENV_TYPE}-${ENV_NAME}-easy-genomics-api-stack"
+          MAIN_STACK_NAME="${ENV_TYPE}-${ENV_NAME}-main-back-end-stack"
+          EASY_STACK_NAME="${ENV_TYPE}-${ENV_NAME}-easy-genomics-api-stack"
+
+          BASE_URL="$(aws cloudformation describe-stacks \
+            --region "$AWS_REGION" \
+            --stack-name "$MAIN_STACK_NAME" \
+            --query 'Stacks[0].Outputs[?OutputKey==`ApiGatewayRestApiUrl`].OutputValue' \
+            --output text)"
+
+          if [ -z "${BASE_URL:-}" ] || [ "${BASE_URL:-}" = "None" ]; then
+            echo "Unable to derive AWS_API_GATEWAY_URL from stack output ApiGatewayRestApiUrl in $MAIN_STACK_NAME" >&2
+            exit 1
+          fi
+
+          BASE_URL="${BASE_URL%/}"
+          echo "AWS_API_GATEWAY_URL=$BASE_URL" >> "$GITHUB_ENV"
+          echo "Derived AWS_API_GATEWAY_URL=$BASE_URL"
+
           EG_URL="$(aws cloudformation describe-stacks \
             --region "$AWS_REGION" \
-            --stack-name "$STACK_NAME" \
+            --stack-name "$EASY_STACK_NAME" \
             --query 'Stacks[0].Outputs[?OutputKey==`EasyGenomicsApiUrl`].OutputValue' \
             --output text 2>/dev/null || true)"
 
@@ -156,7 +173,7 @@ jobs:
             echo "AWS_EASY_GENOMICS_API_URL=$EG_URL" >> "$GITHUB_ENV"
             echo "Derived AWS_EASY_GENOMICS_API_URL=$EG_URL"
           else
-            echo "Easy Genomics API stack output not found; leaving AWS_EASY_GENOMICS_API_URL unset."
+            echo "Easy Genomics API output not found in $EASY_STACK_NAME; leaving AWS_EASY_GENOMICS_API_URL unset."
           fi
       - name: Run CI/CD Build & Deploy Front-End
         run: pnpm cicd-build-deploy-front-end
@@ -227,13 +244,30 @@ jobs:
           role-duration-seconds: 3600
           aws-region: ${{ secrets.AWS_REGION }}
           audience: sts.amazonaws.com
-      - name: Derive Easy Genomics API URL (optional)
+      - name: Derive API URLs from stack outputs
         run: |-
           set -euo pipefail
-          STACK_NAME="${ENV_TYPE}-${ENV_NAME}-easy-genomics-api-stack"
+          MAIN_STACK_NAME="${ENV_TYPE}-${ENV_NAME}-main-back-end-stack"
+          EASY_STACK_NAME="${ENV_TYPE}-${ENV_NAME}-easy-genomics-api-stack"
+
+          BASE_URL="$(aws cloudformation describe-stacks \
+            --region "$AWS_REGION" \
+            --stack-name "$MAIN_STACK_NAME" \
+            --query 'Stacks[0].Outputs[?OutputKey==`ApiGatewayRestApiUrl`].OutputValue' \
+            --output text)"
+
+          if [ -z "${BASE_URL:-}" ] || [ "${BASE_URL:-}" = "None" ]; then
+            echo "Unable to derive AWS_API_GATEWAY_URL from stack output ApiGatewayRestApiUrl in $MAIN_STACK_NAME" >&2
+            exit 1
+          fi
+
+          BASE_URL="${BASE_URL%/}"
+          echo "AWS_API_GATEWAY_URL=$BASE_URL" >> "$GITHUB_ENV"
+          echo "Derived AWS_API_GATEWAY_URL=$BASE_URL"
+
           EG_URL="$(aws cloudformation describe-stacks \
             --region "$AWS_REGION" \
-            --stack-name "$STACK_NAME" \
+            --stack-name "$EASY_STACK_NAME" \
             --query 'Stacks[0].Outputs[?OutputKey==`EasyGenomicsApiUrl`].OutputValue' \
             --output text 2>/dev/null || true)"
 
@@ -242,7 +276,7 @@ jobs:
             echo "AWS_EASY_GENOMICS_API_URL=$EG_URL" >> "$GITHUB_ENV"
             echo "Derived AWS_EASY_GENOMICS_API_URL=$EG_URL"
           else
-            echo "Easy Genomics API stack output not found; leaving AWS_EASY_GENOMICS_API_URL unset."
+            echo "Easy Genomics API output not found in $EASY_STACK_NAME; leaving AWS_EASY_GENOMICS_API_URL unset."
           fi
       - name: Clear Playwright Cache
         run: rm -rf /home/runner/.cache/ms-playwright

--- a/.github/workflows/cicd-release-quality.yml
+++ b/.github/workflows/cicd-release-quality.yml
@@ -141,13 +141,30 @@ jobs:
           role-duration-seconds: 3600
           aws-region: ${{ secrets.AWS_REGION }}
           audience: sts.amazonaws.com
-      - name: Derive Easy Genomics API URL (optional)
+      - name: Derive API URLs from stack outputs
         run: |-
           set -euo pipefail
-          STACK_NAME="${ENV_TYPE}-${ENV_NAME}-easy-genomics-api-stack"
+          MAIN_STACK_NAME="${ENV_TYPE}-${ENV_NAME}-main-back-end-stack"
+          EASY_STACK_NAME="${ENV_TYPE}-${ENV_NAME}-easy-genomics-api-stack"
+
+          BASE_URL="$(aws cloudformation describe-stacks \
+            --region "$AWS_REGION" \
+            --stack-name "$MAIN_STACK_NAME" \
+            --query 'Stacks[0].Outputs[?OutputKey==`ApiGatewayRestApiUrl`].OutputValue' \
+            --output text)"
+
+          if [ -z "${BASE_URL:-}" ] || [ "${BASE_URL:-}" = "None" ]; then
+            echo "Unable to derive AWS_API_GATEWAY_URL from stack output ApiGatewayRestApiUrl in $MAIN_STACK_NAME" >&2
+            exit 1
+          fi
+
+          BASE_URL="${BASE_URL%/}"
+          echo "AWS_API_GATEWAY_URL=$BASE_URL" >> "$GITHUB_ENV"
+          echo "Derived AWS_API_GATEWAY_URL=$BASE_URL"
+
           EG_URL="$(aws cloudformation describe-stacks \
             --region "$AWS_REGION" \
-            --stack-name "$STACK_NAME" \
+            --stack-name "$EASY_STACK_NAME" \
             --query 'Stacks[0].Outputs[?OutputKey==`EasyGenomicsApiUrl`].OutputValue' \
             --output text 2>/dev/null || true)"
 
@@ -156,7 +173,7 @@ jobs:
             echo "AWS_EASY_GENOMICS_API_URL=$EG_URL" >> "$GITHUB_ENV"
             echo "Derived AWS_EASY_GENOMICS_API_URL=$EG_URL"
           else
-            echo "Easy Genomics API stack output not found; leaving AWS_EASY_GENOMICS_API_URL unset."
+            echo "Easy Genomics API output not found in $EASY_STACK_NAME; leaving AWS_EASY_GENOMICS_API_URL unset."
           fi
       - name: Run CI/CD Build & Deploy Front-End
         run: pnpm cicd-build-deploy-front-end
@@ -227,13 +244,30 @@ jobs:
           role-duration-seconds: 3600
           aws-region: ${{ secrets.AWS_REGION }}
           audience: sts.amazonaws.com
-      - name: Derive Easy Genomics API URL (optional)
+      - name: Derive API URLs from stack outputs
         run: |-
           set -euo pipefail
-          STACK_NAME="${ENV_TYPE}-${ENV_NAME}-easy-genomics-api-stack"
+          MAIN_STACK_NAME="${ENV_TYPE}-${ENV_NAME}-main-back-end-stack"
+          EASY_STACK_NAME="${ENV_TYPE}-${ENV_NAME}-easy-genomics-api-stack"
+
+          BASE_URL="$(aws cloudformation describe-stacks \
+            --region "$AWS_REGION" \
+            --stack-name "$MAIN_STACK_NAME" \
+            --query 'Stacks[0].Outputs[?OutputKey==`ApiGatewayRestApiUrl`].OutputValue' \
+            --output text)"
+
+          if [ -z "${BASE_URL:-}" ] || [ "${BASE_URL:-}" = "None" ]; then
+            echo "Unable to derive AWS_API_GATEWAY_URL from stack output ApiGatewayRestApiUrl in $MAIN_STACK_NAME" >&2
+            exit 1
+          fi
+
+          BASE_URL="${BASE_URL%/}"
+          echo "AWS_API_GATEWAY_URL=$BASE_URL" >> "$GITHUB_ENV"
+          echo "Derived AWS_API_GATEWAY_URL=$BASE_URL"
+
           EG_URL="$(aws cloudformation describe-stacks \
             --region "$AWS_REGION" \
-            --stack-name "$STACK_NAME" \
+            --stack-name "$EASY_STACK_NAME" \
             --query 'Stacks[0].Outputs[?OutputKey==`EasyGenomicsApiUrl`].OutputValue' \
             --output text 2>/dev/null || true)"
 
@@ -242,7 +276,7 @@ jobs:
             echo "AWS_EASY_GENOMICS_API_URL=$EG_URL" >> "$GITHUB_ENV"
             echo "Derived AWS_EASY_GENOMICS_API_URL=$EG_URL"
           else
-            echo "Easy Genomics API stack output not found; leaving AWS_EASY_GENOMICS_API_URL unset."
+            echo "Easy Genomics API output not found in $EASY_STACK_NAME; leaving AWS_EASY_GENOMICS_API_URL unset."
           fi
       - name: Clear Playwright Cache
         run: rm -rf /home/runner/.cache/ms-playwright

--- a/.github/workflows/cicd-release-sandbox.yml
+++ b/.github/workflows/cicd-release-sandbox.yml
@@ -141,13 +141,30 @@ jobs:
           role-duration-seconds: 3600
           aws-region: ${{ secrets.AWS_REGION }}
           audience: sts.amazonaws.com
-      - name: Derive Easy Genomics API URL (optional)
+      - name: Derive API URLs from stack outputs
         run: |-
           set -euo pipefail
-          STACK_NAME="${ENV_TYPE}-${ENV_NAME}-easy-genomics-api-stack"
+          MAIN_STACK_NAME="${ENV_TYPE}-${ENV_NAME}-main-back-end-stack"
+          EASY_STACK_NAME="${ENV_TYPE}-${ENV_NAME}-easy-genomics-api-stack"
+
+          BASE_URL="$(aws cloudformation describe-stacks \
+            --region "$AWS_REGION" \
+            --stack-name "$MAIN_STACK_NAME" \
+            --query 'Stacks[0].Outputs[?OutputKey==`ApiGatewayRestApiUrl`].OutputValue' \
+            --output text)"
+
+          if [ -z "${BASE_URL:-}" ] || [ "${BASE_URL:-}" = "None" ]; then
+            echo "Unable to derive AWS_API_GATEWAY_URL from stack output ApiGatewayRestApiUrl in $MAIN_STACK_NAME" >&2
+            exit 1
+          fi
+
+          BASE_URL="${BASE_URL%/}"
+          echo "AWS_API_GATEWAY_URL=$BASE_URL" >> "$GITHUB_ENV"
+          echo "Derived AWS_API_GATEWAY_URL=$BASE_URL"
+
           EG_URL="$(aws cloudformation describe-stacks \
             --region "$AWS_REGION" \
-            --stack-name "$STACK_NAME" \
+            --stack-name "$EASY_STACK_NAME" \
             --query 'Stacks[0].Outputs[?OutputKey==`EasyGenomicsApiUrl`].OutputValue' \
             --output text 2>/dev/null || true)"
 
@@ -156,7 +173,7 @@ jobs:
             echo "AWS_EASY_GENOMICS_API_URL=$EG_URL" >> "$GITHUB_ENV"
             echo "Derived AWS_EASY_GENOMICS_API_URL=$EG_URL"
           else
-            echo "Easy Genomics API stack output not found; leaving AWS_EASY_GENOMICS_API_URL unset."
+            echo "Easy Genomics API output not found in $EASY_STACK_NAME; leaving AWS_EASY_GENOMICS_API_URL unset."
           fi
       - name: Run CI/CD Build & Deploy Front-End
         run: pnpm cicd-build-deploy-front-end

--- a/packages/front-end/nuxt-load-configuration-settings.ts
+++ b/packages/front-end/nuxt-load-configuration-settings.ts
@@ -36,6 +36,7 @@ export async function exportNuxtConfigurationSettings(
   awsRegion: string,
   envName: string,
   envType: string,
+  apiGatewayUrl?: string,
   easyGenomicsApiUrl?: string,
 ) {
   const namePrefix: string = `${envType}-${envName}`;
@@ -45,7 +46,10 @@ export async function exportNuxtConfigurationSettings(
 
   // Ensure the AWS Region for the SDK calls to correctly query the correct region.
   process.env.AWS_REGION = awsRegion;
-  const apiGatewayInfo: ApiGatewayInfo = await getApiGatewayInfo(apiGatewayRestApiName, awsRegion);
+  const normalizedApiGatewayUrl = apiGatewayUrl?.replace(/\/+$/, '');
+  const apiGatewayInfo: ApiGatewayInfo = normalizedApiGatewayUrl
+    ? { RestApiUrl: normalizedApiGatewayUrl }
+    : await getApiGatewayInfo(apiGatewayRestApiName, awsRegion);
   const cognitoIdpInfo: CognitoIdpInfo = await getCognitoIdpInfo(cognitoUserPoolName, cognitoUserPoolClientName);
   const cognitoDomain = await getCognitoDomainInfo(cognitoIdpInfo.UserPoolId || '');
   const clientUrls = await getCognitoClientUrls(cognitoIdpInfo.UserPoolId || '', cognitoIdpInfo.UserPoolClientId || '');
@@ -98,12 +102,13 @@ void (async () => {
       const awsRegion = process.env.AWS_REGION;
       const envName = process.env.ENV_NAME;
       const envType = process.env.ENV_TYPE;
+      const apiGatewayUrl = process.env.AWS_API_GATEWAY_URL;
       const easyGenomicsApiUrl = process.env.AWS_EASY_GENOMICS_API_URL;
       if (!awsRegion || !envName || !envType) {
         throw new Error('Missing required CI/CD env vars: AWS_REGION, ENV_NAME, ENV_TYPE.');
       }
 
-      await exportNuxtConfigurationSettings(awsRegion, envName, envType, easyGenomicsApiUrl);
+      await exportNuxtConfigurationSettings(awsRegion, envName, envType, apiGatewayUrl, easyGenomicsApiUrl);
     } else {
       // @ts-ignore
       const configurations: { [p: string]: ConfigurationSettings }[] = loadConfigurations(
@@ -129,9 +134,10 @@ void (async () => {
 
           const envType: string = configSettings['env-type']; // dev | pre-prod | prod
           const awsRegion: string = configSettings['aws-region'];
+          const apiGatewayUrl: string | undefined = process.env.AWS_API_GATEWAY_URL;
           const easyGenomicsApiUrl: string | undefined = configSettings['aws-easy-genomics-api-url'] ?? undefined;
 
-          await exportNuxtConfigurationSettings(awsRegion, envName, envType, easyGenomicsApiUrl);
+          await exportNuxtConfigurationSettings(awsRegion, envName, envType, apiGatewayUrl, easyGenomicsApiUrl);
         }
       }
     }

--- a/projenrc/github-actions-cicd-release.ts
+++ b/projenrc/github-actions-cicd-release.ts
@@ -65,7 +65,7 @@ export class GithubActionsCICDRelease extends Component {
         steps: [
           ...this.bootstrapSteps(),
           ...this.configureAwsCredentials(),
-          this.deriveEasyGenomicsApiUrlStep(),
+          this.deriveApiUrlsStep(),
           {
             name: 'Run CI/CD Build & Deploy Front-End',
             run: 'pnpm cicd-build-deploy-front-end',
@@ -89,7 +89,7 @@ export class GithubActionsCICDRelease extends Component {
         steps: [
           ...this.bootstrapSteps(),
           ...this.configureAwsCredentials(),
-          this.deriveEasyGenomicsApiUrlStep(),
+          this.deriveApiUrlsStep(),
           {
             name: 'Clear Playwright Cache',
             run: 'rm -rf /home/runner/.cache/ms-playwright',
@@ -218,28 +218,48 @@ export class GithubActionsCICDRelease extends Component {
   }
 
   /**
-   * Derive `AWS_EASY_GENOMICS_API_URL` from the Easy Genomics API stack output.
+   * Derive split-stack API URLs from CloudFormation outputs.
    *
-   * Why: we want split-stack deployments (easy-genomics in its own stack) to
-   * automatically wire the front-end to the new API without requiring a new
-   * GitHub Actions secret/variable. In pre-migration environments this stack
-   * may not exist yet; in that case we intentionally leave the variable unset
-   * so the UI falls back to `AWS_API_GATEWAY_URL + /easy-genomics`.
+   * `AWS_API_GATEWAY_URL` must come from the shared "main-back-end" stack
+   * because it owns `/nf-tower` and `/aws-healthomics`.
+   *
+   * `AWS_EASY_GENOMICS_API_URL` comes from the dedicated easy-genomics stack.
+   * This output can be absent in pre-migration environments, in which case we
+   * leave the var unset and the UI falls back to
+   * `${AWS_API_GATEWAY_URL}/easy-genomics`.
    */
-  private deriveEasyGenomicsApiUrlStep(): github.workflows.JobStep {
+  private deriveApiUrlsStep(): github.workflows.JobStep {
     return {
-      name: 'Derive Easy Genomics API URL (optional)',
+      name: 'Derive API URLs from stack outputs',
       // Note: projen's `JobStep` typing doesn't currently expose `shell`, but
       // GitHub Actions supports it and we want bash strict mode semantics.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ...({ shell: 'bash' } as any),
       run: [
         'set -euo pipefail',
-        'STACK_NAME="${ENV_TYPE}-${ENV_NAME}-easy-genomics-api-stack"',
-        // If the stack does not exist (pre-migration) this command fails; treat that as "unset".
+        'MAIN_STACK_NAME="${ENV_TYPE}-${ENV_NAME}-main-back-end-stack"',
+        'EASY_STACK_NAME="${ENV_TYPE}-${ENV_NAME}-easy-genomics-api-stack"',
+        '',
+        // Main back-end stack is required in all environments.
+        'BASE_URL="$(aws cloudformation describe-stacks \\',
+        '  --region "$AWS_REGION" \\',
+        '  --stack-name "$MAIN_STACK_NAME" \\',
+        "  --query 'Stacks[0].Outputs[?OutputKey==`ApiGatewayRestApiUrl`].OutputValue' \\",
+        '  --output text)"',
+        '',
+        'if [ -z "${BASE_URL:-}" ] || [ "${BASE_URL:-}" = "None" ]; then',
+        '  echo "Unable to derive AWS_API_GATEWAY_URL from stack output ApiGatewayRestApiUrl in $MAIN_STACK_NAME" >&2',
+        '  exit 1',
+        'fi',
+        '',
+        'BASE_URL="${BASE_URL%/}"',
+        'echo "AWS_API_GATEWAY_URL=$BASE_URL" >> "$GITHUB_ENV"',
+        'echo "Derived AWS_API_GATEWAY_URL=$BASE_URL"',
+        '',
+        // If the easy-genomics stack does not exist yet, treat as optional.
         'EG_URL="$(aws cloudformation describe-stacks \\',
         '  --region "$AWS_REGION" \\',
-        '  --stack-name "$STACK_NAME" \\',
+        '  --stack-name "$EASY_STACK_NAME" \\',
         "  --query 'Stacks[0].Outputs[?OutputKey==`EasyGenomicsApiUrl`].OutputValue' \\",
         '  --output text 2>/dev/null || true)"',
         '',
@@ -248,7 +268,7 @@ export class GithubActionsCICDRelease extends Component {
         '  echo "AWS_EASY_GENOMICS_API_URL=$EG_URL" >> "$GITHUB_ENV"',
         '  echo "Derived AWS_EASY_GENOMICS_API_URL=$EG_URL"',
         'else',
-        '  echo "Easy Genomics API stack output not found; leaving AWS_EASY_GENOMICS_API_URL unset."',
+        '  echo "Easy Genomics API output not found in $EASY_STACK_NAME; leaving AWS_EASY_GENOMICS_API_URL unset."',
         'fi',
       ].join('\n'),
     };


### PR DESCRIPTION
## fix: api gateway urls in ci-cd pipeline build after migration

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
In ci-cd build we are using only one api gateway url instead of the two different created after migration. Since both have exact match in name the select always get the same one. Made update to get both urls from their stack instead of by name.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.