### PR TITLE
feat: Data Tagging Page - Workflow Filtering

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -410,6 +410,8 @@ backEndApp.addScripts({
   ['invoke-process-handler']: 'tsx src/local-server/invoke-process-handler.ts',
   ['backfill-omics-run-tags']: 'tsx scripts/backfill-omics-run-tags.ts',
   ['backfill-omics-run-tags:dry-run']: 'tsx scripts/backfill-omics-run-tags.ts --dry-run',
+  ['seed-workflow-tagging-test-runs']: 'tsx scripts/seed-workflow-tagging-test-runs.ts',
+  ['seed-workflow-tagging-test-runs:dry-run']: 'tsx scripts/seed-workflow-tagging-test-runs.ts --dry-run',
 });
 
 if (backEndApp.eslint) {

--- a/packages/back-end/package.json
+++ b/packages/back-end/package.json
@@ -28,7 +28,9 @@
     "local-server:watch": "tsx watch src/local-server/index.ts",
     "invoke-process-handler": "tsx src/local-server/invoke-process-handler.ts",
     "backfill-omics-run-tags": "tsx scripts/backfill-omics-run-tags.ts",
-    "backfill-omics-run-tags:dry-run": "tsx scripts/backfill-omics-run-tags.ts --dry-run"
+    "backfill-omics-run-tags:dry-run": "tsx scripts/backfill-omics-run-tags.ts --dry-run",
+    "seed-workflow-tagging-test-runs": "tsx scripts/seed-workflow-tagging-test-runs.ts",
+    "seed-workflow-tagging-test-runs:dry-run": "tsx scripts/seed-workflow-tagging-test-runs.ts --dry-run"
   },
   "author": {
     "name": "DEPT Agency",

--- a/packages/back-end/scripts/README.md
+++ b/packages/back-end/scripts/README.md
@@ -22,6 +22,38 @@ pnpm run backfill-omics-run-tags:dry-run
 
 **Environment:** `NAME_PREFIX`, `ACCOUNT_ID`, `REGION` (see script header for IAM expectations).
 
+## `seed-workflow-tagging-test-runs.ts`
+
+**Purpose:** Creates twelve synthetic `LaboratoryRun` rows (no Omics or Seqera launch) and applies the same
+workflow→file tagging logic as `create-laboratory-run`, so you can exercise Data Collections workflow filters without
+platform charges.
+
+**When to use:** Local or non-prod environments when you want realistic workflow tag diversity on existing bucket
+objects.
+
+**Usage:**
+
+```bash
+pnpm run seed-workflow-tagging-test-runs -- --laboratoryId <uuid>
+pnpm run seed-workflow-tagging-test-runs -- --laboratoryId <uuid> --reset
+pnpm run seed-workflow-tagging-test-runs:dry-run -- --laboratoryId <uuid>
+pnpm run seed-workflow-tagging-test-runs:dry-run -- --laboratoryId <uuid> --reset
+```
+
+- `--reset` — Deletes laboratory runs created by this script for that lab (matched by `Settings.seededBy` or a `RunName`
+  prefix of `[seed] `), removes each distinct seed workflow tag via `deleteTag` (clears `FILE#` / `MAP#` links), then
+  proceeds with a fresh seed as usual. Combine with `--dry-run` to print what would be removed.
+- `--keys-file path.json` — JSON array of full S3 keys (must start with `OrganizationId/LaboratoryId/`). Use when the
+  bucket is empty under the lab prefix or you want specific files only.
+- `--user-id` / `--owner` — optional overrides for `UserId` (must be a UUID) and `Owner` on each run row.
+
+**Environment:** `NAME_PREFIX`, `REGION`. Optional `SEQERA_PLATFORM_API_BASE_URL` if the lab has no
+`NextFlowTowerApiBaseUrl` but you still want Seqera-style runs to carry a base URL.
+
+**IAM:** DynamoDB `PutItem` / `DeleteItem` on `laboratory-run-table`; DynamoDB read/write (including `DeleteItem` and
+GSI queries) on `laboratory-data-tagging-table` (+ indexes); `s3:ListBucket` (and `ListBucket` on the lab bucket) when
+discovering keys. No Omics or Tower API calls.
+
 ## `recompute-laboratory-run-retention.ts`
 
 **Purpose:** Recomputes DynamoDB TTL-related fields on terminal laboratory runs for **one laboratory**: sets

--- a/packages/back-end/scripts/seed-workflow-tagging-test-runs.ts
+++ b/packages/back-end/scripts/seed-workflow-tagging-test-runs.ts
@@ -1,0 +1,426 @@
+/**
+ * Seeds ~12 synthetic laboratory runs (no Omics / Seqera launch) and applies the same
+ * workflow→file tagging hook as create-laboratory-run, so the Data Collections page shows
+ * workflow filters without incurring platform charges.
+ *
+ * Run from packages/back-end:
+ *   pnpm run seed-workflow-tagging-test-runs -- --laboratoryId <uuid>
+ *
+ * Options:
+ *   --laboratoryId <uuid>   Required. Lab whose bucket/prefix is used for keys.
+ *   --reset                 Delete prior runs created by this script (and their workflow tags / file links), then seed.
+ *   --dry-run               Log actions only; no DynamoDB or S3 writes.
+ *   --keys-file <path>      JSON array of full S3 object keys (under org/lab/). Overrides S3 discovery.
+ *   --user-id <uuid>        Stored as LaboratoryRun.UserId / CreatedBy (default: fixed dev UUID).
+ *   --owner <email>         Stored as LaboratoryRun.Owner (default: seed-script@example.com).
+ *
+ * By default the script lists up to 200 objects under `${OrganizationId}/${LaboratoryId}/`
+ * in the lab bucket and rotates through them for InputFileKeys. If the bucket is empty,
+ * pass --keys-file with keys you care about (you can paste from the AWS console or `aws s3 ls`).
+ *
+ * Requires .env.local (or env) with: NAME_PREFIX, REGION.
+ * AWS credentials need DynamoDB PutItem/DeleteItem on laboratory-run-table and data-tagging-table (+ indexes),
+ * and s3:ListBucket on the lab bucket when not using --keys-file.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import dotenv from 'dotenv';
+import { v4 as uuidv4 } from 'uuid';
+import { AddLaboratoryRun } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/laboratory-run';
+import type { WorkflowPlatform } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/data-collections';
+import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
+import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory-run';
+import { associateInputsWithWorkflowTag } from '../src/app/services/easy-genomics/associate-laboratory-run-workflow-tagging';
+import { LaboratoryDataTaggingService } from '../src/app/services/easy-genomics/laboratory-data-tagging-service';
+import { LaboratoryRunService } from '../src/app/services/easy-genomics/laboratory-run-service';
+import { LaboratoryService } from '../src/app/services/easy-genomics/laboratory-service';
+import { S3Service } from '../src/app/services/s3-service';
+
+const DEFAULT_SCRIPT_USER_ID = '11111111-1111-4111-8111-111111111111';
+const DEFAULT_OWNER = 'seed-script@example.com';
+
+/** Stored in each run's `Settings` JSON (string) so we can find and remove seed rows later. */
+const SEED_SCRIPT_SETTINGS_MARKER = 'seed-workflow-tagging-test-runs';
+
+type Platform = 'AWS HealthOmics' | 'Seqera Cloud';
+
+type WorkflowFixture = {
+  platform: Platform;
+  workflowExternalId: string;
+  workflowName: string;
+  workflowVersionName?: string;
+  /** Number of input keys to attach from the discovered pool for this run */
+  keyCount: number;
+};
+
+/** Twelve distinct workflow identities (mix of Omics + Seqera) to exercise grouping in the UI. */
+const WORKFLOW_FIXTURES: WorkflowFixture[] = [
+  {
+    platform: 'AWS HealthOmics',
+    workflowExternalId: 'seed-omics-fetchngs',
+    workflowName: 'nf-core/fetchngs',
+    workflowVersionName: '1.17',
+    keyCount: 2,
+  },
+  {
+    platform: 'AWS HealthOmics',
+    workflowExternalId: 'seed-omics-rnaseq',
+    workflowName: 'nf-core/rnaseq',
+    workflowVersionName: '3.14.0',
+    keyCount: 2,
+  },
+  {
+    platform: 'AWS HealthOmics',
+    workflowExternalId: 'seed-omics-sarek',
+    workflowName: 'nf-core/sarek',
+    workflowVersionName: '3.4.2',
+    keyCount: 1,
+  },
+  {
+    platform: 'AWS HealthOmics',
+    workflowExternalId: 'seed-omics-methylseq',
+    workflowName: 'nf-core/methylseq',
+    keyCount: 2,
+  },
+  {
+    platform: 'AWS HealthOmics',
+    workflowExternalId: 'seed-omics-ampliseq',
+    workflowName: 'nf-core/ampliseq',
+    workflowVersionName: '2.8.0',
+    keyCount: 1,
+  },
+  {
+    platform: 'Seqera Cloud',
+    workflowExternalId: 'seed-seqera-pipeline-1001',
+    workflowName: 'Demo RNA-seq (Seqera)',
+    workflowVersionName: 'rev_1',
+    keyCount: 2,
+  },
+  {
+    platform: 'Seqera Cloud',
+    workflowExternalId: 'seed-seqera-pipeline-1002',
+    workflowName: 'Demo WGS (Seqera)',
+    keyCount: 2,
+  },
+  {
+    platform: 'Seqera Cloud',
+    workflowExternalId: 'seed-seqera-pipeline-1003',
+    workflowName: 'Demo chipseq',
+    workflowVersionName: 'main',
+    keyCount: 1,
+  },
+  {
+    platform: 'AWS HealthOmics',
+    workflowExternalId: 'seed-omics-viralrecon',
+    workflowName: 'nf-core/viralrecon',
+    keyCount: 2,
+  },
+  {
+    platform: 'Seqera Cloud',
+    workflowExternalId: 'seed-seqera-pipeline-1004',
+    workflowName: 'Demo metagenomics',
+    keyCount: 2,
+  },
+  {
+    platform: 'AWS HealthOmics',
+    workflowExternalId: 'seed-omics-taxprofiler',
+    workflowName: 'nf-core/taxprofiler',
+    workflowVersionName: '1.1.0',
+    keyCount: 1,
+  },
+  {
+    platform: 'Seqera Cloud',
+    workflowExternalId: 'seed-seqera-pipeline-1005',
+    workflowName: 'Demo scrnaseq',
+    workflowVersionName: 'dev',
+    keyCount: 2,
+  },
+];
+
+function loadEnv(): void {
+  const envPath = path.resolve(process.cwd(), '.env.local');
+  dotenv.config({ path: envPath });
+  if (process.env.REGION && !process.env.AWS_REGION) {
+    process.env.AWS_REGION = process.env.REGION;
+  }
+  const required = ['NAME_PREFIX', 'REGION'];
+  const missing = required.filter((k) => !process.env[k]);
+  if (missing.length > 0) {
+    console.error(`Missing required env: ${missing.join(', ')}. Set in .env.local or environment.`);
+    process.exit(1);
+  }
+}
+
+function getFlagValue(flag: string): string | undefined {
+  const i = process.argv.indexOf(flag);
+  if (i >= 0 && process.argv[i + 1] && !process.argv[i + 1].startsWith('--')) {
+    return process.argv[i + 1];
+  }
+  return undefined;
+}
+
+async function discoverKeysUnderLabPrefix(
+  s3: S3Service,
+  bucket: string,
+  prefix: string,
+  maxObjects: number,
+): Promise<string[]> {
+  const keys: string[] = [];
+  let continuationToken: string | undefined;
+  while (keys.length < maxObjects) {
+    const page = await s3.listBucketObjectsV2({
+      Bucket: bucket,
+      Prefix: prefix,
+      MaxKeys: Math.min(1000, maxObjects - keys.length),
+      ...(continuationToken ? { ContinuationToken: continuationToken } : {}),
+    });
+    for (const obj of page.Contents || []) {
+      if (obj.Key && !obj.Key.endsWith('/')) {
+        keys.push(obj.Key);
+      }
+    }
+    if (!page.IsTruncated || !page.NextContinuationToken) break;
+    continuationToken = page.NextContinuationToken;
+  }
+  return keys;
+}
+
+function pickKeysForRun(pool: string[], runIndex: number, count: number): string[] {
+  if (pool.length === 0) return [];
+  const out: string[] = [];
+  for (let k = 0; k < count; k++) {
+    out.push(pool[(runIndex * 3 + k) % pool.length]);
+  }
+  return [...new Set(out)];
+}
+
+function isSeedLaboratoryRun(run: LaboratoryRun): boolean {
+  if (run.RunName?.startsWith('[seed] ')) {
+    return true;
+  }
+  if (!run.Settings) {
+    return false;
+  }
+  try {
+    const parsed = JSON.parse(run.Settings) as { seededBy?: string };
+    return parsed?.seededBy === SEED_SCRIPT_SETTINGS_MARKER;
+  } catch {
+    return false;
+  }
+}
+
+function workflowIdentityDedupeKey(run: LaboratoryRun): string | null {
+  if (!run.WorkflowExternalId) {
+    return null;
+  }
+  return `${run.Platform}\t${run.WorkflowExternalId}\t${run.WorkflowVersionName ?? ''}`;
+}
+
+async function deleteExistingSeedData(args: {
+  laboratory: Laboratory;
+  dryRun: boolean;
+  runService: LaboratoryRunService;
+  tagging: LaboratoryDataTaggingService;
+}): Promise<void> {
+  const { laboratory, dryRun, runService, tagging } = args;
+  const runs = await runService.queryByLaboratoryId(laboratory.LaboratoryId);
+  const seedRuns = runs.filter(isSeedLaboratoryRun);
+
+  if (seedRuns.length === 0) {
+    console.log('No existing seed laboratory runs found for this lab (--reset).');
+    return;
+  }
+
+  const seenIdentity = new Set<string>();
+  const identities: {
+    platform: WorkflowPlatform;
+    externalId: string;
+    versionName?: string;
+  }[] = [];
+
+  for (const run of seedRuns) {
+    const key = workflowIdentityDedupeKey(run);
+    if (!key || seenIdentity.has(key)) {
+      continue;
+    }
+    seenIdentity.add(key);
+    identities.push({
+      platform: run.Platform as WorkflowPlatform,
+      externalId: run.WorkflowExternalId!,
+      ...(run.WorkflowVersionName !== undefined ? { versionName: run.WorkflowVersionName } : {}),
+    });
+  }
+
+  if (dryRun) {
+    console.log(
+      `[dry-run] Would delete ${seedRuns.length} seed laboratory run(s) and remove up to ${identities.length} workflow tag(s) (by identity).`,
+    );
+    for (const run of seedRuns) {
+      console.log(`  [dry-run] run ${run.RunId} — ${run.RunName}`);
+    }
+    return;
+  }
+
+  for (const id of identities) {
+    const tag = await tagging.findWorkflowTagByIdentity(laboratory.LaboratoryId, id);
+    if (tag) {
+      console.log(`Removing workflow tag ${tag.TagId} (${id.externalId}) and its file associations…`);
+      await tagging.deleteTag(laboratory.LaboratoryId, tag.TagId);
+    }
+  }
+
+  for (const run of seedRuns) {
+    console.log(`Deleting laboratory run ${run.RunId} — ${run.RunName}`);
+    await runService.delete(run);
+  }
+
+  console.log(
+    `Reset complete: removed ${seedRuns.length} seed run(s); processed ${identities.length} distinct workflow identity cleanup(es).`,
+  );
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes('--dry-run');
+  const reset = process.argv.includes('--reset');
+  const laboratoryId = getFlagValue('--laboratoryId');
+  const keysFile = getFlagValue('--keys-file');
+  const userId = getFlagValue('--user-id') ?? DEFAULT_SCRIPT_USER_ID;
+  const owner = getFlagValue('--owner') ?? DEFAULT_OWNER;
+
+  if (!laboratoryId) {
+    console.error(
+      'Usage: pnpm run seed-workflow-tagging-test-runs -- --laboratoryId <uuid> [--reset] [--dry-run] [--keys-file path.json]',
+    );
+    process.exit(1);
+  }
+
+  loadEnv();
+
+  if (dryRun) {
+    console.log('DRY RUN: no DynamoDB writes.\n');
+  }
+
+  const labService = new LaboratoryService();
+  const runService = new LaboratoryRunService();
+  const tagging = new LaboratoryDataTaggingService();
+  const s3 = new S3Service();
+
+  const laboratory = await labService.queryByLaboratoryId(laboratoryId);
+  if (!laboratory.S3Bucket) {
+    console.error('Laboratory has no S3Bucket configured. Set a bucket on the lab first.');
+    process.exit(1);
+  }
+
+  if (reset) {
+    console.log('--reset: removing prior seed runs and workflow tags for this lab…\n');
+    await deleteExistingSeedData({ laboratory, dryRun, runService, tagging });
+    console.log('');
+  }
+
+  const labPrefix = `${laboratory.OrganizationId}/${laboratory.LaboratoryId}/`;
+  let keyPool: string[] = [];
+
+  if (keysFile) {
+    const raw = fs.readFileSync(path.resolve(keysFile), 'utf8');
+    keyPool = JSON.parse(raw) as string[];
+    if (!Array.isArray(keyPool) || !keyPool.every((k) => typeof k === 'string')) {
+      console.error('--keys-file must contain a JSON array of strings (full S3 keys).');
+      process.exit(1);
+    }
+    keyPool = keyPool.filter((k) => k.startsWith(labPrefix));
+    console.log(`Loaded ${keyPool.length} key(s) from ${keysFile} (under lab prefix).`);
+  } else {
+    keyPool = await discoverKeysUnderLabPrefix(s3, laboratory.S3Bucket, labPrefix, 200);
+    console.log(`Discovered ${keyPool.length} object key(s) under s3://${laboratory.S3Bucket}/${labPrefix}`);
+  }
+
+  if (keyPool.length === 0) {
+    console.error(
+      'No input keys available. Upload a few files under the lab prefix, or create a JSON file of full keys and pass --keys-file path.',
+    );
+    process.exit(1);
+  }
+
+  const seqeraBase = laboratory.NextFlowTowerApiBaseUrl || process.env.SEQERA_PLATFORM_API_BASE_URL || '';
+
+  let created = 0;
+  for (let i = 0; i < WORKFLOW_FIXTURES.length; i++) {
+    const fx = WORKFLOW_FIXTURES[i];
+    const runId = uuidv4();
+    const inputKeys = pickKeysForRun(keyPool, i, fx.keyCount);
+    const runName = `[seed] ${fx.workflowName} (${i + 1}/${WORKFLOW_FIXTURES.length})`;
+
+    const addPayload: AddLaboratoryRun = {
+      LaboratoryId: laboratory.LaboratoryId,
+      RunId: runId,
+      RunName: runName,
+      Platform: fx.platform,
+      ...(fx.platform === 'Seqera Cloud' && seqeraBase ? { PlatformApiBaseUrl: seqeraBase } : {}),
+      Status: 'SUBMITTED',
+      WorkflowName: fx.workflowName,
+      ...(fx.workflowVersionName !== undefined ? { WorkflowVersionName: fx.workflowVersionName } : {}),
+      WorkflowExternalId: fx.workflowExternalId,
+      InputFileKeys: inputKeys,
+      // Omit ExternalRunId so nothing is published to SNS / no platform polling.
+      InputS3Url: `s3://${laboratory.S3Bucket}/${labPrefix}seed-runs/${runId}/input`,
+      OutputS3Url: `s3://${laboratory.S3Bucket}/${labPrefix}seed-runs/${runId}/results`,
+      SampleSheetS3Url: `s3://${laboratory.S3Bucket}/${labPrefix}seed-runs/${runId}/samplesheet.csv`,
+      Settings: { seededBy: SEED_SCRIPT_SETTINGS_MARKER, fixtureIndex: i },
+    };
+
+    const createdAt = new Date().toISOString();
+    const laboratoryRun: LaboratoryRun = {
+      LaboratoryId: laboratory.LaboratoryId,
+      RunId: runId,
+      UserId: userId,
+      OrganizationId: laboratory.OrganizationId,
+      RunName: runName,
+      Platform: fx.platform,
+      ...(fx.platform === 'Seqera Cloud' && seqeraBase ? { PlatformApiBaseUrl: seqeraBase } : {}),
+      Status: 'SUBMITTED',
+      Owner: owner,
+      WorkflowName: fx.workflowName,
+      ...(fx.workflowVersionName !== undefined ? { WorkflowVersionName: fx.workflowVersionName } : {}),
+      WorkflowExternalId: fx.workflowExternalId,
+      InputFileKeys: inputKeys,
+      InputS3Url: addPayload.InputS3Url,
+      OutputS3Url: addPayload.OutputS3Url,
+      SampleSheetS3Url: addPayload.SampleSheetS3Url,
+      Settings: JSON.stringify(addPayload.Settings || {}),
+      CreatedAt: createdAt,
+      CreatedBy: userId,
+    };
+
+    if (dryRun) {
+      console.log(`[dry-run] Would create run ${runId}:`, {
+        runName,
+        platform: fx.platform,
+        workflowExternalId: fx.workflowExternalId,
+        inputKeys,
+      });
+      created++;
+      continue;
+    }
+
+    await runService.add(laboratoryRun);
+    await associateInputsWithWorkflowTag({
+      laboratory,
+      userId,
+      request: addPayload,
+      tagging,
+    });
+    console.log(`Created run ${runId} (${fx.workflowName}) → tagged ${inputKeys.length} file(s)`);
+    created++;
+  }
+
+  console.log(`\nDone. ${dryRun ? 'Would create' : 'Created'} ${created} laboratory run(s).`);
+  console.log(
+    'Open Data Collections for this lab to see workflow filters. Use --reset on the next run to remove prior seed runs and workflow tags before re-seeding.',
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/create-laboratory-run.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/create-laboratory-run.lambda.ts
@@ -13,6 +13,7 @@ import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-geno
 import { SnsProcessingEvent } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/sns-processing-event';
 import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
 import { v4 as uuidv4 } from 'uuid';
+import { associateInputsWithWorkflowTag } from '@BE/services/easy-genomics/associate-laboratory-run-workflow-tagging';
 import { LaboratoryDataTaggingService } from '@BE/services/easy-genomics/laboratory-data-tagging-service';
 import { LaboratoryRunService } from '@BE/services/easy-genomics/laboratory-run-service';
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
@@ -104,6 +105,7 @@ export const handler: Handler = async (
       laboratory,
       userId: currentUserId,
       request,
+      tagging: dataTaggingService,
     });
 
     if (laboratoryRun.ExternalRunId) {
@@ -127,38 +129,3 @@ export const handler: Handler = async (
     return buildErrorResponse(err, event);
   }
 };
-
-/**
- * Best-effort hook that records the file -> workflow association in the laboratory data
- * tagging table when a run is launched. Skips silently when any of the required pieces
- * are missing (legacy runs, runs without explicit input keys, runs whose keys live outside
- * the lab bucket, etc.) and never throws — tagging failures must not break run creation.
- */
-async function associateInputsWithWorkflowTag(args: {
-  laboratory: Laboratory;
-  userId: string;
-  request: AddLaboratoryRun;
-}): Promise<void> {
-  const { laboratory, userId, request } = args;
-  try {
-    const inputKeys = (request.InputFileKeys || []).filter((k) => typeof k === 'string' && k.length > 0);
-    if (!inputKeys.length) return;
-    if (!request.WorkflowExternalId) return;
-    if (!laboratory.S3Bucket) return;
-
-    const labPrefix = `${laboratory.OrganizationId}/${laboratory.LaboratoryId}/`;
-    const labScopedKeys = inputKeys.filter((k) => k.startsWith(labPrefix));
-    if (!labScopedKeys.length) return;
-
-    const tag = await dataTaggingService.getOrCreateWorkflowTag(laboratory, userId, {
-      platform: request.Platform,
-      externalId: request.WorkflowExternalId,
-      versionName: request.WorkflowVersionName,
-      name: request.WorkflowName?.trim() || request.WorkflowExternalId,
-    });
-
-    await dataTaggingService.applyWorkflowToFiles(laboratory, userId, tag.TagId, laboratory.S3Bucket, labScopedKeys);
-  } catch (err) {
-    console.warn('Failed to associate input files with workflow tag (continuing):', err);
-  }
-}

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/create-laboratory-run.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/create-laboratory-run.lambda.ts
@@ -13,6 +13,7 @@ import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-geno
 import { SnsProcessingEvent } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/sns-processing-event';
 import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
 import { v4 as uuidv4 } from 'uuid';
+import { LaboratoryDataTaggingService } from '@BE/services/easy-genomics/laboratory-data-tagging-service';
 import { LaboratoryRunService } from '@BE/services/easy-genomics/laboratory-run-service';
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
 import { SnsService } from '@BE/services/sns-service';
@@ -30,6 +31,7 @@ import {
 
 const laboratoryRunService = new LaboratoryRunService();
 const laboratoryService = new LaboratoryService();
+const dataTaggingService = new LaboratoryDataTaggingService();
 const snsService = new SnsService();
 
 export const handler: Handler = async (
@@ -83,6 +85,8 @@ export const handler: Handler = async (
       Owner: currentUserEmail,
       WorkflowName: request.WorkflowName,
       WorkflowVersionName: request.WorkflowVersionName,
+      WorkflowExternalId: request.WorkflowExternalId,
+      InputFileKeys: request.InputFileKeys,
       ExternalRunId: request.ExternalRunId,
       InputS3Url: request.InputS3Url,
       OutputS3Url: request.OutputS3Url,
@@ -92,6 +96,14 @@ export const handler: Handler = async (
       CreatedBy: currentUserId,
       ...(isTerminalAtCreate ? { TerminalAt: createdAt.toISOString() } : {}),
       ...(laboratorioRunExpiresAt !== undefined ? { ExpiresAt: laboratorioRunExpiresAt } : {}),
+    });
+
+    // Best-effort: associate input files with a workflow tag so the data tagging page can
+    // show "files used by workflow X". Failures here must NEVER block run creation.
+    await associateInputsWithWorkflowTag({
+      laboratory,
+      userId: currentUserId,
+      request,
     });
 
     if (laboratoryRun.ExternalRunId) {
@@ -115,3 +127,38 @@ export const handler: Handler = async (
     return buildErrorResponse(err, event);
   }
 };
+
+/**
+ * Best-effort hook that records the file -> workflow association in the laboratory data
+ * tagging table when a run is launched. Skips silently when any of the required pieces
+ * are missing (legacy runs, runs without explicit input keys, runs whose keys live outside
+ * the lab bucket, etc.) and never throws — tagging failures must not break run creation.
+ */
+async function associateInputsWithWorkflowTag(args: {
+  laboratory: Laboratory;
+  userId: string;
+  request: AddLaboratoryRun;
+}): Promise<void> {
+  const { laboratory, userId, request } = args;
+  try {
+    const inputKeys = (request.InputFileKeys || []).filter((k) => typeof k === 'string' && k.length > 0);
+    if (!inputKeys.length) return;
+    if (!request.WorkflowExternalId) return;
+    if (!laboratory.S3Bucket) return;
+
+    const labPrefix = `${laboratory.OrganizationId}/${laboratory.LaboratoryId}/`;
+    const labScopedKeys = inputKeys.filter((k) => k.startsWith(labPrefix));
+    if (!labScopedKeys.length) return;
+
+    const tag = await dataTaggingService.getOrCreateWorkflowTag(laboratory, userId, {
+      platform: request.Platform,
+      externalId: request.WorkflowExternalId,
+      versionName: request.WorkflowVersionName,
+      name: request.WorkflowName?.trim() || request.WorkflowExternalId,
+    });
+
+    await dataTaggingService.applyWorkflowToFiles(laboratory, userId, tag.TagId, laboratory.S3Bucket, labScopedKeys);
+  } catch (err) {
+    console.warn('Failed to associate input files with workflow tag (continuing):', err);
+  }
+}

--- a/packages/back-end/src/app/services/easy-genomics/associate-laboratory-run-workflow-tagging.ts
+++ b/packages/back-end/src/app/services/easy-genomics/associate-laboratory-run-workflow-tagging.ts
@@ -1,0 +1,39 @@
+import { AddLaboratoryRun } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/laboratory-run';
+import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
+import { LaboratoryDataTaggingService } from './laboratory-data-tagging-service';
+
+/**
+ * Best-effort hook that records the file -> workflow association in the laboratory data
+ * tagging table when a run is created. Shared by create-laboratory-run and maintenance scripts.
+ *
+ * Failures are logged and swallowed — tagging must not break run creation.
+ */
+export async function associateInputsWithWorkflowTag(args: {
+  laboratory: Laboratory;
+  userId: string;
+  request: AddLaboratoryRun;
+  tagging: LaboratoryDataTaggingService;
+}): Promise<void> {
+  const { laboratory, userId, request, tagging } = args;
+  try {
+    const inputKeys = (request.InputFileKeys || []).filter((k) => typeof k === 'string' && k.length > 0);
+    if (!inputKeys.length) return;
+    if (!request.WorkflowExternalId) return;
+    if (!laboratory.S3Bucket) return;
+
+    const labPrefix = `${laboratory.OrganizationId}/${laboratory.LaboratoryId}/`;
+    const labScopedKeys = inputKeys.filter((k) => k.startsWith(labPrefix));
+    if (!labScopedKeys.length) return;
+
+    const tag = await tagging.getOrCreateWorkflowTag(laboratory, userId, {
+      platform: request.Platform,
+      externalId: request.WorkflowExternalId,
+      versionName: request.WorkflowVersionName,
+      name: request.WorkflowName?.trim() || request.WorkflowExternalId,
+    });
+
+    await tagging.applyWorkflowToFiles(laboratory, userId, tag.TagId, laboratory.S3Bucket, labScopedKeys);
+  } catch (err) {
+    console.warn('Failed to associate input files with workflow tag (continuing):', err);
+  }
+}

--- a/packages/back-end/src/app/services/easy-genomics/laboratory-data-tagging-service.ts
+++ b/packages/back-end/src/app/services/easy-genomics/laboratory-data-tagging-service.ts
@@ -42,6 +42,39 @@ function workflowGsiPk(laboratoryId: string): string {
   return `${laboratoryId}#WORKFLOW`;
 }
 
+/**
+ * Inverse of {@link workflowGsiSk}. Workflow TAG rows store identity on `Gsi1Sk` as
+ * `{platform}#{externalId}#{version}` so we can recover Kind/Platform when legacy rows
+ * omitted scalar attributes.
+ */
+function parseWorkflowIdentityFromGsiSk(gsk: unknown): {
+  Platform: WorkflowPlatform;
+  WorkflowExternalId: string;
+  WorkflowVersionName: string;
+} | null {
+  if (typeof gsk !== 'string' || !gsk.length) {
+    return null;
+  }
+  const platforms: WorkflowPlatform[] = ['AWS HealthOmics', 'Seqera Cloud'];
+  for (const platform of platforms) {
+    const prefix = `${platform}#`;
+    if (!gsk.startsWith(prefix)) {
+      continue;
+    }
+    const tail = gsk.slice(prefix.length);
+    const i = tail.indexOf('#');
+    if (i === -1) {
+      return { Platform: platform, WorkflowExternalId: tail, WorkflowVersionName: '' };
+    }
+    return {
+      Platform: platform,
+      WorkflowExternalId: tail.slice(0, i),
+      WorkflowVersionName: tail.slice(i + 1),
+    };
+  }
+  return null;
+}
+
 export function encodeS3ObjectRef(bucket: string, key: string): string {
   return Buffer.from(JSON.stringify({ bucket, key }), 'utf8').toString('base64url');
 }
@@ -82,31 +115,77 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
   }
 
   public async listTags(laboratoryId: string): Promise<ListLaboratoryDataTagsResponse> {
-    const response: QueryCommandOutput = await this.queryItems({
-      TableName: TABLE_NAME,
-      KeyConditionExpression: '#pk = :pk AND begins_with(#sk, :tagPrefix)',
-      ExpressionAttributeNames: {
-        '#pk': 'LaboratoryId',
-        '#sk': 'Sk',
-      },
-      ExpressionAttributeValues: {
-        ':pk': { S: laboratoryId },
-        ':tagPrefix': { S: 'TAG#' },
-      },
-    });
+    const tags: LaboratoryDataTag[] = [];
+    let startKey: Record<string, unknown> | undefined;
+    do {
+      const response: QueryCommandOutput = await this.queryItems({
+        TableName: TABLE_NAME,
+        KeyConditionExpression: '#pk = :pk AND begins_with(#sk, :tagPrefix)',
+        ExpressionAttributeNames: {
+          '#pk': 'LaboratoryId',
+          '#sk': 'Sk',
+        },
+        ExpressionAttributeValues: {
+          ':pk': { S: laboratoryId },
+          ':tagPrefix': { S: 'TAG#' },
+        },
+        /** Strongly consistent read so tag metadata matches FILE# rows updated in the same session (e.g. workflow seeding). */
+        ConsistentRead: true,
+        ...(startKey ? { ExclusiveStartKey: startKey as never } : {}),
+      });
 
-    const tags: LaboratoryDataTag[] = (response.Items || []).map((item) =>
-      this.tagRowToModel(unmarshall(item) as Record<string, unknown>),
-    );
+      for (const item of response.Items || []) {
+        tags.push(this.tagRowToModel(unmarshall(item) as Record<string, unknown>));
+      }
+      startKey = response.LastEvaluatedKey as Record<string, unknown> | undefined;
+    } while (startKey);
+
     tags.sort((a, b) => a.Name.localeCompare(b.Name));
     return { Tags: tags };
   }
 
   /** Converts a raw TAG row from DynamoDB into the shared LaboratoryDataTag model. */
   private tagRowToModel(row: Record<string, unknown>): LaboratoryDataTag {
-    const rawKind = typeof row.Kind === 'string' ? (row.Kind as string) : 'standard';
-    const kind: LaboratoryDataTagKind =
-      rawKind === 'batch' ? 'batch' : rawKind === 'workflow' ? 'workflow' : 'standard';
+    /** Set on workflow TAG rows; Kind/Platform scalars may be missing on legacy or partially-projected items. */
+    const gsiSkParsed = parseWorkflowIdentityFromGsiSk(row.Gsi1Sk ?? row.gsi1Sk);
+
+    const rawKindAttr = row.Kind ?? row.kind;
+    const rawKind = typeof rawKindAttr === 'string' ? rawKindAttr : 'standard';
+    let kind: LaboratoryDataTagKind = rawKind === 'batch' ? 'batch' : rawKind === 'workflow' ? 'workflow' : 'standard';
+    /** Workflow rows always carry platform + external id; infer Kind if an older row omitted it. */
+    const hasWorkflowIdentity =
+      typeof row.Platform === 'string' &&
+      row.Platform.length > 0 &&
+      typeof row.WorkflowExternalId === 'string' &&
+      (row.WorkflowExternalId as string).length > 0;
+    if (kind !== 'batch' && hasWorkflowIdentity) {
+      kind = 'workflow';
+    }
+    /** Workflow tags are indexed under Gsi1Pk `{LaboratoryId}#WORKFLOW` — infer Kind when scalars were omitted. */
+    const laboratoryId = row.LaboratoryId as string | undefined;
+    const gsi1Pk = row.Gsi1Pk as string | undefined;
+    const workflowIndexTag =
+      typeof laboratoryId === 'string' &&
+      laboratoryId.length > 0 &&
+      typeof gsi1Pk === 'string' &&
+      gsi1Pk === workflowGsiPk(laboratoryId);
+    /**
+     * Also infer from `Gsi1Sk` alone: some stored rows retain the workflow identity sort key but not Gsi1Pk/Kind
+     * (e.g. partial updates). Pattern matches {@link workflowGsiSk} output only for workflow tags.
+     */
+    if (kind !== 'batch' && (workflowIndexTag || gsiSkParsed)) {
+      kind = 'workflow';
+    }
+
+    let platform = row.Platform as WorkflowPlatform | undefined;
+    let workflowExternalId = row.WorkflowExternalId as string | undefined;
+    let workflowVersionName = row.WorkflowVersionName as string | undefined;
+    if (kind === 'workflow' && (!platform || !workflowExternalId) && gsiSkParsed) {
+      platform = platform ?? gsiSkParsed.Platform;
+      workflowExternalId = workflowExternalId ?? gsiSkParsed.WorkflowExternalId;
+      workflowVersionName = workflowVersionName ?? gsiSkParsed.WorkflowVersionName;
+    }
+
     return {
       TagId: row.TagId as string,
       Name: row.Name as string,
@@ -115,9 +194,9 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
       FileCount: Number(row.FileCount ?? 0),
       ...(kind === 'workflow'
         ? {
-            Platform: row.Platform as WorkflowPlatform | undefined,
-            WorkflowExternalId: row.WorkflowExternalId as string | undefined,
-            WorkflowVersionName: row.WorkflowVersionName as string | undefined,
+            Platform: platform,
+            WorkflowExternalId: workflowExternalId,
+            WorkflowVersionName: workflowVersionName,
           }
         : {}),
       CreatedAt: row.CreatedAt as string | undefined,
@@ -189,6 +268,34 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
   }
 
   /**
+   * Returns an existing workflow tag for the identity tuple, or null if none exists.
+   * Does not create a tag (use {@link getOrCreateWorkflowTag} for that).
+   */
+  public async findWorkflowTagByIdentity(
+    laboratoryId: string,
+    args: {
+      platform: WorkflowPlatform;
+      externalId: string;
+      versionName?: string;
+    },
+  ): Promise<LaboratoryDataTag | null> {
+    const gpk = workflowGsiPk(laboratoryId);
+    const gsk = workflowGsiSk(args.platform, args.externalId, args.versionName);
+    const existing: QueryCommandOutput = await this.queryItems({
+      TableName: TABLE_NAME,
+      IndexName: GSI1_NAME,
+      KeyConditionExpression: '#gpk = :gpk AND #gsk = :gsk',
+      ExpressionAttributeNames: { '#gpk': 'Gsi1Pk', '#gsk': 'Gsi1Sk' },
+      ExpressionAttributeValues: { ':gpk': { S: gpk }, ':gsk': { S: gsk } },
+      Limit: 1,
+    });
+    if (!(existing.Items || []).length) {
+      return null;
+    }
+    return this.tagRowToModel(unmarshall(existing.Items![0]) as Record<string, unknown>);
+  }
+
+  /**
    * Workflow tags are auto-created when a run is launched (or backfilled). Each unique
    * (laboratoryId, platform, workflowExternalId, workflowVersionName) tuple gets its own tag,
    * looked up via GSI `Gsi1Pk_Index` so we don't have to scan the partition.
@@ -204,26 +311,17 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
     },
   ): Promise<LaboratoryDataTag> {
     const laboratoryId = laboratory.LaboratoryId;
-    const gpk = workflowGsiPk(laboratoryId);
-    const gsk = workflowGsiSk(args.platform, args.externalId, args.versionName);
-
-    const existing: QueryCommandOutput = await this.queryItems({
-      TableName: TABLE_NAME,
-      IndexName: GSI1_NAME,
-      KeyConditionExpression: '#gpk = :gpk AND #gsk = :gsk',
-      ExpressionAttributeNames: { '#gpk': 'Gsi1Pk', '#gsk': 'Gsi1Sk' },
-      ExpressionAttributeValues: { ':gpk': { S: gpk }, ':gsk': { S: gsk } },
-      Limit: 1,
-    });
-
-    if ((existing.Items || []).length > 0) {
-      return this.tagRowToModel(unmarshall(existing.Items![0]) as Record<string, unknown>);
+    const existing = await this.findWorkflowTagByIdentity(laboratoryId, args);
+    if (existing) {
+      return existing;
     }
 
     const tagId = randomUUID();
     const now = new Date().toISOString();
     const trimmedName = args.name.trim() || args.externalId;
     const colorHex = pickWorkflowTagColor(`${args.platform}#${args.externalId}`);
+    const gpk = workflowGsiPk(laboratoryId);
+    const gsk = workflowGsiSk(args.platform, args.externalId, args.versionName);
 
     await this.putItem({
       TableName: TABLE_NAME,
@@ -409,9 +507,53 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
     });
   }
 
+  /**
+   * For tag ids present on files but missing from the listTags-derived sets (e.g. eventual
+   * consistency right after workflow tagging), load TAG# rows via BatchGetItem and add ids
+   * to batchTagIds / workflowTagIds so listFileTags partitions correctly.
+   */
+  private async hydrateKindSetsFromTagIds(
+    laboratoryId: string,
+    tagIds: Iterable<string>,
+    batchTagIds: Set<string>,
+    workflowTagIds: Set<string>,
+  ): Promise<void> {
+    const toResolve = [...new Set(tagIds)].filter((id) => !batchTagIds.has(id) && !workflowTagIds.has(id));
+    if (!toResolve.length) return;
+
+    for (let i = 0; i < toResolve.length; i += 100) {
+      const chunk = toResolve.slice(i, i + 100);
+      const res: BatchGetItemCommandOutput = await this.batchGetItem({
+        RequestItems: {
+          [TABLE_NAME]: {
+            Keys: chunk.map((tagId) =>
+              marshall({
+                LaboratoryId: laboratoryId,
+                Sk: skTag(tagId),
+              }),
+            ),
+            /** Strongly consistent so Kind/workflow metadata is visible right after PutItem on TAG# rows. */
+            ConsistentRead: true,
+          },
+        },
+      });
+      for (const item of res.Responses?.[TABLE_NAME] || []) {
+        const tag = this.tagRowToModel(unmarshall(item) as Record<string, unknown>);
+        const isWorkflow = tag.Kind === 'workflow' || !!(tag.Platform && tag.WorkflowExternalId);
+        if (tag.Kind === 'batch') {
+          batchTagIds.add(tag.TagId);
+        } else if (isWorkflow) {
+          workflowTagIds.add(tag.TagId);
+        }
+      }
+    }
+  }
+
   public async listFileTags(laboratoryId: string, bucket: string, keys: string[]): Promise<FileTagAssignment[]> {
     const out: FileTagAssignment[] = [];
     const { batchTagIds, workflowTagIds } = await this.getKindIndexedTagIds(laboratoryId);
+    const batchTagIdsMutable = new Set(batchTagIds);
+    const workflowTagIdsMutable = new Set(workflowTagIds);
 
     for (let i = 0; i < keys.length; i += 100) {
       const batchKeys = keys.slice(i, i + 100);
@@ -424,16 +566,23 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
         RequestItems: {
           [TABLE_NAME]: {
             Keys: dynamoKeys.map((k) => marshall(k)),
+            /** Strongly consistent with workflow writes (FILE# + TAG# in the same request path). */
+            ConsistentRead: true,
           },
         },
       });
 
       const items = res.Responses?.[TABLE_NAME] || [];
       const bySk = new Map<string, string[]>();
+      const chunkTagIds = new Set<string>();
       for (const item of items) {
         const row = unmarshall(item) as Record<string, unknown>;
-        bySk.set(row.Sk as string, (row.TagIds as string[]) || []);
+        const ids = (row.TagIds as string[]) || [];
+        bySk.set(row.Sk as string, ids);
+        for (const id of ids) chunkTagIds.add(id);
       }
+
+      await this.hydrateKindSetsFromTagIds(laboratoryId, chunkTagIds, batchTagIdsMutable, workflowTagIdsMutable);
 
       for (let j = 0; j < batchKeys.length; j++) {
         const key = batchKeys[j];
@@ -443,9 +592,9 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
         const workflowIds: string[] = [];
         let batchTagId: string | undefined;
         for (const id of rawIds) {
-          if (batchTagIds.has(id)) {
+          if (batchTagIdsMutable.has(id)) {
             batchTagId = id;
-          } else if (workflowTagIds.has(id)) {
+          } else if (workflowTagIdsMutable.has(id)) {
             workflowIds.push(id);
           } else {
             standard.push(id);
@@ -481,7 +630,8 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
 
     const tagRow = await this.getTagRow(laboratoryId, workflowTagId);
     if (!tagRow) throw new Error(`Unknown tag: ${workflowTagId}`);
-    if (tagRow.Kind !== 'workflow') {
+    const isWorkflow = tagRow.Kind === 'workflow' || !!(tagRow.Platform && tagRow.WorkflowExternalId);
+    if (!isWorkflow) {
       throw new Error('applyWorkflowToFiles can only be used with workflow-kind tags');
     }
 
@@ -734,8 +884,11 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
     const workflowTagIds = new Set<string>();
     for (const t of Tags) {
       const kind = t.Kind ?? 'standard';
-      if (kind === 'batch') batchTagIds.add(t.TagId);
-      else if (kind === 'workflow') workflowTagIds.add(t.TagId);
+      if (kind === 'batch') {
+        batchTagIds.add(t.TagId);
+      } else if (kind === 'workflow' || !!(t.Platform && t.WorkflowExternalId)) {
+        workflowTagIds.add(t.TagId);
+      }
     }
     return { batchTagIds, workflowTagIds };
   }
@@ -794,6 +947,7 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
     const res = await this.getItem({
       TableName: TABLE_NAME,
       Key: marshall({ LaboratoryId: laboratoryId, Sk: skTag(tagId) }),
+      ConsistentRead: true,
     });
     if (!res.Item) return null;
     return this.tagRowToModel(unmarshall(res.Item) as Record<string, unknown>);
@@ -806,6 +960,7 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
     const res = await this.getItem({
       TableName: TABLE_NAME,
       Key: marshall({ LaboratoryId: laboratoryId, Sk: skFile(ref) }),
+      ConsistentRead: true,
     });
     if (!res.Item) return null;
     const row = unmarshall(res.Item) as Record<string, unknown>;

--- a/packages/back-end/src/app/services/easy-genomics/laboratory-data-tagging-service.ts
+++ b/packages/back-end/src/app/services/easy-genomics/laboratory-data-tagging-service.ts
@@ -1,5 +1,9 @@
 import { randomUUID } from 'crypto';
-import { BatchGetItemCommandOutput, QueryCommandOutput } from '@aws-sdk/client-dynamodb';
+import {
+  BatchGetItemCommandOutput,
+  ConditionalCheckFailedException,
+  QueryCommandOutput,
+} from '@aws-sdk/client-dynamodb';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
 import {
   FileTagAssignment,
@@ -11,10 +15,30 @@ import {
   WorkflowPlatform,
 } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/data-collections';
 import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
+import { v5 as uuidv5 } from 'uuid';
 import { DynamoDBService } from '../dynamodb-service';
 
 const TABLE_NAME = `${process.env.NAME_PREFIX}-laboratory-data-tagging-table`;
 const GSI1_NAME = 'Gsi1Pk_Index';
+
+/** Namespace UUID for v5 workflow tag ids (stable per lab + platform + workflow identity). */
+const WORKFLOW_TAG_ID_NAMESPACE = 'a3d8f7e2-4c1b-5d6e-9f8a-0b1c2d3e4f5a';
+
+function isConditionalCheckFailed(e: unknown): boolean {
+  return (
+    e instanceof ConditionalCheckFailedException ||
+    (typeof e === 'object' && e !== null && (e as { name?: string }).name === 'ConditionalCheckFailedException')
+  );
+}
+
+function deterministicWorkflowTagId(
+  laboratoryId: string,
+  platform: WorkflowPlatform,
+  externalId: string,
+  versionName: string,
+): string {
+  return uuidv5(`${laboratoryId}\u0000${platform}\u0000${externalId}\u0000${versionName}`, WORKFLOW_TAG_ID_NAMESPACE);
+}
 
 /**
  * Deterministic palette used for auto-assigned workflow tag colors. Mirrors the
@@ -316,39 +340,64 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
       return existing;
     }
 
-    const tagId = randomUUID();
+    const versionKey = args.versionName ?? '';
+    const tagId = deterministicWorkflowTagId(laboratoryId, args.platform, args.externalId, versionKey);
+    const existingByPk = await this.getTagRow(laboratoryId, tagId);
+    if (existingByPk) {
+      const isWorkflow =
+        existingByPk.Kind === 'workflow' || !!(existingByPk.Platform && existingByPk.WorkflowExternalId);
+      if (isWorkflow) {
+        return existingByPk;
+      }
+      throw new Error('Workflow tag id collision with an existing non-workflow tag');
+    }
+
     const now = new Date().toISOString();
     const trimmedName = args.name.trim() || args.externalId;
     const colorHex = pickWorkflowTagColor(`${args.platform}#${args.externalId}`);
     const gpk = workflowGsiPk(laboratoryId);
     const gsk = workflowGsiSk(args.platform, args.externalId, args.versionName);
 
-    await this.putItem({
-      TableName: TABLE_NAME,
-      Item: marshall(
-        {
-          LaboratoryId: laboratoryId,
-          Sk: skTag(tagId),
-          TagId: tagId,
-          Name: trimmedName,
-          ColorHex: colorHex,
-          Kind: 'workflow',
-          Platform: args.platform,
-          WorkflowExternalId: args.externalId,
-          WorkflowVersionName: args.versionName ?? '',
-          FileCount: 0,
-          Gsi1Pk: gpk,
-          Gsi1Sk: gsk,
-          CreatedAt: now,
-          CreatedBy: userId,
-          ModifiedAt: now,
-          ModifiedBy: userId,
-        },
-        { removeUndefinedValues: true },
-      ),
-      ConditionExpression: 'attribute_not_exists(#pk) AND attribute_not_exists(#sk)',
-      ExpressionAttributeNames: { '#pk': 'LaboratoryId', '#sk': 'Sk' },
-    });
+    try {
+      await this.putItem({
+        TableName: TABLE_NAME,
+        Item: marshall(
+          {
+            LaboratoryId: laboratoryId,
+            Sk: skTag(tagId),
+            TagId: tagId,
+            Name: trimmedName,
+            ColorHex: colorHex,
+            Kind: 'workflow',
+            Platform: args.platform,
+            WorkflowExternalId: args.externalId,
+            WorkflowVersionName: versionKey,
+            FileCount: 0,
+            Gsi1Pk: gpk,
+            Gsi1Sk: gsk,
+            CreatedAt: now,
+            CreatedBy: userId,
+            ModifiedAt: now,
+            ModifiedBy: userId,
+          },
+          { removeUndefinedValues: true },
+        ),
+        ConditionExpression: 'attribute_not_exists(#pk) AND attribute_not_exists(#sk)',
+        ExpressionAttributeNames: { '#pk': 'LaboratoryId', '#sk': 'Sk' },
+      });
+    } catch (e: unknown) {
+      if (isConditionalCheckFailed(e)) {
+        const won = await this.findWorkflowTagByIdentity(laboratoryId, args);
+        if (won) {
+          return won;
+        }
+        const row = await this.getTagRow(laboratoryId, tagId);
+        if (row) {
+          return row;
+        }
+      }
+      throw e;
+    }
 
     return {
       TagId: tagId,
@@ -357,7 +406,7 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
       Kind: 'workflow',
       Platform: args.platform,
       WorkflowExternalId: args.externalId,
-      WorkflowVersionName: args.versionName ?? '',
+      WorkflowVersionName: versionKey,
       FileCount: 0,
       CreatedAt: now,
       CreatedBy: userId,
@@ -616,6 +665,10 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
    * Idempotently associate a set of input file keys with a workflow tag. The keys must lie under
    * the laboratory prefix; bucket validation is performed by the caller via `assertBucketMatchesLab`.
    * Re-applying the same workflow tag to a file is a no-op (no FileCount drift, no duplicate MAP rows).
+   *
+   * Uses an atomic DynamoDB `UpdateItem` (list_append + NOT contains) so concurrent launches cannot
+   * drop each other's workflow ids on the same FILE# row; MAP rows and FileCount are updated only
+   * when a new MAP link is inserted.
    */
   public async applyWorkflowToFiles(
     laboratory: Laboratory,
@@ -638,32 +691,68 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
     for (const key of keys) {
       this.assertKeyUnderLabPrefix(laboratory, key);
       const ref = encodeS3ObjectRef(bucket, key);
-      const existing = await this.getFileRow(laboratoryId, ref);
-      const tagIds = new Set<string>(existing?.TagIds || []);
-
-      if (tagIds.has(workflowTagId)) continue;
-
-      tagIds.add(workflowTagId);
-      await this.putMapRow(laboratoryId, workflowTagId, ref, bucket, key);
-      await this.adjustTagFileCount(laboratoryId, workflowTagId, 1);
-
-      const now = new Date().toISOString();
-      await this.putItem({
-        TableName: TABLE_NAME,
-        Item: marshall(
-          {
-            LaboratoryId: laboratoryId,
-            Sk: skFile(ref),
-            S3Bucket: bucket,
-            ObjectKey: key,
-            TagIds: [...tagIds],
-            ModifiedAt: now,
-            ModifiedBy: userId,
-          },
-          { removeUndefinedValues: true },
-        ),
-      });
+      await this.applyWorkflowToSingleFileKey(laboratoryId, userId, workflowTagId, bucket, key, ref);
     }
+  }
+
+  /**
+   * Atomically appends the workflow tag id to the file row's TagIds list when absent, then
+   * ensures a MAP# row exists (insert-only). Heals a missing MAP row when the file row already
+   * lists the workflow (e.g. partial failure or client retry).
+   */
+  private async applyWorkflowToSingleFileKey(
+    laboratoryId: string,
+    userId: string,
+    workflowTagId: string,
+    bucket: string,
+    key: string,
+    ref: string,
+  ): Promise<void> {
+    const ensureMapAndCount = async (): Promise<void> => {
+      const mapInserted = await this.putMapRowIfAbsent(laboratoryId, workflowTagId, ref, bucket, key);
+      if (mapInserted) {
+        await this.adjustTagFileCount(laboratoryId, workflowTagId, 1);
+      }
+    };
+
+    const existing = await this.getFileRow(laboratoryId, ref);
+    if (existing?.TagIds?.includes(workflowTagId)) {
+      await ensureMapAndCount();
+      return;
+    }
+
+    const now = new Date().toISOString();
+    try {
+      await this.updateItem({
+        TableName: TABLE_NAME,
+        Key: marshall({ LaboratoryId: laboratoryId, Sk: skFile(ref) }),
+        UpdateExpression:
+          'SET #tid = list_append(if_not_exists(#tid, :empty), :one), ModifiedBy = :mb, ModifiedAt = :ma, #sb = if_not_exists(#sb, :bucket), #ok = if_not_exists(#ok, :objectKey)',
+        ExpressionAttributeNames: {
+          '#tid': 'TagIds',
+          '#sb': 'S3Bucket',
+          '#ok': 'ObjectKey',
+        },
+        ExpressionAttributeValues: marshall({
+          ':empty': [],
+          ':one': [workflowTagId],
+          ':mb': userId,
+          ':ma': now,
+          ':bucket': bucket,
+          ':objectKey': key,
+          ':wfElem': workflowTagId,
+        }),
+        ConditionExpression: 'attribute_not_exists(#tid) OR NOT contains(#tid, :wfElem)',
+      });
+    } catch (e: unknown) {
+      if (isConditionalCheckFailed(e)) {
+        await ensureMapAndCount();
+        return;
+      }
+      throw e;
+    }
+
+    await ensureMapAndCount();
   }
 
   public async listFilesByTag(
@@ -917,6 +1006,43 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
         { removeUndefinedValues: true },
       ),
     });
+  }
+
+  /** Returns true if a new MAP# row was written; false if it already existed. */
+  private async putMapRowIfAbsent(
+    laboratoryId: string,
+    tagId: string,
+    ref: string,
+    bucket: string,
+    key: string,
+  ): Promise<boolean> {
+    const now = new Date().toISOString();
+    try {
+      await this.putItem({
+        TableName: TABLE_NAME,
+        Item: marshall(
+          {
+            LaboratoryId: laboratoryId,
+            Sk: skMap(tagId, ref),
+            Gsi1Pk: gsi1PkForTag(laboratoryId, tagId),
+            Gsi1Sk: ref,
+            S3Bucket: bucket,
+            ObjectKey: key,
+            TagId: tagId,
+            CreatedAt: now,
+          },
+          { removeUndefinedValues: true },
+        ),
+        ConditionExpression: 'attribute_not_exists(#sk)',
+        ExpressionAttributeNames: { '#sk': 'Sk' },
+      });
+      return true;
+    } catch (e: unknown) {
+      if (isConditionalCheckFailed(e)) {
+        return false;
+      }
+      throw e;
+    }
   }
 
   private async deleteMapIfExists(laboratoryId: string, tagId: string, ref: string): Promise<void> {

--- a/packages/back-end/src/app/services/easy-genomics/laboratory-data-tagging-service.ts
+++ b/packages/back-end/src/app/services/easy-genomics/laboratory-data-tagging-service.ts
@@ -8,12 +8,39 @@ import {
   ListFilesByTagResponse,
   ListLaboratoryDataTagsResponse,
   S3TaggedObjectRef,
+  WorkflowPlatform,
 } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/data-collections';
 import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
 import { DynamoDBService } from '../dynamodb-service';
 
 const TABLE_NAME = `${process.env.NAME_PREFIX}-laboratory-data-tagging-table`;
 const GSI1_NAME = 'Gsi1Pk_Index';
+
+/**
+ * Deterministic palette used for auto-assigned workflow tag colors. Mirrors the
+ * preset palette exposed in the data tagging UI so workflow chips look at home
+ * next to user-created tags.
+ */
+const WORKFLOW_TAG_COLOR_PALETTE = ['#5B4FD4', '#85B7EB', '#F09595', '#97C459', '#ED93B1', '#EF9F27', '#B4B2A9'];
+
+/** 2^32 — wraps the running hash to an unsigned 32-bit range without bitwise operators (satisfies no-bitwise lint). */
+const UINT32_RANGE = 2 ** 32;
+
+function pickWorkflowTagColor(seed: string): string {
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) {
+    h = (h * 31 + seed.charCodeAt(i)) % UINT32_RANGE;
+  }
+  return WORKFLOW_TAG_COLOR_PALETTE[h % WORKFLOW_TAG_COLOR_PALETTE.length];
+}
+
+function workflowGsiSk(platform: WorkflowPlatform, externalId: string, versionName?: string): string {
+  return `${platform}#${externalId}#${versionName ?? ''}`;
+}
+
+function workflowGsiPk(laboratoryId: string): string {
+  return `${laboratoryId}#WORKFLOW`;
+}
 
 export function encodeS3ObjectRef(bucket: string, key: string): string {
   return Buffer.from(JSON.stringify({ bucket, key }), 'utf8').toString('base64url');
@@ -68,23 +95,36 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
       },
     });
 
-    const tags: LaboratoryDataTag[] = (response.Items || []).map((item) => {
-      const row = unmarshall(item) as Record<string, unknown>;
-      const kind: LaboratoryDataTagKind = row.Kind === 'batch' ? 'batch' : 'standard';
-      return {
-        TagId: row.TagId as string,
-        Name: row.Name as string,
-        ColorHex: row.ColorHex as string,
-        ...(kind === 'batch' ? { Kind: 'batch' as const } : {}),
-        FileCount: Number(row.FileCount ?? 0),
-        CreatedAt: row.CreatedAt as string | undefined,
-        CreatedBy: row.CreatedBy as string | undefined,
-        ModifiedAt: row.ModifiedAt as string | undefined,
-        ModifiedBy: row.ModifiedBy as string | undefined,
-      };
-    });
+    const tags: LaboratoryDataTag[] = (response.Items || []).map((item) =>
+      this.tagRowToModel(unmarshall(item) as Record<string, unknown>),
+    );
     tags.sort((a, b) => a.Name.localeCompare(b.Name));
     return { Tags: tags };
+  }
+
+  /** Converts a raw TAG row from DynamoDB into the shared LaboratoryDataTag model. */
+  private tagRowToModel(row: Record<string, unknown>): LaboratoryDataTag {
+    const rawKind = typeof row.Kind === 'string' ? (row.Kind as string) : 'standard';
+    const kind: LaboratoryDataTagKind =
+      rawKind === 'batch' ? 'batch' : rawKind === 'workflow' ? 'workflow' : 'standard';
+    return {
+      TagId: row.TagId as string,
+      Name: row.Name as string,
+      ColorHex: row.ColorHex as string,
+      ...(kind !== 'standard' ? { Kind: kind } : {}),
+      FileCount: Number(row.FileCount ?? 0),
+      ...(kind === 'workflow'
+        ? {
+            Platform: row.Platform as WorkflowPlatform | undefined,
+            WorkflowExternalId: row.WorkflowExternalId as string | undefined,
+            WorkflowVersionName: row.WorkflowVersionName as string | undefined,
+          }
+        : {}),
+      CreatedAt: row.CreatedAt as string | undefined,
+      CreatedBy: row.CreatedBy as string | undefined,
+      ModifiedAt: row.ModifiedAt as string | undefined,
+      ModifiedBy: row.ModifiedBy as string | undefined,
+    };
   }
 
   public async createTag(
@@ -94,10 +134,18 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
     colorHex: string,
     kind: LaboratoryDataTagKind = 'standard',
   ): Promise<LaboratoryDataTag> {
+    if (kind === 'workflow') {
+      throw new Error('Workflow tags cannot be created directly; use getOrCreateWorkflowTag.');
+    }
     const laboratoryId = laboratory.LaboratoryId;
     const existing = await this.listTags(laboratoryId);
     const normalized = name.trim().toLowerCase();
-    if (existing.Tags.some((t) => t.Name.trim().toLowerCase() === normalized)) {
+    // Workflow tags are namespaced by (Platform, WorkflowExternalId, WorkflowVersionName) and are
+    // allowed to share display names with user-created tags, so they are excluded from the
+    // user-tag uniqueness check.
+    if (
+      existing.Tags.some((t) => (t.Kind ?? 'standard') !== 'workflow' && t.Name.trim().toLowerCase() === normalized)
+    ) {
       throw new Error('A tag with this name already exists');
     }
 
@@ -140,6 +188,86 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
     };
   }
 
+  /**
+   * Workflow tags are auto-created when a run is launched (or backfilled). Each unique
+   * (laboratoryId, platform, workflowExternalId, workflowVersionName) tuple gets its own tag,
+   * looked up via GSI `Gsi1Pk_Index` so we don't have to scan the partition.
+   */
+  public async getOrCreateWorkflowTag(
+    laboratory: Laboratory,
+    userId: string,
+    args: {
+      platform: WorkflowPlatform;
+      externalId: string;
+      versionName?: string;
+      name: string;
+    },
+  ): Promise<LaboratoryDataTag> {
+    const laboratoryId = laboratory.LaboratoryId;
+    const gpk = workflowGsiPk(laboratoryId);
+    const gsk = workflowGsiSk(args.platform, args.externalId, args.versionName);
+
+    const existing: QueryCommandOutput = await this.queryItems({
+      TableName: TABLE_NAME,
+      IndexName: GSI1_NAME,
+      KeyConditionExpression: '#gpk = :gpk AND #gsk = :gsk',
+      ExpressionAttributeNames: { '#gpk': 'Gsi1Pk', '#gsk': 'Gsi1Sk' },
+      ExpressionAttributeValues: { ':gpk': { S: gpk }, ':gsk': { S: gsk } },
+      Limit: 1,
+    });
+
+    if ((existing.Items || []).length > 0) {
+      return this.tagRowToModel(unmarshall(existing.Items![0]) as Record<string, unknown>);
+    }
+
+    const tagId = randomUUID();
+    const now = new Date().toISOString();
+    const trimmedName = args.name.trim() || args.externalId;
+    const colorHex = pickWorkflowTagColor(`${args.platform}#${args.externalId}`);
+
+    await this.putItem({
+      TableName: TABLE_NAME,
+      Item: marshall(
+        {
+          LaboratoryId: laboratoryId,
+          Sk: skTag(tagId),
+          TagId: tagId,
+          Name: trimmedName,
+          ColorHex: colorHex,
+          Kind: 'workflow',
+          Platform: args.platform,
+          WorkflowExternalId: args.externalId,
+          WorkflowVersionName: args.versionName ?? '',
+          FileCount: 0,
+          Gsi1Pk: gpk,
+          Gsi1Sk: gsk,
+          CreatedAt: now,
+          CreatedBy: userId,
+          ModifiedAt: now,
+          ModifiedBy: userId,
+        },
+        { removeUndefinedValues: true },
+      ),
+      ConditionExpression: 'attribute_not_exists(#pk) AND attribute_not_exists(#sk)',
+      ExpressionAttributeNames: { '#pk': 'LaboratoryId', '#sk': 'Sk' },
+    });
+
+    return {
+      TagId: tagId,
+      Name: trimmedName,
+      ColorHex: colorHex,
+      Kind: 'workflow',
+      Platform: args.platform,
+      WorkflowExternalId: args.externalId,
+      WorkflowVersionName: args.versionName ?? '',
+      FileCount: 0,
+      CreatedAt: now,
+      CreatedBy: userId,
+      ModifiedAt: now,
+      ModifiedBy: userId,
+    };
+  }
+
   public async updateTag(
     laboratoryId: string,
     tagId: string,
@@ -151,6 +279,9 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
     if (!existingRow) {
       throw new Error('Tag not found');
     }
+    if (existingRow.Kind === 'workflow') {
+      throw new Error('Workflow tags are auto-managed and cannot be edited');
+    }
 
     const nextName = name !== undefined ? name.trim() : existingRow.Name;
     const nextColor = colorHex !== undefined ? colorHex : existingRow.ColorHex;
@@ -159,7 +290,12 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
     if (name !== undefined) {
       const existing = await this.listTags(laboratoryId);
       const normalized = nextName.toLowerCase();
-      if (existing.Tags.some((t) => t.TagId !== tagId && t.Name.trim().toLowerCase() === normalized)) {
+      if (
+        existing.Tags.some(
+          (t) =>
+            t.TagId !== tagId && (t.Kind ?? 'standard') !== 'workflow' && t.Name.trim().toLowerCase() === normalized,
+        )
+      ) {
         throw new Error('A tag with this name already exists');
       }
     }
@@ -275,7 +411,7 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
 
   public async listFileTags(laboratoryId: string, bucket: string, keys: string[]): Promise<FileTagAssignment[]> {
     const out: FileTagAssignment[] = [];
-    const batchTagIds = await this.getBatchTagIdSet(laboratoryId);
+    const { batchTagIds, workflowTagIds } = await this.getKindIndexedTagIds(laboratoryId);
 
     for (let i = 0; i < keys.length; i += 100) {
       const batchKeys = keys.slice(i, i + 100);
@@ -304,19 +440,80 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
         const sk = dynamoKeys[j].Sk;
         const rawIds = bySk.get(sk) || [];
         const standard: string[] = [];
+        const workflowIds: string[] = [];
         let batchTagId: string | undefined;
         for (const id of rawIds) {
           if (batchTagIds.has(id)) {
             batchTagId = id;
+          } else if (workflowTagIds.has(id)) {
+            workflowIds.push(id);
           } else {
             standard.push(id);
           }
         }
-        out.push({ Key: key, TagIds: standard, ...(batchTagId ? { BatchTagId: batchTagId } : {}) });
+        out.push({
+          Key: key,
+          TagIds: standard,
+          WorkflowTagIds: workflowIds,
+          ...(batchTagId ? { BatchTagId: batchTagId } : {}),
+        });
       }
     }
 
     return out;
+  }
+
+  /**
+   * Idempotently associate a set of input file keys with a workflow tag. The keys must lie under
+   * the laboratory prefix; bucket validation is performed by the caller via `assertBucketMatchesLab`.
+   * Re-applying the same workflow tag to a file is a no-op (no FileCount drift, no duplicate MAP rows).
+   */
+  public async applyWorkflowToFiles(
+    laboratory: Laboratory,
+    userId: string,
+    workflowTagId: string,
+    bucket: string,
+    keys: string[],
+  ): Promise<void> {
+    if (!keys.length) return;
+    const laboratoryId = laboratory.LaboratoryId;
+    this.assertBucketMatchesLab(laboratory, bucket);
+
+    const tagRow = await this.getTagRow(laboratoryId, workflowTagId);
+    if (!tagRow) throw new Error(`Unknown tag: ${workflowTagId}`);
+    if (tagRow.Kind !== 'workflow') {
+      throw new Error('applyWorkflowToFiles can only be used with workflow-kind tags');
+    }
+
+    for (const key of keys) {
+      this.assertKeyUnderLabPrefix(laboratory, key);
+      const ref = encodeS3ObjectRef(bucket, key);
+      const existing = await this.getFileRow(laboratoryId, ref);
+      const tagIds = new Set<string>(existing?.TagIds || []);
+
+      if (tagIds.has(workflowTagId)) continue;
+
+      tagIds.add(workflowTagId);
+      await this.putMapRow(laboratoryId, workflowTagId, ref, bucket, key);
+      await this.adjustTagFileCount(laboratoryId, workflowTagId, 1);
+
+      const now = new Date().toISOString();
+      await this.putItem({
+        TableName: TABLE_NAME,
+        Item: marshall(
+          {
+            LaboratoryId: laboratoryId,
+            Sk: skFile(ref),
+            S3Bucket: bucket,
+            ObjectKey: key,
+            TagIds: [...tagIds],
+            ModifiedAt: now,
+            ModifiedBy: userId,
+          },
+          { removeUndefinedValues: true },
+        ),
+      });
+    }
   }
 
   public async listFilesByTag(
@@ -373,10 +570,16 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
     for (const tagId of add) {
       const t = await this.getTagRow(laboratoryId, tagId);
       if (!t) throw new Error(`Unknown tag: ${tagId}`);
+      if (t.Kind === 'workflow') {
+        throw new Error('Workflow tags are auto-managed and cannot be added through this API');
+      }
     }
     for (const tagId of remove) {
       const t = await this.getTagRow(laboratoryId, tagId);
       if (!t) throw new Error(`Unknown tag: ${tagId}`);
+      if (t.Kind === 'workflow') {
+        throw new Error('Workflow tags are auto-managed and cannot be removed through this API');
+      }
     }
 
     for (const key of keys) {
@@ -519,6 +722,24 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
     return new Set(Tags.filter((t) => (t.Kind ?? 'standard') === 'batch').map((t) => t.TagId));
   }
 
+  /**
+   * Single-pass tag listing that returns the batch and workflow tag id sets used to
+   * partition file rows in `listFileTags`. Avoids two `listTags` round-trips on hot paths.
+   */
+  private async getKindIndexedTagIds(
+    laboratoryId: string,
+  ): Promise<{ batchTagIds: Set<string>; workflowTagIds: Set<string> }> {
+    const { Tags } = await this.listTags(laboratoryId);
+    const batchTagIds = new Set<string>();
+    const workflowTagIds = new Set<string>();
+    for (const t of Tags) {
+      const kind = t.Kind ?? 'standard';
+      if (kind === 'batch') batchTagIds.add(t.TagId);
+      else if (kind === 'workflow') workflowTagIds.add(t.TagId);
+    }
+    return { batchTagIds, workflowTagIds };
+  }
+
   private async putMapRow(
     laboratoryId: string,
     tagId: string,
@@ -556,24 +777,16 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
     const row = await this.getTagRow(laboratoryId, tagId);
     if (!row) return;
     const next = Math.max(0, (row.FileCount || 0) + delta);
-    await this.putItem({
+    // UpdateItem (rather than putItem) so we don't accidentally drop kind-specific attributes
+    // (Platform/WorkflowExternalId/WorkflowVersionName) or GSI keys on workflow-kind tag rows.
+    await this.updateItem({
       TableName: TABLE_NAME,
-      Item: marshall(
-        {
-          LaboratoryId: laboratoryId,
-          Sk: skTag(tagId),
-          TagId: row.TagId,
-          Name: row.Name,
-          ColorHex: row.ColorHex,
-          ...(row.Kind === 'batch' ? { Kind: 'batch' as const } : {}),
-          FileCount: next,
-          CreatedAt: row.CreatedAt,
-          CreatedBy: row.CreatedBy,
-          ModifiedAt: new Date().toISOString(),
-          ModifiedBy: row.ModifiedBy,
-        },
-        { removeUndefinedValues: true },
-      ),
+      Key: marshall({ LaboratoryId: laboratoryId, Sk: skTag(tagId) }),
+      UpdateExpression: 'SET FileCount = :n, ModifiedAt = :ma',
+      ExpressionAttributeValues: marshall({
+        ':n': next,
+        ':ma': new Date().toISOString(),
+      }),
     });
   }
 
@@ -583,18 +796,7 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
       Key: marshall({ LaboratoryId: laboratoryId, Sk: skTag(tagId) }),
     });
     if (!res.Item) return null;
-    const row = unmarshall(res.Item) as Record<string, unknown>;
-    return {
-      TagId: row.TagId as string,
-      Name: row.Name as string,
-      ColorHex: row.ColorHex as string,
-      ...(row.Kind === 'batch' ? { Kind: 'batch' as const } : {}),
-      FileCount: Number(row.FileCount ?? 0),
-      CreatedAt: row.CreatedAt as string | undefined,
-      CreatedBy: row.CreatedBy as string | undefined,
-      ModifiedAt: row.ModifiedAt as string | undefined,
-      ModifiedBy: row.ModifiedBy as string | undefined,
-    };
+    return this.tagRowToModel(unmarshall(res.Item) as Record<string, unknown>);
   }
 
   private async getFileRow(

--- a/packages/back-end/src/app/services/sns-service.ts
+++ b/packages/back-end/src/app/services/sns-service.ts
@@ -6,43 +6,43 @@ import {
   SNSServiceException,
 } from '@aws-sdk/client-sns';
 
-export enum SnsCommand {
-  PUBLISH = 'publish',
-}
+/** Region segment in `arn:aws:sns:<region>:...` */
+const SNS_TOPIC_ARN_REGION = /^arn:aws:sns:([a-z0-9-]+):/;
 
 export class SnsService {
-  private readonly snsClient;
+  private readonly clientsByRegion = new Map<string, SNSClient>();
+  private readonly fallbackRegion = process.env.AWS_REGION ?? process.env.REGION;
 
-  public constructor() {
-    this.snsClient = new SNSClient();
+  /**
+   * SNS Publish must target the topic's region. Using the default client region
+   * while `TopicArn` points elsewhere yields InvalidParameter errors locally
+   * when REGION and copied topic ARNs disagree.
+   */
+  private clientForTopicArn(topicArn: string | undefined): SNSClient {
+    const m = topicArn?.match(SNS_TOPIC_ARN_REGION);
+    const region = m?.[1] ?? this.fallbackRegion;
+    if (!region) {
+      return new SNSClient();
+    }
+    let client = this.clientsByRegion.get(region);
+    if (!client) {
+      client = new SNSClient({ region });
+      this.clientsByRegion.set(region, client);
+    }
+    return client;
   }
 
   public publish = async (publishCommandInput: PublishCommandInput): Promise<PublishCommandOutput> => {
-    return this.snsRequest<PublishCommandInput, PublishCommandOutput>(SnsCommand.PUBLISH, publishCommandInput);
-  };
-
-  private snsRequest = async <RequestType, ResponseType>(
-    command: SnsCommand,
-    data?: RequestType,
-  ): Promise<ResponseType> => {
     try {
-      return (await this.snsClient.send(this.getSnsCommand(command, data))) as ResponseType;
+      const client = this.clientForTopicArn(publishCommandInput.TopicArn);
+      return await client.send(new PublishCommand(publishCommandInput));
     } catch (error: any) {
-      console.error(`[sns-service : snsRequest] command: ${command} exception encountered:`, error);
+      console.error('[sns-service : publish] exception encountered:', error);
       throw this.handleError(error);
     }
   };
 
   private handleError = (error: any): SNSServiceException => {
     return error as SNSServiceException; // Base Exception
-  };
-
-  private getSnsCommand = (command: SnsCommand, data: unknown): any => {
-    switch (command) {
-      case SnsCommand.PUBLISH:
-        return new PublishCommand(data as PublishCommandInput);
-      default:
-        throw new Error(`Unsupported SNS Management Command '${command}'`);
-    }
   };
 }

--- a/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
@@ -959,6 +959,23 @@ export class EasyGenomicsNestedStack extends NestedStack {
         actions: ['dynamodb:Query'],
         effect: Effect.ALLOW,
       }),
+      // Data tagging table: best-effort association of input files with the workflow tag.
+      // create-laboratory-run reads/writes TAG/FILE/MAP rows via LaboratoryDataTaggingService.
+      new PolicyStatement({
+        resources: [
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-data-tagging-table`,
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-data-tagging-table/index/*`,
+        ],
+        actions: [
+          'dynamodb:GetItem',
+          'dynamodb:PutItem',
+          'dynamodb:UpdateItem',
+          'dynamodb:DeleteItem',
+          'dynamodb:Query',
+          'dynamodb:BatchGetItem',
+        ],
+        effect: Effect.ALLOW,
+      }),
       new PolicyStatement({
         resources: [`${this.sns.snsTopics.get('laboratory-run-update-topic')?.topicArn || ''}`],
         actions: ['sns:Publish'],

--- a/packages/back-end/src/local-server/index.ts
+++ b/packages/back-end/src/local-server/index.ts
@@ -6,7 +6,7 @@
 import path from 'path';
 import { ACCESS_CONTROL_ALLOW_HEADERS } from '@easy-genomics/shared-lib/lib/app/utils/common';
 import dotenv from 'dotenv';
-import express, { type Request, type Response } from 'express';
+import express, { type NextFunction, type Request, type Response } from 'express';
 import { runAuth, attachClaimsToEvent, sendUnauthorizedIfNeeded } from './auth-middleware';
 import { buildApiGatewayEvent } from './event-builder';
 import { invokeHandler } from './lambda-invoker';
@@ -106,10 +106,11 @@ function main(): void {
     });
   }
 
-  app.use((err: Error, _req: Request, res: Response) => {
+  app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
+    void _next;
     console.error('[local-server] Unhandled error', err);
     res.status(500).json({
-      Error: err.message || 'Internal server error',
+      Error: err instanceof Error ? err.message : 'Internal server error',
       ErrorCode: 'EG-100',
     });
   });

--- a/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/create-laboratory-run.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/create-laboratory-run.lambda.test.ts
@@ -3,6 +3,7 @@ import { handler } from '../../../../../../src/app/controllers/easy-genomics/lab
 
 jest.mock('../../../../../../src/app/services/easy-genomics/laboratory-run-service');
 jest.mock('../../../../../../src/app/services/easy-genomics/laboratory-service');
+jest.mock('../../../../../../src/app/services/easy-genomics/laboratory-data-tagging-service');
 jest.mock('../../../../../../src/app/services/sns-service');
 jest.mock('../../../../../../src/app/utils/auth-utils');
 

--- a/packages/back-end/test/app/services/easy-genomics/laboratory-data-tagging-service.test.ts
+++ b/packages/back-end/test/app/services/easy-genomics/laboratory-data-tagging-service.test.ts
@@ -231,3 +231,125 @@ describe('LaboratoryDataTaggingService.applyTagsToFiles', () => {
     );
   });
 });
+
+describe('LaboratoryDataTaggingService.listTags', () => {
+  let svc: LaboratoryDataTaggingService;
+  let mockQueryItems: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    svc = new LaboratoryDataTaggingService();
+    mockQueryItems = jest.fn().mockResolvedValue({ Items: [] });
+    (svc as unknown as { queryItems: typeof mockQueryItems }).queryItems = mockQueryItems;
+  });
+
+  it('infers workflow Kind from Gsi1Sk when Kind, Platform, and Gsi1Pk are missing', async () => {
+    const lab = labFixture();
+    const wfTagId = 'wf111111-1111-4111-8111-111111111111';
+    mockQueryItems.mockResolvedValue({
+      Items: [
+        marshall({
+          LaboratoryId: lab.LaboratoryId,
+          Sk: `TAG#${wfTagId}`,
+          TagId: wfTagId,
+          Name: 'nf-core/rnaseq',
+          ColorHex: '#5B4FD4',
+          FileCount: 3,
+          Gsi1Sk: 'AWS HealthOmics#seed-omics-rnaseq#3.14.0',
+        }),
+      ],
+    });
+
+    const { Tags } = await svc.listTags(lab.LaboratoryId);
+    expect(Tags).toHaveLength(1);
+    expect(Tags[0].Kind).toBe('workflow');
+    expect(Tags[0].Platform).toBe('AWS HealthOmics');
+    expect(Tags[0].WorkflowExternalId).toBe('seed-omics-rnaseq');
+    expect(Tags[0].WorkflowVersionName).toBe('3.14.0');
+  });
+});
+
+describe('LaboratoryDataTaggingService.listFileTags', () => {
+  let svc: LaboratoryDataTaggingService;
+  let mockQueryItems: jest.Mock;
+  let mockBatchGetItem: jest.Mock;
+
+  const tableName = `${process.env.NAME_PREFIX}-laboratory-data-tagging-table`;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    svc = new LaboratoryDataTaggingService();
+    mockQueryItems = jest.fn().mockResolvedValue({ Items: [] });
+    mockBatchGetItem = jest.fn();
+    (svc as unknown as { queryItems: typeof mockQueryItems }).queryItems = mockQueryItems;
+    (svc as unknown as { batchGetItem: typeof mockBatchGetItem }).batchGetItem = mockBatchGetItem;
+  });
+
+  it('classifies workflow tag ids via BatchGetItem when listTags returns no workflow rows yet', async () => {
+    const lab = labFixture();
+    const bucket = lab.S3Bucket!;
+    const key = 'org-1/lab-1/reads.fq.gz';
+    const wfTagId = 'aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeeeee';
+    const stdTagId = 'bbbbbbbb-cccc-4ddd-eeee-ffffffffffff';
+    const ref = encodeS3ObjectRef(bucket, key);
+
+    mockQueryItems.mockResolvedValue({ Items: [] });
+
+    mockBatchGetItem.mockImplementation(async (cmd: { RequestItems?: Record<string, { Keys?: unknown[] }> }) => {
+      const keys = (cmd.RequestItems?.[tableName]?.Keys || []) as Record<string, AttributeValue>[];
+      const rows: Record<string, AttributeValue>[] = [];
+      for (const k of keys) {
+        const row = unmarshall(k) as { Sk: string; LaboratoryId: string };
+        if (row.Sk === `FILE#${ref}`) {
+          rows.push(
+            marshall({
+              LaboratoryId: lab.LaboratoryId,
+              Sk: row.Sk,
+              S3Bucket: bucket,
+              ObjectKey: key,
+              TagIds: [wfTagId, stdTagId],
+            }),
+          );
+        } else if (row.Sk === `TAG#${wfTagId}`) {
+          rows.push(
+            marshall({
+              LaboratoryId: lab.LaboratoryId,
+              Sk: row.Sk,
+              TagId: wfTagId,
+              Name: 'nf-core/rnaseq',
+              Kind: 'workflow',
+              Platform: 'AWS HealthOmics',
+              WorkflowExternalId: 'wf-ext',
+              ColorHex: '#5B4FD4',
+              FileCount: 2,
+            }),
+          );
+        } else if (row.Sk === `TAG#${stdTagId}`) {
+          rows.push(
+            marshall({
+              LaboratoryId: lab.LaboratoryId,
+              Sk: row.Sk,
+              TagId: stdTagId,
+              Name: 'My label',
+              ColorHex: '#111111',
+              FileCount: 1,
+            }),
+          );
+        }
+      }
+
+      return {
+        Responses: {
+          [tableName]: rows,
+        },
+      };
+    });
+
+    const assignments = await svc.listFileTags(lab.LaboratoryId, bucket, [key]);
+
+    expect(assignments).toHaveLength(1);
+    expect(assignments[0].TagIds).toEqual([stdTagId]);
+    expect(assignments[0].WorkflowTagIds).toEqual([wfTagId]);
+    expect(mockBatchGetItem).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/back-end/test/app/services/easy-genomics/laboratory-data-tagging-service.test.ts
+++ b/packages/back-end/test/app/services/easy-genomics/laboratory-data-tagging-service.test.ts
@@ -53,6 +53,7 @@ describe('LaboratoryDataTaggingService.applyTagsToFiles', () => {
   let mockPutItem: jest.Mock;
   let mockDeleteItem: jest.Mock;
   let mockQueryItems: jest.Mock;
+  let mockUpdateItem: jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -61,10 +62,12 @@ describe('LaboratoryDataTaggingService.applyTagsToFiles', () => {
     mockPutItem = jest.fn().mockResolvedValue({});
     mockDeleteItem = jest.fn().mockResolvedValue({});
     mockQueryItems = jest.fn().mockResolvedValue({ Items: [] });
+    mockUpdateItem = jest.fn().mockResolvedValue({});
     (svc as unknown as { getItem: typeof mockGetItem }).getItem = mockGetItem;
     (svc as unknown as { putItem: typeof mockPutItem }).putItem = mockPutItem;
     (svc as unknown as { deleteItem: typeof mockDeleteItem }).deleteItem = mockDeleteItem;
     (svc as unknown as { queryItems: typeof mockQueryItems }).queryItems = mockQueryItems;
+    (svc as unknown as { updateItem: typeof mockUpdateItem }).updateItem = mockUpdateItem;
   });
 
   it('does not create duplicate MAP rows when re-applying the same tag to a file', async () => {

--- a/packages/front-end/env.nuxt.config.ts
+++ b/packages/front-end/env.nuxt.config.ts
@@ -28,7 +28,11 @@ export function loadNuxtSettings() {
 
   // Env var toggle: use local back-end without renaming/editing .env.nuxt.local
   if (LOCAL_BACKEND_VALUES.has(String(process.env.USE_LOCAL_BACKEND ?? '').toLowerCase())) {
-    process.env.AWS_API_GATEWAY_URL = (process.env.LOCAL_API_URL ?? DEFAULT_LOCAL_API_URL).replace(/\/+$/, '');
+    const localBase = (process.env.LOCAL_API_URL ?? DEFAULT_LOCAL_API_URL).replace(/\/+$/, '');
+    process.env.AWS_API_GATEWAY_URL = localBase;
+    // Split-stack deploys set AWS_EASY_GENOMICS_API_URL; HttpFactory prefers it over BASE_API_URL.
+    // Clear it for local so easy-genomics calls use the same local server as everything else.
+    process.env.AWS_EASY_GENOMICS_API_URL = '';
   }
 
   if (

--- a/packages/front-end/src/app/components/EGDataCollectionsExplorer.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsExplorer.vue
@@ -103,6 +103,42 @@
 
   const keyToBatchResolved = computed(() => props.keyToBatchTagId ?? {});
 
+  type BatchSectionHeaderParts = {
+    /** Batch display name (tag name); for unbatched rows this is `Unbatched`. */
+    titleBold: string;
+    sampleCount: number;
+    sampleNoun: string;
+    notYetAnalyzed: number;
+    analyzed: number;
+  };
+
+  const BATCH_HEADER_DOT_NOT_ANALYZED = '#EF9F27';
+  const BATCH_HEADER_DOT_ANALYZED = '#2DB48F';
+
+  function batchSectionHeaderParts(sec: {
+    batchId: string | null;
+    title: string;
+    files: readonly { Key: string }[];
+  }): BatchSectionHeaderParts {
+    const n = sec.files.length;
+    const sampleNoun = n === 1 ? 'sample' : 'samples';
+    const titleBold = sec.title;
+    let notYetAnalyzed = 0;
+    let analyzed = 0;
+    for (const f of sec.files) {
+      const ids = props.keyToWorkflowTagIds?.[f.Key];
+      if (ids && ids.length > 0) analyzed += 1;
+      else notYetAnalyzed += 1;
+    }
+    return {
+      titleBold,
+      sampleCount: n,
+      sampleNoun,
+      notYetAnalyzed,
+      analyzed,
+    };
+  }
+
   /** Group visible files by batch for section headers (single scroll, not nested folders). */
   const fileSections = computed(() => {
     type Row = (typeof props.visibleFiles)[number];
@@ -133,7 +169,10 @@
         files,
       });
     }
-    return sections;
+    return sections.map((sec) => ({
+      ...sec,
+      headerParts: batchSectionHeaderParts(sec),
+    }));
   });
 
   function batchDisplayName(key: string): string {
@@ -141,19 +180,6 @@
     if (!bid) return '—';
     const tag = batchTagsResolved.value.find((b: LaboratoryDataTag) => b.TagId === bid);
     return tag?.Name ?? bid;
-  }
-
-  function batchSectionHeading(sec: {
-    batchId: string | null;
-    title: string;
-    files: readonly { Key: string }[];
-  }): string {
-    const n = sec.files.length;
-    const samples = n === 1 ? 'sample' : 'samples';
-    if (sec.batchId === null) {
-      return `Unbatched · ${n} ${samples}`;
-    }
-    return `Batch ${sec.title} · ${n} ${samples}`;
   }
 
   function batchSectionFullySelected(sec: { files: readonly { Key: string }[] }): boolean {
@@ -205,9 +231,8 @@
     scrollEl.value?.querySelectorAll('[data-file-card]').forEach((el) => {
       const r = (el as HTMLElement).getBoundingClientRect();
       const hit = r.left < lr.right && r.right > lr.left && r.top < lr.bottom && r.bottom > lr.top;
-      (el as HTMLElement).classList.toggle('ring-2', hit);
-      (el as HTMLElement).classList.toggle('ring-primary', hit);
-      (el as HTMLElement).classList.toggle('bg-primary-muted', hit);
+      /** Lasso-only class — never strip Vue-bound `ring-*` on selected cards (Vue may not re-patch if props unchanged). */
+      (el as HTMLElement).classList.toggle('eg-data-collections-lasso-hit', hit);
     });
   }
 
@@ -218,11 +243,11 @@
     const added: string[] = [];
     scrollEl.value?.querySelectorAll('[data-file-card]').forEach((el) => {
       const h = el as HTMLElement;
-      if (h.classList.contains('ring-primary')) {
+      if (h.classList.contains('eg-data-collections-lasso-hit')) {
         const id = h.dataset.key;
         if (id) added.push(id);
       }
-      h.classList.remove('ring-2', 'ring-primary', 'bg-primary-muted');
+      h.classList.remove('eg-data-collections-lasso-hit');
     });
     if (added.length) {
       const s = new Set(props.selectedKeys);
@@ -327,19 +352,44 @@
       listing limit.
     </div>
 
-    <div ref="scrollEl" class="relative flex-1 overflow-auto p-4" @mousedown="onScrollHostMouseDown">
+    <div ref="scrollEl" class="relative flex-1 overflow-auto p-2" @mousedown="onScrollHostMouseDown">
       <div v-if="explorerView === 'cards'" class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
         <template v-for="(sec, secIdx) in fileSections" :key="sec.batchId ?? 'unbatched'">
           <div
             class="border-border-muted col-span-full flex items-start justify-between gap-3 border-b pb-2"
             :class="secIdx === 0 ? 'mt-0' : 'mt-6'"
           >
-            <h3 class="text-muted min-w-0 flex-1 text-xs font-normal leading-snug tracking-wide">
-              {{ batchSectionHeading(sec) }}
+            <h3 class="text-muted min-w-0 flex-1 whitespace-normal text-xs font-normal leading-snug tracking-wide">
+              <span class="inline-flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                <span class="inline-flex min-w-0 flex-wrap items-baseline gap-x-1.5">
+                  <span class="font-semibold text-gray-900">
+                    <template v-if="sec.batchId !== null">Batch {{ sec.headerParts.titleBold }}</template>
+                    <template v-else>{{ sec.headerParts.titleBold }}</template>
+                  </span>
+                  <span>{{ sec.headerParts.sampleCount }} {{ sec.headerParts.sampleNoun }}</span>
+                </span>
+                <span class="inline-flex items-center gap-1.5">
+                  <span
+                    class="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+                    :style="{ backgroundColor: BATCH_HEADER_DOT_NOT_ANALYZED }"
+                    aria-hidden="true"
+                  />
+                  <span>{{ sec.headerParts.notYetAnalyzed }} not yet analyzed</span>
+                </span>
+                <span class="inline-flex items-center gap-1.5">
+                  <span
+                    class="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+                    :style="{ backgroundColor: BATCH_HEADER_DOT_ANALYZED }"
+                    aria-hidden="true"
+                  />
+                  <span>{{ sec.headerParts.analyzed }} analyzed</span>
+                </span>
+              </span>
             </h3>
             <button
               type="button"
               class="text-primary shrink-0 text-xs font-normal hover:underline"
+              @mousedown.stop
               @click.stop="toggleBatchSection(sec)"
             >
               {{ batchSectionFullySelected(sec) ? 'Deselect batch' : 'Select batch' }}
@@ -352,7 +402,7 @@
             :data-key="f.Key"
             draggable="true"
             class="border-border-muted relative cursor-pointer rounded-xl border bg-white p-3 shadow-sm transition"
-            :class="{ 'ring-primary ring-2': selectedKeys.includes(f.Key) }"
+            :class="{ 'bg-primary-muted ring-primary ring-2': selectedKeys.includes(f.Key) }"
             @click="emit('toggleKey', f.Key)"
             @dragstart="onCardDragStart($event, f.Key)"
             @dragover="onCardDragOver"
@@ -403,13 +453,40 @@
             <template v-for="sec in fileSections" :key="sec.batchId ?? 'unbatched'">
               <tr class="bg-gray-50/95">
                 <td colspan="6" class="border-border-muted border-b px-3 py-2.5" scope="colgroup">
-                  <div class="flex items-center justify-between gap-4">
-                    <span class="text-muted min-w-0 flex-1 truncate text-xs font-normal leading-snug tracking-wide">
-                      {{ batchSectionHeading(sec) }}
+                  <div class="flex w-full min-w-0 flex-wrap items-start justify-between gap-x-3 gap-y-2">
+                    <span
+                      class="text-muted min-w-0 flex-1 whitespace-normal text-xs font-normal leading-snug tracking-wide"
+                    >
+                      <span class="inline-flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                        <span class="inline-flex min-w-0 flex-wrap items-baseline gap-x-1.5">
+                          <span class="font-semibold text-gray-900">
+                            <template v-if="sec.batchId !== null">Batch {{ sec.headerParts.titleBold }}</template>
+                            <template v-else>{{ sec.headerParts.titleBold }}</template>
+                          </span>
+                          <span>{{ sec.headerParts.sampleCount }} {{ sec.headerParts.sampleNoun }}</span>
+                        </span>
+                        <span class="inline-flex items-center gap-1.5">
+                          <span
+                            class="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+                            :style="{ backgroundColor: BATCH_HEADER_DOT_NOT_ANALYZED }"
+                            aria-hidden="true"
+                          />
+                          <span>{{ sec.headerParts.notYetAnalyzed }} not yet analyzed</span>
+                        </span>
+                        <span class="inline-flex items-center gap-1.5">
+                          <span
+                            class="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+                            :style="{ backgroundColor: BATCH_HEADER_DOT_ANALYZED }"
+                            aria-hidden="true"
+                          />
+                          <span>{{ sec.headerParts.analyzed }} analyzed</span>
+                        </span>
+                      </span>
                     </span>
                     <button
                       type="button"
-                      class="text-primary shrink-0 text-xs font-normal hover:underline"
+                      class="text-primary ml-auto shrink-0 self-start whitespace-nowrap text-xs font-normal hover:underline"
+                      @mousedown.stop
                       @click.stop="toggleBatchSection(sec)"
                     >
                       {{ batchSectionFullySelected(sec) ? 'Deselect batch' : 'Select batch' }}
@@ -425,7 +502,7 @@
                 draggable="true"
                 class="border-border-muted cursor-pointer border-b transition last:border-b-0"
                 :class="{
-                  'bg-primary-muted/50': selectedKeys.includes(f.Key),
+                  'bg-primary-muted ring-primary ring-2 ring-inset': selectedKeys.includes(f.Key),
                   'hover:bg-gray-50/80': !selectedKeys.includes(f.Key),
                 }"
                 @click="emit('toggleKey', f.Key)"
@@ -477,7 +554,7 @@
         <p class="font-medium text-gray-900">No files found under this lab’s prefix in this bucket</p>
       </div>
       <div v-else-if="allFilesHiddenByFilters" class="text-muted py-8 text-center text-sm">
-        No files match your current search or tag filter. Clear the search box or choose "All files" or "Untagged" in
+        No files match your current search or tag filter. Clear the search box or choose "All samples" or "Untagged" in
         the tag list.
       </div>
       <div
@@ -487,3 +564,11 @@
     </div>
   </div>
 </template>
+
+<style scoped>
+  /** Lasso drag highlight only — selection rings come from Vue `:class` on `[data-file-card]`. */
+  [data-file-card].eg-data-collections-lasso-hit {
+    box-shadow: 0 0 0 2px #5524e0;
+    background-color: #eee9fc;
+  }
+</style>

--- a/packages/front-end/src/app/components/EGDataCollectionsExplorer.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsExplorer.vue
@@ -25,6 +25,8 @@
     listingFileCount: number;
     /** Recursive listing stopped at MaxTotalKeys; more objects exist in S3. */
     listingTruncated?: boolean;
+    /** Active filter chips (scope + tags); each chip can be dismissed independently in the explorer header. */
+    filterChips?: { chipId: string; label: string }[];
   }>();
 
   const emit = defineEmits<{
@@ -33,8 +35,11 @@
     toggleKey: [key: string];
     selectAllDisplayed: [];
     clearSelection: [];
+    clearFilter: [chipId: string];
     removeTagFromFile: [payload: { key: string; tagId: string }];
   }>();
+
+  const filterChipsResolved = computed(() => props.filterChips ?? []);
 
   /** Cards grid vs tabular explorer layout. */
   const explorerView = ref<'cards' | 'table'>('cards');
@@ -98,6 +103,8 @@
   const allFilesHiddenByFilters = computed(
     () => !props.loading && props.listingFileCount > 0 && props.visibleFiles.length === 0,
   );
+
+  const visibleSampleNoun = computed(() => (props.visibleFiles.length === 1 ? 'sample' : 'samples'));
 
   const batchTagsResolved = computed(() => props.batchTags ?? []);
 
@@ -331,6 +338,29 @@
           @click="explorerView = 'table'"
         />
       </div>
+    </div>
+    <div class="border-border-muted flex flex-wrap items-center gap-2 border-b bg-gray-50 px-4 py-2">
+      <span class="text-xs font-semibold leading-snug text-gray-900">
+        {{ visibleFiles.length }} {{ visibleSampleNoun }}
+      </span>
+      <div class="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+        <div
+          v-for="chip in filterChipsResolved"
+          :key="chip.chipId"
+          class="bg-primary-muted text-primary-dark inline-flex max-w-full items-center gap-0.5 rounded-full border border-transparent py-0.5 pl-2 pr-0.5 text-xs font-medium"
+        >
+          <span class="min-w-0 max-w-[min(14rem,100%)] truncate">{{ chip.label }}</span>
+          <UButton
+            size="xs"
+            square
+            variant="ghost"
+            icon="i-heroicons-x-mark"
+            class="text-primary-dark shrink-0 rounded-full"
+            :aria-label="`Clear filter: ${chip.label}`"
+            @click="emit('clearFilter', chip.chipId)"
+          />
+        </div>
+      </div>
       <div class="ml-auto flex shrink-0">
         <UButton v-if="selectedKeys.length" size="xs" variant="ghost" @click="emit('clearSelection')">
           Deselect all ({{ selectedKeys.length }})
@@ -554,8 +584,7 @@
         <p class="font-medium text-gray-900">No files found under this lab’s prefix in this bucket</p>
       </div>
       <div v-else-if="allFilesHiddenByFilters" class="text-muted py-8 text-center text-sm">
-        No files match your current search or tag filter. Clear the search box or choose "All samples" or "Untagged" in
-        the tag list.
+        No files match your current search or filters. Clear the search box or adjust filters in the left panel.
       </div>
       <div
         class="border-primary bg-primary/10 pointer-events-none fixed z-[9999] rounded border-2"

--- a/packages/front-end/src/app/components/EGDataCollectionsExplorer.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsExplorer.vue
@@ -11,6 +11,11 @@
     keyToTagIds: Record<string, string[]>;
     /** Batch tag id per file key (optional until parent loads assignments). */
     keyToBatchTagId?: Record<string, string | undefined>;
+    /**
+     * Workflow tag ids per file key (optional until parent loads assignments). Used to drive
+     * the per-file Analyzed / Not yet analyzed status without an extra round-trip.
+     */
+    keyToWorkflowTagIds?: Record<string, string[]>;
     batchTags?: LaboratoryDataTag[];
     tags: LaboratoryDataTag[];
     selectedKeys: string[];
@@ -77,9 +82,15 @@
     return `${parts.join('/')}/`;
   }
 
-  /** Placeholder until workflow run state is wired per file. */
-  function fileAnalysisStatus(_key: string): 'Not yet analyzed' | 'Analyzed' {
-    return 'Not yet analyzed';
+  /**
+   * "Analyzed" iff the parent has recorded at least one workflow tag association for this
+   * file (via the data tagging system's per-run workflow tag). The mapping is sparse — files
+   * whose key is missing from the prop are treated as not analyzed, which matches the
+   * pre-existing UI default.
+   */
+  function fileAnalysisStatus(key: string): 'Not yet analyzed' | 'Analyzed' {
+    const ids = props.keyToWorkflowTagIds?.[key];
+    return ids && ids.length > 0 ? 'Analyzed' : 'Not yet analyzed';
   }
 
   /** No file objects returned for this listing (under lab prefix). */

--- a/packages/front-end/src/app/components/EGDataCollectionsPage.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsPage.vue
@@ -75,11 +75,68 @@
     return tags.value.find((t) => t.TagId === id);
   }
 
-  const standardTags = computed(() => tags.value.filter((t) => (t.Kind ?? 'standard') === 'standard'));
+  /** True for workflow tags — Kind may be omitted in some API payloads; platform + external id is definitive. */
+  function isWorkflowLaboratoryTag(t: LaboratoryDataTag | undefined): boolean {
+    if (!t) return false;
+    if (t.Kind === 'workflow') return true;
+    return !!(t.Platform && t.WorkflowExternalId);
+  }
+
+  /**
+   * Workflow tag ids for a file: prefer API `WorkflowTagIds`, else infer from raw `TagIds` using
+   * tag metadata (needed when list-file-tags mis-buckets or tags load after file assignments).
+   */
+  function workflowTagIdsForFileKey(key: string): string[] {
+    const fromApi = keyToWorkflowTagIds.value[key] ?? [];
+    const raw = keyToTagIds.value[key] ?? [];
+    const merged = new Set<string>(fromApi);
+    if (tags.value.length) {
+      for (const tid of raw) {
+        if (isWorkflowLaboratoryTag(tagById(tid))) {
+          merged.add(tid);
+        }
+      }
+    }
+    return [...merged];
+  }
+
+  const keyToWorkflowTagIdsEffective = computed(() => {
+    const m: Record<string, string[]> = {};
+    for (const f of files.value) {
+      m[f.Key] = workflowTagIdsForFileKey(f.Key);
+    }
+    return m;
+  });
+
+  /**
+   * Tag ids that belong in the generic (user) tag pill row. The API splits workflow ids into
+   * `WorkflowTagIds`, but mis-partitioning or missing `Kind` on list-tags must not show workflow
+   * chips in the standard row.
+   */
+  function standardTagIdsForFileKey(key: string): string[] {
+    const wf = new Set(workflowTagIdsForFileKey(key));
+    return (keyToTagIds.value[key] || []).filter((tid: string) => {
+      if (wf.has(tid)) return false;
+      if (isWorkflowLaboratoryTag(tagById(tid))) return false;
+      return true;
+    });
+  }
+
+  const keyToStandardTagIdsForExplorer = computed(() => {
+    const m: Record<string, string[]> = {};
+    for (const f of files.value) {
+      m[f.Key] = standardTagIdsForFileKey(f.Key);
+    }
+    return m;
+  });
+
+  const standardTags = computed(() =>
+    tags.value.filter((t) => (t.Kind ?? 'standard') === 'standard' && !isWorkflowLaboratoryTag(t)),
+  );
 
   const batchTags = computed(() => tags.value.filter((t) => (t.Kind ?? 'standard') === 'batch'));
 
-  const workflowTags = computed(() => tags.value.filter((t) => t.Kind === 'workflow'));
+  const workflowTags = computed(() => tags.value.filter((t) => isWorkflowLaboratoryTag(t)));
 
   /**
    * Group workflow tags by (Platform, WorkflowExternalId) so the user sees one row per
@@ -181,7 +238,7 @@
     if (!sel.length) return [] as { tagId: string; count: number }[];
     const counts = new Map<string, number>();
     for (const key of sel) {
-      for (const tid of keyToTagIds.value[key] || []) {
+      for (const tid of standardTagIdsForFileKey(key)) {
         counts.set(tid, (counts.get(tid) || 0) + 1);
       }
     }
@@ -255,14 +312,11 @@
     () => [props.labId, lab.value?.S3Bucket],
     async () => {
       if (!lab.value?.S3Bucket) return;
+      await loadTags();
       await loadListing();
     },
     { immediate: true },
   );
-
-  onMounted(async () => {
-    await loadTags();
-  });
 
   const visibleFiles = computed(() => {
     let list = files.value;
@@ -273,27 +327,29 @@
       case 'all':
         break;
       case 'untagged':
-        list = list.filter((f) => !keyToTagIds.value[f.Key]?.length);
+        list = list.filter((f) => !standardTagIdsForFileKey(f.Key).length);
         break;
       case 'tag':
-        list = list.filter((f) => (keyToTagIds.value[f.Key] || []).includes(af.tagId));
+        list = list.filter((f) => standardTagIdsForFileKey(f.Key).includes(af.tagId));
         break;
       case 'all-samples':
         // Surface only files that have been touched by any workflow run, mirroring the
         // ticket's "All samples" filter (i.e. anything that's been analysed at least once).
-        list = list.filter((f) => (keyToWorkflowTagIds.value[f.Key] || []).length > 0);
+        list = list.filter((f) => (keyToWorkflowTagIdsEffective.value[f.Key] || []).length > 0);
         break;
       case 'not-analyzed':
-        list = list.filter((f) => !(keyToWorkflowTagIds.value[f.Key] || []).length);
+        list = list.filter((f) => !(keyToWorkflowTagIdsEffective.value[f.Key] || []).length);
         break;
       case 'workflow-template': {
         const tmpl = workflowTemplates.value.find((t) => t.key === af.templateKey);
         const versionTagIds = new Set((tmpl?.versions || []).map((v) => v.tag.TagId));
-        list = list.filter((f) => (keyToWorkflowTagIds.value[f.Key] || []).some((id) => versionTagIds.has(id)));
+        list = list.filter((f) =>
+          (keyToWorkflowTagIdsEffective.value[f.Key] || []).some((id) => versionTagIds.has(id)),
+        );
         break;
       }
       case 'workflow-version':
-        list = list.filter((f) => (keyToWorkflowTagIds.value[f.Key] || []).includes(af.tagId));
+        list = list.filter((f) => (keyToWorkflowTagIdsEffective.value[f.Key] || []).includes(af.tagId));
         break;
     }
     return list;
@@ -698,11 +754,11 @@
         class="min-h-0 min-w-0 flex-1"
         :lab-root="labRoot"
         :visible-files="visibleFiles"
-        :key-to-tag-ids="keyToTagIds"
+        :key-to-tag-ids="keyToStandardTagIdsForExplorer"
         :key-to-batch-tag-id="keyToBatchTagId"
-        :key-to-workflow-tag-ids="keyToWorkflowTagIds"
+        :key-to-workflow-tag-ids="keyToWorkflowTagIdsEffective"
         :batch-tags="batchTags"
-        :tags="standardTags"
+        :tags="tags"
         :selected-keys="selectedKeys"
         :loading="loading"
         :search="search"

--- a/packages/front-end/src/app/components/EGDataCollectionsPage.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsPage.vue
@@ -30,22 +30,25 @@
   const selectedKeys = ref<string[]>([]);
 
   /**
-   * The active filter in the left rail. "All samples" in the UI maps to `all` (no filter).
-   * Tag, untagged, not-analyzed, workflow-template, and workflow-version are mutually exclusive.
+   * Scope rail filter: at most one of all | not-yet-analyzed | workflow template | workflow version.
+   * Tags section (untagged + multiple standard tags) applies on top with OR semantics among selected tags.
    */
-  type ActiveFilter =
+  type ScopeFilter =
     | { kind: 'all' }
-    | { kind: 'untagged' }
-    | { kind: 'tag'; tagId: string }
     | { kind: 'not-analyzed' }
     | { kind: 'workflow-template'; templateKey: string }
     | { kind: 'workflow-version'; tagId: string };
-  const activeFilter = ref<ActiveFilter>({ kind: 'all' });
+
+  const scopeFilter = ref<ScopeFilter>({ kind: 'all' });
+  /** Tags section: untagged is mutually exclusive with selecting specific standard tags. */
+  const tagsFilterUntagged = ref(false);
+  /** Multiple standard tags combine with OR (file matches if it has any selected tag). */
+  const tagsFilterTagIds = ref<string[]>([]);
   /** Per-template open/close state for the workflows left-rail accordion. */
   const expandedWorkflowTemplates = ref<Record<string, boolean>>({});
   /** Whether the long-list "Show more" toggle is open for the workflow templates. */
   const showAllWorkflowTemplates = ref(false);
-  /** Left-rail Tags / Workflows blocks start expanded. */
+  /** Left-rail Workflows / Tags blocks start expanded. */
   const tagsSectionExpanded = ref(true);
   const workflowsSectionExpanded = ref(true);
   const search = ref('');
@@ -186,7 +189,7 @@
 
   /**
    * Soft cap for the workflows left-rail before the "Show more" toggle kicks in. Picked to
-   * roughly match the room available next to the Tags section without scrolling.
+   * roughly limit workflow rows before the Tags section in the same rail without excessive scrolling.
    */
   const WORKFLOW_TEMPLATE_COLLAPSED_LIMIT = 6;
   const visibleWorkflowTemplates = computed(() =>
@@ -195,18 +198,85 @@
       : workflowTemplates.value.slice(0, WORKFLOW_TEMPLATE_COLLAPSED_LIMIT),
   );
 
-  function isFilterActive(target: ActiveFilter): boolean {
-    const a = activeFilter.value;
-    if (a.kind !== target.kind) return false;
-    if (a.kind === 'tag' && target.kind === 'tag') return a.tagId === target.tagId;
-    if (a.kind === 'workflow-template' && target.kind === 'workflow-template')
-      return a.templateKey === target.templateKey;
-    if (a.kind === 'workflow-version' && target.kind === 'workflow-version') return a.tagId === target.tagId;
-    return true;
+  /** True only when no scope filter and no Tags-section filters — matches fully unfiltered listing (aside from search). */
+  function isScopeAllActive(): boolean {
+    if (scopeFilter.value.kind !== 'all') return false;
+    if (tagsFilterUntagged.value) return false;
+    return tagsFilterTagIds.value.length === 0;
   }
 
-  function setFilter(next: ActiveFilter): void {
-    activeFilter.value = next;
+  function isNotAnalyzedScopeActive(): boolean {
+    return scopeFilter.value.kind === 'not-analyzed';
+  }
+
+  function isWorkflowTemplateScopeActive(templateKey: string): boolean {
+    const s = scopeFilter.value;
+    return s.kind === 'workflow-template' && s.templateKey === templateKey;
+  }
+
+  function isWorkflowVersionScopeActive(tagId: string): boolean {
+    const s = scopeFilter.value;
+    return s.kind === 'workflow-version' && s.tagId === tagId;
+  }
+
+  function isUntaggedTagFilterActive(): boolean {
+    return tagsFilterUntagged.value;
+  }
+
+  function isStandardTagFilterActive(tagId: string): boolean {
+    return tagsFilterTagIds.value.includes(tagId);
+  }
+
+  function onAllSamplesScopeClick(): void {
+    if (scopeFilter.value.kind === 'all') {
+      tagsFilterUntagged.value = false;
+      tagsFilterTagIds.value = [];
+      return;
+    }
+    scopeFilter.value = { kind: 'all' };
+  }
+
+  function onNotYetAnalyzedScopeClick(): void {
+    if (scopeFilter.value.kind === 'not-analyzed') {
+      scopeFilter.value = { kind: 'all' };
+      return;
+    }
+    scopeFilter.value = { kind: 'not-analyzed' };
+  }
+
+  function onWorkflowTemplateScopeClick(templateKey: string): void {
+    if (scopeFilter.value.kind === 'workflow-template' && scopeFilter.value.templateKey === templateKey) {
+      scopeFilter.value = { kind: 'all' };
+      return;
+    }
+    scopeFilter.value = { kind: 'workflow-template', templateKey };
+  }
+
+  function onWorkflowVersionScopeClick(tagId: string): void {
+    if (scopeFilter.value.kind === 'workflow-version' && scopeFilter.value.tagId === tagId) {
+      scopeFilter.value = { kind: 'all' };
+      return;
+    }
+    scopeFilter.value = { kind: 'workflow-version', tagId };
+  }
+
+  function onUntaggedTagFilterClick(): void {
+    if (tagsFilterUntagged.value) {
+      tagsFilterUntagged.value = false;
+      return;
+    }
+    tagsFilterUntagged.value = true;
+    tagsFilterTagIds.value = [];
+  }
+
+  function onStandardTagFilterClick(tagId: string): void {
+    const idx = tagsFilterTagIds.value.indexOf(tagId);
+    if (idx >= 0) {
+      tagsFilterTagIds.value = tagsFilterTagIds.value.filter((id: string) => id !== tagId);
+      return;
+    }
+    tagsFilterUntagged.value = false;
+    tagsFilterTagIds.value = [...tagsFilterTagIds.value, tagId];
   }
 
   function toggleWorkflowTemplate(templateKey: string): void {
@@ -329,21 +399,15 @@
 
   const visibleFiles = computed(() => {
     let list = filesMatchingSearch.value;
-    const af = activeFilter.value;
-    switch (af.kind) {
+    const sf = scopeFilter.value;
+    switch (sf.kind) {
       case 'all':
-        break;
-      case 'untagged':
-        list = list.filter((f) => !standardTagIdsForFileKey(f.Key).length);
-        break;
-      case 'tag':
-        list = list.filter((f) => standardTagIdsForFileKey(f.Key).includes(af.tagId));
         break;
       case 'not-analyzed':
         list = list.filter((f) => !(keyToWorkflowTagIdsEffective.value[f.Key] || []).length);
         break;
       case 'workflow-template': {
-        const tmpl = workflowTemplates.value.find((t) => t.key === af.templateKey);
+        const tmpl = workflowTemplates.value.find((t) => t.key === sf.templateKey);
         const versionTagIds = new Set((tmpl?.versions || []).map((v) => v.tag.TagId));
         list = list.filter((f) =>
           (keyToWorkflowTagIdsEffective.value[f.Key] || []).some((id) => versionTagIds.has(id)),
@@ -351,8 +415,14 @@
         break;
       }
       case 'workflow-version':
-        list = list.filter((f) => (keyToWorkflowTagIdsEffective.value[f.Key] || []).includes(af.tagId));
+        list = list.filter((f) => (keyToWorkflowTagIdsEffective.value[f.Key] || []).includes(sf.tagId));
         break;
+    }
+    if (tagsFilterUntagged.value) {
+      list = list.filter((f) => !standardTagIdsForFileKey(f.Key).length);
+    } else if (tagsFilterTagIds.value.length > 0) {
+      const selected = new Set(tagsFilterTagIds.value);
+      list = list.filter((f) => standardTagIdsForFileKey(f.Key).some((tid: string) => selected.has(tid)));
     }
     return list;
   });
@@ -379,6 +449,79 @@
     return out;
   });
 
+  /** Explorer dismiss chips — ids must stay in sync with `clearExplorerFilter`. */
+  const CHIP_SCOPE_NOT_ANALYZED = 'chip-scope-not-analyzed';
+  const CHIP_TAG_UNTAGGED = 'chip-tag-untagged';
+
+  function chipIdWorkflowTemplate(templateKey: string): string {
+    return `chip-wft:${templateKey}`;
+  }
+
+  function chipIdWorkflowVersion(tagId: string): string {
+    return `chip-wfv:${tagId}`;
+  }
+
+  function chipIdStandardTag(tagId: string): string {
+    return `chip-tag:${tagId}`;
+  }
+
+  const explorerFilterChips = computed((): { chipId: string; label: string }[] => {
+    const chips: { chipId: string; label: string }[] = [];
+    const sf = scopeFilter.value;
+    if (sf.kind === 'not-analyzed') {
+      chips.push({ chipId: CHIP_SCOPE_NOT_ANALYZED, label: 'Not yet analyzed' });
+    } else if (sf.kind === 'workflow-template') {
+      const tmpl = workflowTemplates.value.find((t) => t.key === sf.templateKey);
+      chips.push({
+        chipId: chipIdWorkflowTemplate(sf.templateKey),
+        label: tmpl?.name ?? sf.templateKey,
+      });
+    } else if (sf.kind === 'workflow-version') {
+      const tag = tagById(sf.tagId);
+      const versionLabel = tag?.WorkflowVersionName?.trim() ? tag.WorkflowVersionName.trim() : 'default';
+      chips.push({
+        chipId: chipIdWorkflowVersion(sf.tagId),
+        label: tag ? `${tag.Name} (${versionLabel})` : sf.tagId,
+      });
+    }
+    if (tagsFilterUntagged.value) {
+      chips.push({ chipId: CHIP_TAG_UNTAGGED, label: 'Untagged' });
+    }
+    for (const tid of tagsFilterTagIds.value) {
+      chips.push({ chipId: chipIdStandardTag(tid), label: tagById(tid)?.Name ?? tid });
+    }
+    return chips;
+  });
+
+  function clearExplorerFilter(chipId: string): void {
+    if (chipId === CHIP_SCOPE_NOT_ANALYZED) {
+      if (scopeFilter.value.kind === 'not-analyzed') scopeFilter.value = { kind: 'all' };
+      return;
+    }
+    if (chipId.startsWith('chip-wft:')) {
+      const templateKey = chipId.slice('chip-wft:'.length);
+      if (scopeFilter.value.kind === 'workflow-template' && scopeFilter.value.templateKey === templateKey) {
+        scopeFilter.value = { kind: 'all' };
+      }
+      return;
+    }
+    if (chipId.startsWith('chip-wfv:')) {
+      const wfTagId = chipId.slice('chip-wfv:'.length);
+      if (scopeFilter.value.kind === 'workflow-version' && scopeFilter.value.tagId === wfTagId) {
+        scopeFilter.value = { kind: 'all' };
+      }
+      return;
+    }
+    if (chipId === CHIP_TAG_UNTAGGED) {
+      tagsFilterUntagged.value = false;
+      return;
+    }
+    if (chipId.startsWith('chip-tag:')) {
+      const tid = chipId.slice('chip-tag:'.length);
+      tagsFilterTagIds.value = tagsFilterTagIds.value.filter((id: string) => id !== tid);
+    }
+  }
+
   function toggleKey(key: string): void {
     const s = new Set(selectedKeys.value);
     if (s.has(key)) s.delete(key);
@@ -403,14 +546,24 @@
     resetBulkPanelDraft();
   }
 
+  const bulkPanelContentEl = ref<HTMLElement | null>(null);
+
+  function scrollBulkPanelIntoView(): void {
+    nextTick(() => {
+      bulkPanelContentEl.value?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    });
+  }
+
   function openAddBulkPanel(): void {
     bulkPanelMode.value = 'add';
     resetBulkPanelDraft();
+    scrollBulkPanelIntoView();
   }
 
   function openRemoveBulkPanel(): void {
     bulkPanelMode.value = 'remove';
     resetBulkPanelDraft();
+    scrollBulkPanelIntoView();
   }
 
   function toggleBulkAddTag(tagId: string): void {
@@ -444,27 +597,52 @@
 
   const presetColors = ['#5B4FD4', '#85B7EB', '#F09595', '#97C459', '#ED93B1', '#EF9F27', '#B4B2A9'];
 
-  async function createTagInline(): Promise<void> {
-    if (!inlineNewTagName.value.trim()) return;
+  /** Shared create-tag API call + reload (used by bulk tray and left-rail create card). */
+  async function createStandardTag(name: string, colorHex: string): Promise<{ TagId: string } | null> {
+    const trimmed = name.trim();
+    if (!trimmed) return null;
     uiStore.setRequestPending('dataCollectionsMutate');
     try {
       const created = await $api.dataCollections.createTag({
         LaboratoryId: props.labId,
-        Name: inlineNewTagName.value.trim(),
-        ColorHex: inlineNewTagColor.value,
+        Name: trimmed,
+        ColorHex: colorHex,
       });
       await loadTags();
-      bulkAddTagIds.value = [...new Set([...bulkAddTagIds.value, created.TagId])];
-      showInlineCreateTag.value = false;
-      inlineNewTagName.value = '';
-      inlineNewTagColor.value = '#5B4FD4';
       toast.success('Tag created');
+      return created;
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
       toast.error(`Create tag failed: ${msg}`);
+      return null;
     } finally {
       uiStore.setRequestComplete('dataCollectionsMutate');
     }
+  }
+
+  async function createTagInline(): Promise<void> {
+    const created = await createStandardTag(inlineNewTagName.value, inlineNewTagColor.value);
+    if (!created) return;
+    bulkAddTagIds.value = [...new Set([...bulkAddTagIds.value, created.TagId])];
+    showInlineCreateTag.value = false;
+    inlineNewTagName.value = '';
+    inlineNewTagColor.value = '#5B4FD4';
+  }
+
+  const showLeftRailCreateTag = ref(false);
+  const leftRailNewTagName = ref('');
+  const leftRailNewTagColor = ref('#5B4FD4');
+
+  function cancelLeftRailCreateTag(): void {
+    showLeftRailCreateTag.value = false;
+    leftRailNewTagName.value = '';
+    leftRailNewTagColor.value = '#5B4FD4';
+  }
+
+  async function createTagLeftRail(): Promise<void> {
+    const created = await createStandardTag(leftRailNewTagName.value, leftRailNewTagColor.value);
+    if (!created) return;
+    cancelLeftRailCreateTag();
   }
 
   async function applyBulkChanges(): Promise<void> {
@@ -653,8 +831,8 @@
           <button
             type="button"
             class="hover:bg-primary-muted flex w-full items-center justify-between gap-2 rounded-lg px-2 py-2 text-left text-sm"
-            :class="{ 'bg-primary-muted font-medium': isFilterActive({ kind: 'all' }) }"
-            @click="setFilter({ kind: 'all' })"
+            :class="{ 'bg-primary-muted font-medium': isScopeAllActive() }"
+            @click="onAllSamplesScopeClick"
           >
             <span>All samples</span>
             <UBadge
@@ -667,8 +845,8 @@
           <button
             type="button"
             class="hover:bg-primary-muted flex w-full items-center justify-between gap-2 rounded-lg px-2 py-2 text-left text-sm"
-            :class="{ 'bg-primary-muted font-medium': isFilterActive({ kind: 'not-analyzed' }) }"
-            @click="setFilter({ kind: 'not-analyzed' })"
+            :class="{ 'bg-primary-muted font-medium': isNotAnalyzedScopeActive() }"
+            @click="onNotYetAnalyzedScopeClick"
           >
             <span>Not yet analyzed</span>
             <UBadge
@@ -681,52 +859,6 @@
         </div>
 
         <div class="border-border-muted border-b p-2">
-          <button
-            type="button"
-            class="text-muted hover:bg-primary-muted mb-1 flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left text-xs font-medium uppercase tracking-wide"
-            :aria-expanded="tagsSectionExpanded"
-            @click="tagsSectionExpanded = !tagsSectionExpanded"
-          >
-            <UIcon
-              :name="tagsSectionExpanded ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'"
-              class="h-4 w-4 shrink-0"
-              aria-hidden="true"
-            />
-            <span>Tags</span>
-          </button>
-          <div v-show="tagsSectionExpanded">
-            <button
-              type="button"
-              class="hover:bg-primary-muted flex w-full items-center justify-between rounded-lg px-2 py-2 text-left text-sm"
-              :class="{ 'bg-primary-muted font-medium': isFilterActive({ kind: 'untagged' }) }"
-              @click="setFilter({ kind: 'untagged' })"
-            >
-              <span>Untagged</span>
-            </button>
-            <button
-              v-for="t in standardTags"
-              :key="t.TagId"
-              class="hover:bg-primary-muted flex w-full cursor-pointer items-center justify-between gap-2 rounded-lg px-2 py-2 text-left text-sm"
-              :class="{ 'bg-primary-muted font-medium': isFilterActive({ kind: 'tag', tagId: t.TagId }) }"
-              @click="setFilter({ kind: 'tag', tagId: t.TagId })"
-              @dragover.prevent="onCardDragOverTag"
-              @drop="onTagRowDrop($event, t.TagId)"
-            >
-              <span class="flex min-w-0 items-center gap-2">
-                <span class="inline-block h-2.5 w-2.5 shrink-0 rounded-full" :style="{ background: t.ColorHex }" />
-                <span class="truncate">{{ t.Name }}</span>
-              </span>
-              <UBadge
-                size="xs"
-                class="bg-primary-muted text-primary-dark shrink-0 rounded-xl border-0 font-serif tabular-nums ring-0"
-              >
-                {{ standardTagIdToChipCount[t.TagId] ?? 0 }}
-              </UBadge>
-            </button>
-          </div>
-        </div>
-
-        <div class="p-2">
           <button
             type="button"
             class="text-muted hover:bg-primary-muted mb-1 flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left text-xs font-medium uppercase tracking-wide"
@@ -749,7 +881,7 @@
               <div
                 class="hover:bg-primary-muted flex w-full cursor-pointer items-center gap-1 rounded-lg pr-2 text-left text-sm"
                 :class="{
-                  'bg-primary-muted font-medium': isFilterActive({ kind: 'workflow-template', templateKey: tmpl.key }),
+                  'bg-primary-muted font-medium': isWorkflowTemplateScopeActive(tmpl.key),
                 }"
               >
                 <button
@@ -770,7 +902,7 @@
                 <button
                   type="button"
                   class="flex min-w-0 flex-1 items-center justify-between gap-2 py-2 text-left"
-                  @click="setFilter({ kind: 'workflow-template', templateKey: tmpl.key })"
+                  @click="onWorkflowTemplateScopeClick(tmpl.key)"
                 >
                   <span class="flex min-w-0 items-center gap-2">
                     <span class="inline-block h-2.5 w-2.5 shrink-0 rounded-full" :style="{ background: tmpl.color }" />
@@ -787,9 +919,9 @@
                   type="button"
                   class="hover:bg-primary-muted flex w-full items-center justify-between gap-2 rounded-lg px-2 py-1.5 text-left text-xs"
                   :class="{
-                    'bg-primary-muted font-medium': isFilterActive({ kind: 'workflow-version', tagId: v.tag.TagId }),
+                    'bg-primary-muted font-medium': isWorkflowVersionScopeActive(v.tag.TagId),
                   }"
-                  @click="setFilter({ kind: 'workflow-version', tagId: v.tag.TagId })"
+                  @click="onWorkflowVersionScopeClick(v.tag.TagId)"
                 >
                   <span class="text-muted truncate">{{ v.label }}</span>
                   <span class="text-muted shrink-0 tabular-nums">{{ v.tag.FileCount }}</span>
@@ -812,6 +944,98 @@
             </button>
           </div>
         </div>
+
+        <div class="p-2">
+          <button
+            type="button"
+            class="text-muted hover:bg-primary-muted mb-1 flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left text-xs font-medium uppercase tracking-wide"
+            :aria-expanded="tagsSectionExpanded"
+            @click="tagsSectionExpanded = !tagsSectionExpanded"
+          >
+            <UIcon
+              :name="tagsSectionExpanded ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'"
+              class="h-4 w-4 shrink-0"
+              aria-hidden="true"
+            />
+            <span>Tags</span>
+          </button>
+          <div v-show="tagsSectionExpanded">
+            <button
+              type="button"
+              class="hover:bg-primary-muted flex w-full items-center justify-between rounded-lg px-2 py-2 text-left text-sm"
+              :class="{ 'bg-primary-muted font-medium': isUntaggedTagFilterActive() }"
+              @click="onUntaggedTagFilterClick"
+            >
+              <span>Untagged</span>
+            </button>
+            <button
+              v-for="t in standardTags"
+              :key="t.TagId"
+              class="hover:bg-primary-muted flex w-full cursor-pointer items-center justify-between gap-2 rounded-lg px-2 py-2 text-left text-sm"
+              :class="{ 'bg-primary-muted font-medium': isStandardTagFilterActive(t.TagId) }"
+              @click="onStandardTagFilterClick(t.TagId)"
+              @dragover.prevent="onCardDragOverTag"
+              @drop="onTagRowDrop($event, t.TagId)"
+            >
+              <span class="flex min-w-0 items-center gap-2">
+                <span class="inline-block h-2.5 w-2.5 shrink-0 rounded-full" :style="{ background: t.ColorHex }" />
+                <span class="truncate">{{ t.Name }}</span>
+              </span>
+              <UBadge
+                size="xs"
+                class="bg-primary-muted text-primary-dark shrink-0 rounded-xl border-0 font-serif tabular-nums ring-0"
+              >
+                {{ standardTagIdToChipCount[t.TagId] ?? 0 }}
+              </UBadge>
+            </button>
+
+            <div class="border-border-muted mt-2 border-t pt-2">
+              <button
+                v-if="!showLeftRailCreateTag"
+                type="button"
+                class="text-primary hover:text-primary-dark px-2 py-1.5 text-left text-xs font-medium hover:underline"
+                @click="showLeftRailCreateTag = true"
+              >
+                + New Tag
+              </button>
+              <div v-else class="rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
+                <div class="text-muted mb-2 text-xs font-semibold uppercase tracking-wide">Create Tag</div>
+                <div class="space-y-2">
+                  <div>
+                    <label class="text-muted mb-0.5 block text-xs font-medium">Tag name</label>
+                    <UInput v-model="leftRailNewTagName" placeholder="Tag name" size="sm" />
+                  </div>
+                  <div>
+                    <label class="text-muted mb-0.5 block text-xs font-medium">Tag color</label>
+                    <div class="flex flex-wrap gap-1">
+                      <button
+                        v-for="c in presetColors"
+                        :key="'left-rail-preset-' + c"
+                        type="button"
+                        class="h-7 w-7 rounded border-2"
+                        :class="leftRailNewTagColor === c ? 'border-primary' : 'border-transparent'"
+                        :style="{ background: c }"
+                        @click="leftRailNewTagColor = c"
+                      />
+                    </div>
+                    <UInput v-model="leftRailNewTagColor" placeholder="#RRGGBB" size="sm" class="mt-1.5" />
+                  </div>
+                  <div class="flex gap-2 pt-1">
+                    <UButton size="xs" variant="ghost" @click="cancelLeftRailCreateTag">Cancel</UButton>
+                    <UButton
+                      size="xs"
+                      :disabled="!leftRailNewTagName.trim()"
+                      :loading="loading"
+                      @click="createTagLeftRail"
+                    >
+                      Create
+                    </UButton>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
 
       <EGDataCollectionsExplorer
@@ -828,11 +1052,13 @@
         :search="search"
         :listing-file-count="files.length"
         :listing-truncated="listingTruncated"
+        :filter-chips="explorerFilterChips"
         @update:search="search = $event"
         @update:selected-keys="selectedKeys = $event"
         @toggle-key="toggleKey"
         @select-all-displayed="selectAllDisplayed"
         @clear-selection="selectedKeys = []"
+        @clear-filter="clearExplorerFilter($event)"
         @remove-tag-from-file="removeTagFromFile($event.key, $event.tagId)"
       />
     </div>
@@ -853,7 +1079,11 @@
         </div>
       </div>
 
-      <div v-if="bulkPanelOpen" class="border-border-muted relative border-t bg-white px-4 pb-4 pt-3">
+      <div
+        v-if="bulkPanelOpen"
+        ref="bulkPanelContentEl"
+        class="border-border-muted relative border-t bg-white px-4 pb-4 pt-3"
+      >
         <div
           v-if="bulkPanelBusy"
           class="absolute inset-0 z-10 flex items-center justify-center bg-white/70 backdrop-blur-[1px]"

--- a/packages/front-end/src/app/components/EGDataCollectionsPage.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsPage.vue
@@ -19,10 +19,34 @@
   const keyToTagIds = ref<Record<string, string[]>>({});
   /** Batch assignment per object key (tag ids with Kind batch are tracked separately from TagIds). */
   const keyToBatchTagId = ref<Record<string, string | undefined>>({});
+  /**
+   * Workflow tag ids associated with each file key. Populated alongside keyToTagIds so the
+   * explorer can render an Analyzed/Not yet analyzed status and the left-rail Workflows
+   * filter section can drive visibility.
+   */
+  const keyToWorkflowTagIds = ref<Record<string, string[]>>({});
   const files = ref<{ Key: string; Size?: number; LastModified?: string }[]>([]);
   const listingTruncated = ref(false);
   const selectedKeys = ref<string[]>([]);
-  const filterTagId = ref<string | null>(null);
+
+  /**
+   * The active filter in the left rail. Tag, untagged, workflow-template, workflow-version,
+   * and the workflow-meta filters (all-samples / not-analyzed) are mutually exclusive — so a
+   * single discriminated union keeps state-handling tight.
+   */
+  type ActiveFilter =
+    | { kind: 'all' }
+    | { kind: 'untagged' }
+    | { kind: 'tag'; tagId: string }
+    | { kind: 'all-samples' }
+    | { kind: 'not-analyzed' }
+    | { kind: 'workflow-template'; templateKey: string }
+    | { kind: 'workflow-version'; tagId: string };
+  const activeFilter = ref<ActiveFilter>({ kind: 'all' });
+  /** Per-template open/close state for the workflows left-rail accordion. */
+  const expandedWorkflowTemplates = ref<Record<string, boolean>>({});
+  /** Whether the long-list "Show more" toggle is open for the workflow templates. */
+  const showAllWorkflowTemplates = ref(false);
   const search = ref('');
 
   const KEYS_CHUNK = 100;
@@ -51,9 +75,88 @@
     return tags.value.find((t) => t.TagId === id);
   }
 
-  const standardTags = computed(() => tags.value.filter((t) => (t.Kind ?? 'standard') !== 'batch'));
+  const standardTags = computed(() => tags.value.filter((t) => (t.Kind ?? 'standard') === 'standard'));
 
   const batchTags = computed(() => tags.value.filter((t) => (t.Kind ?? 'standard') === 'batch'));
+
+  const workflowTags = computed(() => tags.value.filter((t) => t.Kind === 'workflow'));
+
+  /**
+   * Group workflow tags by (Platform, WorkflowExternalId) so the user sees one row per
+   * workflow template in the left rail, with the individual versions exposed when the row
+   * is expanded. The default version (empty WorkflowVersionName) is rendered as "default".
+   */
+  type WorkflowTemplate = {
+    key: string;
+    platform: string;
+    externalId: string;
+    name: string;
+    color: string;
+    fileCount: number;
+    versions: { tag: LaboratoryDataTag; label: string }[];
+  };
+  const workflowTemplates = computed<WorkflowTemplate[]>(() => {
+    const grouped = new Map<string, WorkflowTemplate>();
+    for (const t of workflowTags.value) {
+      const platform = t.Platform ?? '';
+      const externalId = t.WorkflowExternalId ?? t.TagId;
+      const key = `${platform}#${externalId}`;
+      const existing = grouped.get(key);
+      const versionLabel = t.WorkflowVersionName?.trim() ? t.WorkflowVersionName.trim() : 'default';
+      if (existing) {
+        existing.fileCount += t.FileCount ?? 0;
+        existing.versions.push({ tag: t, label: versionLabel });
+      } else {
+        grouped.set(key, {
+          key,
+          platform,
+          externalId,
+          name: t.Name,
+          color: t.ColorHex,
+          fileCount: t.FileCount ?? 0,
+          versions: [{ tag: t, label: versionLabel }],
+        });
+      }
+    }
+    const list = [...grouped.values()];
+    for (const tmpl of list) {
+      tmpl.versions.sort((a, b) => a.label.localeCompare(b.label));
+    }
+    list.sort((a, b) => b.fileCount - a.fileCount || a.name.localeCompare(b.name));
+    return list;
+  });
+
+  /**
+   * Soft cap for the workflows left-rail before the "Show more" toggle kicks in. Picked to
+   * roughly match the room available next to the Tags section without scrolling.
+   */
+  const WORKFLOW_TEMPLATE_COLLAPSED_LIMIT = 6;
+  const visibleWorkflowTemplates = computed(() =>
+    showAllWorkflowTemplates.value || workflowTemplates.value.length <= WORKFLOW_TEMPLATE_COLLAPSED_LIMIT
+      ? workflowTemplates.value
+      : workflowTemplates.value.slice(0, WORKFLOW_TEMPLATE_COLLAPSED_LIMIT),
+  );
+
+  function isFilterActive(target: ActiveFilter): boolean {
+    const a = activeFilter.value;
+    if (a.kind !== target.kind) return false;
+    if (a.kind === 'tag' && target.kind === 'tag') return a.tagId === target.tagId;
+    if (a.kind === 'workflow-template' && target.kind === 'workflow-template')
+      return a.templateKey === target.templateKey;
+    if (a.kind === 'workflow-version' && target.kind === 'workflow-version') return a.tagId === target.tagId;
+    return true;
+  }
+
+  function setFilter(next: ActiveFilter): void {
+    activeFilter.value = next;
+  }
+
+  function toggleWorkflowTemplate(templateKey: string): void {
+    expandedWorkflowTemplates.value = {
+      ...expandedWorkflowTemplates.value,
+      [templateKey]: !expandedWorkflowTemplates.value[templateKey],
+    };
+  }
 
   function batchAssignmentLabelForKey(key: string): string {
     const bid = keyToBatchTagId.value[key];
@@ -121,6 +224,7 @@
       const keys = files.value.map((f) => f.Key);
       const map: Record<string, string[]> = {};
       const batchMap: Record<string, string | undefined> = {};
+      const workflowMap: Record<string, string[]> = {};
       if (keys.length) {
         for (let i = 0; i < keys.length; i += KEYS_CHUNK) {
           const chunk = keys.slice(i, i + KEYS_CHUNK);
@@ -132,11 +236,13 @@
           for (const f of tr.Files) {
             map[f.Key] = f.TagIds;
             batchMap[f.Key] = f.BatchTagId;
+            workflowMap[f.Key] = f.WorkflowTagIds ?? [];
           }
         }
       }
       keyToTagIds.value = map;
       keyToBatchTagId.value = batchMap;
+      keyToWorkflowTagIds.value = workflowMap;
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
       toast.error(`Failed to load files: ${msg}`);
@@ -162,10 +268,33 @@
     let list = files.value;
     const q = search.value.trim().toLowerCase();
     if (q) list = list.filter((f) => f.Key.toLowerCase().includes(q));
-    if (filterTagId.value === 'untagged') {
-      list = list.filter((f) => !keyToTagIds.value[f.Key]?.length);
-    } else if (filterTagId.value) {
-      list = list.filter((f) => (keyToTagIds.value[f.Key] || []).includes(filterTagId.value!));
+    const af = activeFilter.value;
+    switch (af.kind) {
+      case 'all':
+        break;
+      case 'untagged':
+        list = list.filter((f) => !keyToTagIds.value[f.Key]?.length);
+        break;
+      case 'tag':
+        list = list.filter((f) => (keyToTagIds.value[f.Key] || []).includes(af.tagId));
+        break;
+      case 'all-samples':
+        // Surface only files that have been touched by any workflow run, mirroring the
+        // ticket's "All samples" filter (i.e. anything that's been analysed at least once).
+        list = list.filter((f) => (keyToWorkflowTagIds.value[f.Key] || []).length > 0);
+        break;
+      case 'not-analyzed':
+        list = list.filter((f) => !(keyToWorkflowTagIds.value[f.Key] || []).length);
+        break;
+      case 'workflow-template': {
+        const tmpl = workflowTemplates.value.find((t) => t.key === af.templateKey);
+        const versionTagIds = new Set((tmpl?.versions || []).map((v) => v.tag.TagId));
+        list = list.filter((f) => (keyToWorkflowTagIds.value[f.Key] || []).some((id) => versionTagIds.has(id)));
+        break;
+      }
+      case 'workflow-version':
+        list = list.filter((f) => (keyToWorkflowTagIds.value[f.Key] || []).includes(af.tagId));
+        break;
     }
     return list;
   });
@@ -445,16 +574,16 @@
           <button
             type="button"
             class="hover:bg-primary-muted flex w-full items-center justify-between rounded-lg px-2 py-2 text-left text-sm"
-            :class="{ 'bg-primary-muted font-medium': filterTagId === null }"
-            @click="filterTagId = null"
+            :class="{ 'bg-primary-muted font-medium': isFilterActive({ kind: 'all' }) }"
+            @click="setFilter({ kind: 'all' })"
           >
             <span>All files</span>
           </button>
           <button
             type="button"
             class="hover:bg-primary-muted flex w-full items-center justify-between rounded-lg px-2 py-2 text-left text-sm"
-            :class="{ 'bg-primary-muted font-medium': filterTagId === 'untagged' }"
-            @click="filterTagId = 'untagged'"
+            :class="{ 'bg-primary-muted font-medium': isFilterActive({ kind: 'untagged' }) }"
+            @click="setFilter({ kind: 'untagged' })"
           >
             <span>Untagged</span>
           </button>
@@ -462,8 +591,8 @@
             v-for="t in standardTags"
             :key="t.TagId"
             class="hover:bg-primary-muted flex w-full cursor-pointer items-center justify-between rounded-lg px-2 py-2 text-left text-sm"
-            :class="{ 'bg-primary-muted font-medium': filterTagId === t.TagId }"
-            @click="filterTagId = t.TagId"
+            :class="{ 'bg-primary-muted font-medium': isFilterActive({ kind: 'tag', tagId: t.TagId }) }"
+            @click="setFilter({ kind: 'tag', tagId: t.TagId })"
             @dragover.prevent="onCardDragOverTag"
             @drop="onTagRowDrop($event, t.TagId)"
           >
@@ -474,6 +603,95 @@
             <span class="text-muted text-xs">{{ t.FileCount }}</span>
           </button>
         </div>
+
+        <div class="p-4">
+          <div class="text-muted mb-2 text-xs font-medium uppercase tracking-wide">Workflows</div>
+
+          <button
+            type="button"
+            class="hover:bg-primary-muted flex w-full items-center justify-between rounded-lg px-2 py-2 text-left text-sm"
+            :class="{ 'bg-primary-muted font-medium': isFilterActive({ kind: 'all-samples' }) }"
+            @click="setFilter({ kind: 'all-samples' })"
+          >
+            <span>All samples</span>
+          </button>
+          <button
+            type="button"
+            class="hover:bg-primary-muted flex w-full items-center justify-between rounded-lg px-2 py-2 text-left text-sm"
+            :class="{ 'bg-primary-muted font-medium': isFilterActive({ kind: 'not-analyzed' }) }"
+            @click="setFilter({ kind: 'not-analyzed' })"
+          >
+            <span>Not yet analyzed</span>
+          </button>
+
+          <p v-if="!workflowTemplates.length" class="text-muted mt-2 px-2 text-xs italic">
+            No workflows have been run on these files yet.
+          </p>
+
+          <div v-for="tmpl in visibleWorkflowTemplates" :key="tmpl.key" class="mt-1">
+            <div
+              class="hover:bg-primary-muted flex w-full cursor-pointer items-center gap-1 rounded-lg pr-2 text-left text-sm"
+              :class="{
+                'bg-primary-muted font-medium': isFilterActive({ kind: 'workflow-template', templateKey: tmpl.key }),
+              }"
+            >
+              <button
+                v-if="tmpl.versions.length > 1"
+                type="button"
+                class="text-muted hover:text-primary flex h-7 w-7 shrink-0 items-center justify-center rounded"
+                :aria-label="expandedWorkflowTemplates[tmpl.key] ? 'Collapse versions' : 'Expand versions'"
+                @click.stop="toggleWorkflowTemplate(tmpl.key)"
+              >
+                <UIcon
+                  :name="expandedWorkflowTemplates[tmpl.key] ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'"
+                  class="h-4 w-4"
+                />
+              </button>
+              <span v-else class="block h-7 w-7 shrink-0" />
+              <button
+                type="button"
+                class="flex min-w-0 flex-1 items-center justify-between gap-2 py-2 text-left"
+                @click="setFilter({ kind: 'workflow-template', templateKey: tmpl.key })"
+              >
+                <span class="flex min-w-0 items-center gap-2">
+                  <span class="inline-block h-2.5 w-2.5 shrink-0 rounded-full" :style="{ background: tmpl.color }" />
+                  <span class="truncate">{{ tmpl.name }}</span>
+                </span>
+                <span class="text-muted shrink-0 text-xs">{{ tmpl.fileCount }}</span>
+              </button>
+            </div>
+
+            <div v-if="expandedWorkflowTemplates[tmpl.key] && tmpl.versions.length > 1" class="ml-7 mt-0.5">
+              <button
+                v-for="v in tmpl.versions"
+                :key="v.tag.TagId"
+                type="button"
+                class="hover:bg-primary-muted flex w-full items-center justify-between gap-2 rounded-lg px-2 py-1.5 text-left text-xs"
+                :class="{
+                  'bg-primary-muted font-medium': isFilterActive({ kind: 'workflow-version', tagId: v.tag.TagId }),
+                }"
+                @click="setFilter({ kind: 'workflow-version', tagId: v.tag.TagId })"
+              >
+                <span class="text-muted truncate">{{ v.label }}</span>
+                <span class="text-muted shrink-0 tabular-nums">{{ v.tag.FileCount }}</span>
+              </button>
+            </div>
+          </div>
+
+          <button
+            v-if="workflowTemplates.length > visibleWorkflowTemplates.length || showAllWorkflowTemplates"
+            v-show="workflowTemplates.length > 6"
+            type="button"
+            class="text-primary mt-2 px-2 text-xs font-medium hover:underline"
+            @click="showAllWorkflowTemplates = !showAllWorkflowTemplates"
+          >
+            {{
+              showAllWorkflowTemplates
+                ? 'Show fewer'
+                : `Show ${workflowTemplates.length - visibleWorkflowTemplates.length} more`
+            }}
+          </button>
+        </div>
       </div>
 
       <EGDataCollectionsExplorer
@@ -482,6 +700,7 @@
         :visible-files="visibleFiles"
         :key-to-tag-ids="keyToTagIds"
         :key-to-batch-tag-id="keyToBatchTagId"
+        :key-to-workflow-tag-ids="keyToWorkflowTagIds"
         :batch-tags="batchTags"
         :tags="standardTags"
         :selected-keys="selectedKeys"

--- a/packages/front-end/src/app/components/EGDataCollectionsPage.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsPage.vue
@@ -30,15 +30,13 @@
   const selectedKeys = ref<string[]>([]);
 
   /**
-   * The active filter in the left rail. Tag, untagged, workflow-template, workflow-version,
-   * and the workflow-meta filters (all-samples / not-analyzed) are mutually exclusive — so a
-   * single discriminated union keeps state-handling tight.
+   * The active filter in the left rail. "All samples" in the UI maps to `all` (no filter).
+   * Tag, untagged, not-analyzed, workflow-template, and workflow-version are mutually exclusive.
    */
   type ActiveFilter =
     | { kind: 'all' }
     | { kind: 'untagged' }
     | { kind: 'tag'; tagId: string }
-    | { kind: 'all-samples' }
     | { kind: 'not-analyzed' }
     | { kind: 'workflow-template'; templateKey: string }
     | { kind: 'workflow-version'; tagId: string };
@@ -47,6 +45,9 @@
   const expandedWorkflowTemplates = ref<Record<string, boolean>>({});
   /** Whether the long-list "Show more" toggle is open for the workflow templates. */
   const showAllWorkflowTemplates = ref(false);
+  /** Left-rail Tags / Workflows blocks start expanded. */
+  const tagsSectionExpanded = ref(true);
+  const workflowsSectionExpanded = ref(true);
   const search = ref('');
 
   const KEYS_CHUNK = 100;
@@ -318,10 +319,16 @@
     { immediate: true },
   );
 
-  const visibleFiles = computed(() => {
+  /** Same first step as `visibleFiles` — used for sidebar chips so counts follow search. */
+  const filesMatchingSearch = computed(() => {
     let list = files.value;
     const q = search.value.trim().toLowerCase();
     if (q) list = list.filter((f) => f.Key.toLowerCase().includes(q));
+    return list;
+  });
+
+  const visibleFiles = computed(() => {
+    let list = filesMatchingSearch.value;
     const af = activeFilter.value;
     switch (af.kind) {
       case 'all':
@@ -331,11 +338,6 @@
         break;
       case 'tag':
         list = list.filter((f) => standardTagIdsForFileKey(f.Key).includes(af.tagId));
-        break;
-      case 'all-samples':
-        // Surface only files that have been touched by any workflow run, mirroring the
-        // ticket's "All samples" filter (i.e. anything that's been analysed at least once).
-        list = list.filter((f) => (keyToWorkflowTagIdsEffective.value[f.Key] || []).length > 0);
         break;
       case 'not-analyzed':
         list = list.filter((f) => !(keyToWorkflowTagIdsEffective.value[f.Key] || []).length);
@@ -353,6 +355,28 @@
         break;
     }
     return list;
+  });
+
+  /** Count for "All samples" chip — all loaded files matching search (same universe as no filter). */
+  const allSamplesChipCount = computed(() => filesMatchingSearch.value.length);
+
+  const notAnalyzedChipCount = computed(
+    () => filesMatchingSearch.value.filter((f) => !(keyToWorkflowTagIdsEffective.value[f.Key] || []).length).length,
+  );
+
+  /** Per standard-tag file counts among `filesMatchingSearch` (matches `case 'tag'` in `visibleFiles`). */
+  const standardTagIdToChipCount = computed((): Record<string, number> => {
+    const tagIds = new Set<string>(standardTags.value.map((t: LaboratoryDataTag) => t.TagId));
+    const counts = new Map<string, number>();
+    for (const id of tagIds) counts.set(id, 0);
+    for (const f of filesMatchingSearch.value) {
+      for (const tid of standardTagIdsForFileKey(f.Key)) {
+        if (tagIds.has(tid)) counts.set(tid, (counts.get(tid) ?? 0) + 1);
+      }
+    }
+    const out: Record<string, number> = {};
+    for (const [k, v] of counts) out[k] = v;
+    return out;
   });
 
   function toggleKey(key: string): void {
@@ -625,128 +649,168 @@
   >
     <div class="flex min-h-0 min-w-0 flex-1 overflow-hidden">
       <div class="border-border-muted flex w-[280px] shrink-0 flex-col overflow-y-auto border-r bg-gray-50">
-        <div class="border-border-muted border-b p-4">
-          <div class="text-muted mb-2 text-xs font-medium uppercase tracking-wide">Tags</div>
+        <div class="border-border-muted border-b p-2">
           <button
             type="button"
-            class="hover:bg-primary-muted flex w-full items-center justify-between rounded-lg px-2 py-2 text-left text-sm"
+            class="hover:bg-primary-muted flex w-full items-center justify-between gap-2 rounded-lg px-2 py-2 text-left text-sm"
             :class="{ 'bg-primary-muted font-medium': isFilterActive({ kind: 'all' }) }"
             @click="setFilter({ kind: 'all' })"
           >
-            <span>All files</span>
-          </button>
-          <button
-            type="button"
-            class="hover:bg-primary-muted flex w-full items-center justify-between rounded-lg px-2 py-2 text-left text-sm"
-            :class="{ 'bg-primary-muted font-medium': isFilterActive({ kind: 'untagged' }) }"
-            @click="setFilter({ kind: 'untagged' })"
-          >
-            <span>Untagged</span>
-          </button>
-          <button
-            v-for="t in standardTags"
-            :key="t.TagId"
-            class="hover:bg-primary-muted flex w-full cursor-pointer items-center justify-between rounded-lg px-2 py-2 text-left text-sm"
-            :class="{ 'bg-primary-muted font-medium': isFilterActive({ kind: 'tag', tagId: t.TagId }) }"
-            @click="setFilter({ kind: 'tag', tagId: t.TagId })"
-            @dragover.prevent="onCardDragOverTag"
-            @drop="onTagRowDrop($event, t.TagId)"
-          >
-            <span class="flex items-center gap-2">
-              <span class="inline-block h-2.5 w-2.5 shrink-0 rounded-full" :style="{ background: t.ColorHex }" />
-              {{ t.Name }}
-            </span>
-            <span class="text-muted text-xs">{{ t.FileCount }}</span>
-          </button>
-        </div>
-
-        <div class="p-4">
-          <div class="text-muted mb-2 text-xs font-medium uppercase tracking-wide">Workflows</div>
-
-          <button
-            type="button"
-            class="hover:bg-primary-muted flex w-full items-center justify-between rounded-lg px-2 py-2 text-left text-sm"
-            :class="{ 'bg-primary-muted font-medium': isFilterActive({ kind: 'all-samples' }) }"
-            @click="setFilter({ kind: 'all-samples' })"
-          >
             <span>All samples</span>
+            <UBadge
+              size="xs"
+              class="bg-primary-muted text-primary-dark shrink-0 rounded-xl border-0 font-serif tabular-nums ring-0"
+            >
+              {{ allSamplesChipCount }}
+            </UBadge>
           </button>
           <button
             type="button"
-            class="hover:bg-primary-muted flex w-full items-center justify-between rounded-lg px-2 py-2 text-left text-sm"
+            class="hover:bg-primary-muted flex w-full items-center justify-between gap-2 rounded-lg px-2 py-2 text-left text-sm"
             :class="{ 'bg-primary-muted font-medium': isFilterActive({ kind: 'not-analyzed' }) }"
             @click="setFilter({ kind: 'not-analyzed' })"
           >
             <span>Not yet analyzed</span>
-          </button>
-
-          <p v-if="!workflowTemplates.length" class="text-muted mt-2 px-2 text-xs italic">
-            No workflows have been run on these files yet.
-          </p>
-
-          <div v-for="tmpl in visibleWorkflowTemplates" :key="tmpl.key" class="mt-1">
-            <div
-              class="hover:bg-primary-muted flex w-full cursor-pointer items-center gap-1 rounded-lg pr-2 text-left text-sm"
-              :class="{
-                'bg-primary-muted font-medium': isFilterActive({ kind: 'workflow-template', templateKey: tmpl.key }),
-              }"
+            <UBadge
+              size="xs"
+              class="bg-primary-muted text-primary-dark shrink-0 rounded-xl border-0 font-serif tabular-nums ring-0"
             >
-              <button
-                v-if="tmpl.versions.length > 1"
-                type="button"
-                class="text-muted hover:text-primary flex h-7 w-7 shrink-0 items-center justify-center rounded"
-                :aria-label="expandedWorkflowTemplates[tmpl.key] ? 'Collapse versions' : 'Expand versions'"
-                @click.stop="toggleWorkflowTemplate(tmpl.key)"
-              >
-                <UIcon
-                  :name="expandedWorkflowTemplates[tmpl.key] ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'"
-                  class="h-4 w-4"
-                />
-              </button>
-              <span v-else class="block h-7 w-7 shrink-0" />
-              <button
-                type="button"
-                class="flex min-w-0 flex-1 items-center justify-between gap-2 py-2 text-left"
-                @click="setFilter({ kind: 'workflow-template', templateKey: tmpl.key })"
-              >
-                <span class="flex min-w-0 items-center gap-2">
-                  <span class="inline-block h-2.5 w-2.5 shrink-0 rounded-full" :style="{ background: tmpl.color }" />
-                  <span class="truncate">{{ tmpl.name }}</span>
-                </span>
-                <span class="text-muted shrink-0 text-xs">{{ tmpl.fileCount }}</span>
-              </button>
-            </div>
-
-            <div v-if="expandedWorkflowTemplates[tmpl.key] && tmpl.versions.length > 1" class="ml-7 mt-0.5">
-              <button
-                v-for="v in tmpl.versions"
-                :key="v.tag.TagId"
-                type="button"
-                class="hover:bg-primary-muted flex w-full items-center justify-between gap-2 rounded-lg px-2 py-1.5 text-left text-xs"
-                :class="{
-                  'bg-primary-muted font-medium': isFilterActive({ kind: 'workflow-version', tagId: v.tag.TagId }),
-                }"
-                @click="setFilter({ kind: 'workflow-version', tagId: v.tag.TagId })"
-              >
-                <span class="text-muted truncate">{{ v.label }}</span>
-                <span class="text-muted shrink-0 tabular-nums">{{ v.tag.FileCount }}</span>
-              </button>
-            </div>
-          </div>
-
-          <button
-            v-if="workflowTemplates.length > visibleWorkflowTemplates.length || showAllWorkflowTemplates"
-            v-show="workflowTemplates.length > 6"
-            type="button"
-            class="text-primary mt-2 px-2 text-xs font-medium hover:underline"
-            @click="showAllWorkflowTemplates = !showAllWorkflowTemplates"
-          >
-            {{
-              showAllWorkflowTemplates
-                ? 'Show fewer'
-                : `Show ${workflowTemplates.length - visibleWorkflowTemplates.length} more`
-            }}
+              {{ notAnalyzedChipCount }}
+            </UBadge>
           </button>
+        </div>
+
+        <div class="border-border-muted border-b p-2">
+          <button
+            type="button"
+            class="text-muted hover:bg-primary-muted mb-1 flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left text-xs font-medium uppercase tracking-wide"
+            :aria-expanded="tagsSectionExpanded"
+            @click="tagsSectionExpanded = !tagsSectionExpanded"
+          >
+            <UIcon
+              :name="tagsSectionExpanded ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'"
+              class="h-4 w-4 shrink-0"
+              aria-hidden="true"
+            />
+            <span>Tags</span>
+          </button>
+          <div v-show="tagsSectionExpanded">
+            <button
+              type="button"
+              class="hover:bg-primary-muted flex w-full items-center justify-between rounded-lg px-2 py-2 text-left text-sm"
+              :class="{ 'bg-primary-muted font-medium': isFilterActive({ kind: 'untagged' }) }"
+              @click="setFilter({ kind: 'untagged' })"
+            >
+              <span>Untagged</span>
+            </button>
+            <button
+              v-for="t in standardTags"
+              :key="t.TagId"
+              class="hover:bg-primary-muted flex w-full cursor-pointer items-center justify-between gap-2 rounded-lg px-2 py-2 text-left text-sm"
+              :class="{ 'bg-primary-muted font-medium': isFilterActive({ kind: 'tag', tagId: t.TagId }) }"
+              @click="setFilter({ kind: 'tag', tagId: t.TagId })"
+              @dragover.prevent="onCardDragOverTag"
+              @drop="onTagRowDrop($event, t.TagId)"
+            >
+              <span class="flex min-w-0 items-center gap-2">
+                <span class="inline-block h-2.5 w-2.5 shrink-0 rounded-full" :style="{ background: t.ColorHex }" />
+                <span class="truncate">{{ t.Name }}</span>
+              </span>
+              <UBadge
+                size="xs"
+                class="bg-primary-muted text-primary-dark shrink-0 rounded-xl border-0 font-serif tabular-nums ring-0"
+              >
+                {{ standardTagIdToChipCount[t.TagId] ?? 0 }}
+              </UBadge>
+            </button>
+          </div>
+        </div>
+
+        <div class="p-2">
+          <button
+            type="button"
+            class="text-muted hover:bg-primary-muted mb-1 flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left text-xs font-medium uppercase tracking-wide"
+            :aria-expanded="workflowsSectionExpanded"
+            @click="workflowsSectionExpanded = !workflowsSectionExpanded"
+          >
+            <UIcon
+              :name="workflowsSectionExpanded ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'"
+              class="h-4 w-4 shrink-0"
+              aria-hidden="true"
+            />
+            <span>Workflows</span>
+          </button>
+          <div v-show="workflowsSectionExpanded">
+            <p v-if="!workflowTemplates.length" class="text-muted mt-2 px-2 text-xs italic">
+              No workflows have been run on these files yet.
+            </p>
+
+            <div v-for="tmpl in visibleWorkflowTemplates" :key="tmpl.key" class="mt-1">
+              <div
+                class="hover:bg-primary-muted flex w-full cursor-pointer items-center gap-1 rounded-lg pr-2 text-left text-sm"
+                :class="{
+                  'bg-primary-muted font-medium': isFilterActive({ kind: 'workflow-template', templateKey: tmpl.key }),
+                }"
+              >
+                <button
+                  v-if="tmpl.versions.length > 1"
+                  type="button"
+                  class="text-muted hover:text-primary flex h-7 w-7 shrink-0 items-center justify-center rounded"
+                  :aria-label="expandedWorkflowTemplates[tmpl.key] ? 'Collapse versions' : 'Expand versions'"
+                  @click.stop="toggleWorkflowTemplate(tmpl.key)"
+                >
+                  <UIcon
+                    :name="
+                      expandedWorkflowTemplates[tmpl.key] ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'
+                    "
+                    class="h-4 w-4"
+                  />
+                </button>
+                <span v-else class="block h-7 w-7 shrink-0" />
+                <button
+                  type="button"
+                  class="flex min-w-0 flex-1 items-center justify-between gap-2 py-2 text-left"
+                  @click="setFilter({ kind: 'workflow-template', templateKey: tmpl.key })"
+                >
+                  <span class="flex min-w-0 items-center gap-2">
+                    <span class="inline-block h-2.5 w-2.5 shrink-0 rounded-full" :style="{ background: tmpl.color }" />
+                    <span class="truncate">{{ tmpl.name }}</span>
+                  </span>
+                  <span class="text-muted shrink-0 text-xs">{{ tmpl.fileCount }}</span>
+                </button>
+              </div>
+
+              <div v-if="expandedWorkflowTemplates[tmpl.key] && tmpl.versions.length > 1" class="ml-7 mt-0.5">
+                <button
+                  v-for="v in tmpl.versions"
+                  :key="v.tag.TagId"
+                  type="button"
+                  class="hover:bg-primary-muted flex w-full items-center justify-between gap-2 rounded-lg px-2 py-1.5 text-left text-xs"
+                  :class="{
+                    'bg-primary-muted font-medium': isFilterActive({ kind: 'workflow-version', tagId: v.tag.TagId }),
+                  }"
+                  @click="setFilter({ kind: 'workflow-version', tagId: v.tag.TagId })"
+                >
+                  <span class="text-muted truncate">{{ v.label }}</span>
+                  <span class="text-muted shrink-0 tabular-nums">{{ v.tag.FileCount }}</span>
+                </button>
+              </div>
+            </div>
+
+            <button
+              v-if="workflowTemplates.length > visibleWorkflowTemplates.length || showAllWorkflowTemplates"
+              v-show="workflowTemplates.length > 6"
+              type="button"
+              class="text-primary mt-2 px-2 text-xs font-medium hover:underline"
+              @click="showAllWorkflowTemplates = !showAllWorkflowTemplates"
+            >
+              {{
+                showAllWorkflowTemplates
+                  ? 'Show fewer'
+                  : `Show ${workflowTemplates.length - visibleWorkflowTemplates.length} more`
+              }}
+            </button>
+          </div>
         </div>
       </div>
 

--- a/packages/front-end/src/app/components/EGRunFormUploadData.vue
+++ b/packages/front-end/src/app/components/EGRunFormUploadData.vue
@@ -12,7 +12,7 @@
     UploadedFileInfo,
     UploadedFilePairInfo,
   } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/upload/s3-file-upload-sample-sheet';
-  import { validateSampleSheetFile } from '@FE/utils/sample-sheet-utils';
+  import { extractS3KeysFromCsv, validateSampleSheetFile } from '@FE/utils/sample-sheet-utils';
   import { useToastStore } from '@FE/stores';
   import { useNetwork } from '@vueuse/core';
   import { RunType } from '@easy-genomics/shared-lib/src/app/types/base-entity';
@@ -533,10 +533,17 @@
       // save to wip run
       const { S3Url, Bucket, Path } = sampleSheetResponse.SampleSheetInfo;
 
+      // Track every uploaded input file key so we can record file -> workflow associations
+      // when this run is launched. R1/R2 may be undefined for single-end pairs.
+      const inputFileKeys: string[] = uploadedFilePairs
+        .flatMap((pair) => [pair.R1?.Key, pair.R2?.Key])
+        .filter((k): k is string => typeof k === 'string' && k.length > 0);
+
       wipRunUpdateFunction.value(props.wipRunTempId, {
         sampleSheetS3Url: S3Url,
         s3Bucket: Bucket,
         s3Path: Path,
+        inputFileKeys,
       });
       wipRunUpdateParamsFunction.value(props.wipRunTempId, {
         input: S3Url,
@@ -899,10 +906,23 @@
       const s3Uri = `s3://${fileInfo.Bucket}/${fileInfo.Key}`;
       const s3Path = fileInfo.Key.substring(0, fileInfo.Key.lastIndexOf('/'));
 
+      // Best-effort: parse the CSV client-side to find any s3:// references that point at
+      // this lab's bucket. Used to associate the inputs with a workflow tag on launch.
+      // Failure here is non-fatal — empty inputFileKeys just means the data tagging system
+      // won't know about these inputs (the run still launches normally).
+      let inputFileKeys: string[] = [];
+      try {
+        const csvText = await file.text();
+        inputFileKeys = extractS3KeysFromCsv(csvText, fileInfo.Bucket);
+      } catch (parseErr) {
+        console.warn('Could not parse custom sample sheet for input file keys:', parseErr);
+      }
+
       wipRunUpdateFunction.value(props.wipRunTempId, {
         sampleSheetS3Url: s3Uri,
         s3Bucket: fileInfo.Bucket,
         s3Path,
+        inputFileKeys,
       });
       wipRunUpdateParamsFunction.value(props.wipRunTempId, {
         input: s3Uri,

--- a/packages/front-end/src/app/components/EGRunPipelineFormReview.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineFormReview.vue
@@ -79,6 +79,7 @@
       }
 
       try {
+        const inputFileKeys = wipSeqeraRun.value?.inputFileKeys ?? [];
         const labRunRequest = {
           'LaboratoryId': props.labId,
           'RunId': wipSeqeraRun.value?.transactionId,
@@ -87,6 +88,8 @@
           'PlatformApiBaseUrl': labNextFlowTowerApiBaseUrl,
           'Status': 'SUBMITTED',
           'WorkflowName': pipeline.value?.name,
+          'WorkflowExternalId': props.pipelineId,
+          ...(inputFileKeys.length ? { InputFileKeys: inputFileKeys } : {}),
           'ExternalRunId': res.workflowId,
           'InputS3Url': props.params.input.substring(0, props.params.input.lastIndexOf('/')),
           'OutputS3Url': props.params.outdir,

--- a/packages/front-end/src/app/components/EGRunWorkflowFormReview.vue
+++ b/packages/front-end/src/app/components/EGRunWorkflowFormReview.vue
@@ -21,6 +21,7 @@
   const { $api } = useNuxtApp();
 
   const runStore = useRunStore();
+  const wipOmicsRun = computed(() => runStore.wipOmicsRuns[props.omicsRunTempId]);
 
   const labName = useLabsStore().labs[props.labId].Name;
   const isLaunchingRun = ref(false);
@@ -66,6 +67,7 @@
       }
 
       try {
+        const inputFileKeys = wipOmicsRun.value?.inputFileKeys ?? [];
         const labRunRequest = {
           'LaboratoryId': props.labId,
           'RunId': props.transactionId,
@@ -74,6 +76,8 @@
           'Status': 'SUBMITTED',
           'WorkflowName': props.workflowName,
           ...(props.workflowVersionName ? { WorkflowVersionName: props.workflowVersionName } : {}),
+          'WorkflowExternalId': props.workflowId,
+          ...(inputFileKeys.length ? { InputFileKeys: inputFileKeys } : {}),
           'ExternalRunId': startOmicsRes.id,
           'InputS3Url': props.params.input.substring(0, props.params.input.lastIndexOf('/')),
           'OutputS3Url': props.params.outdir,

--- a/packages/front-end/src/app/stores/run.ts
+++ b/packages/front-end/src/app/stores/run.ts
@@ -21,6 +21,13 @@ export interface WipRun {
   s3Bucket?: string;
   s3Path?: string;
   files?: FilePair[];
+  /**
+   * S3 object keys (within the laboratory bucket) for the inputs of this run. Populated
+   * either from the EG upload manifest or by best-effort parsing of a user-supplied
+   * sample sheet CSV. Forwarded to create-laboratory-run so the data tagging system can
+   * associate the files with the workflow that processed them.
+   */
+  inputFileKeys?: string[];
   paramsRequired: string[];
 }
 

--- a/packages/front-end/src/app/utils/sample-sheet-utils.ts
+++ b/packages/front-end/src/app/utils/sample-sheet-utils.ts
@@ -57,3 +57,25 @@ export async function validateSampleSheetFile(file: File | null | undefined): Pr
 
   return { valid: true };
 }
+
+/**
+ * Best-effort extraction of S3 object keys from an arbitrary sample sheet CSV. Picks up any
+ * `s3://<bucket>/<key>` reference that points at the supplied bucket; bucket-mismatched and
+ * non-S3 cells are ignored. Used to associate user-supplied sample sheets with workflow tags
+ * on the data tagging page. The match is intentionally permissive (does not assume specific
+ * column names) since EG-generated and user-supplied CSV formats vary.
+ */
+export function extractS3KeysFromCsv(csv: string, bucket: string): string[] {
+  if (!csv || !bucket) return [];
+  const pattern = /s3:\/\/([^/\s",]+)\/([^\s",]+)/gi;
+  const keys = new Set<string>();
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(csv)) !== null) {
+    const refBucket = match[1];
+    const refKey = match[2];
+    if (refBucket === bucket && refKey) {
+      keys.add(refKey);
+    }
+  }
+  return [...keys];
+}

--- a/packages/shared-lib/src/app/schema/easy-genomics/laboratory-run.ts
+++ b/packages/shared-lib/src/app/schema/easy-genomics/laboratory-run.ts
@@ -18,6 +18,20 @@ export const LaboratoryRunSchema = z
     Owner: z.string(),
     WorkflowName: z.string().optional(),
     WorkflowVersionName: z.string().optional(),
+    /**
+     * Platform-side workflow identifier (HealthOmics workflowId or Seqera pipelineId).
+     * Persisted at run-creation time so the data tagging system can associate inputs
+     * with a stable workflow identity.
+     */
+    WorkflowExternalId: z.string().optional(),
+    /**
+     * S3 object keys (within the laboratory bucket) that were used as inputs
+     * for this run. Populated at run-creation time and consumed by the data
+     * tagging system to record file -> workflow associations. Optional because
+     * legacy runs and runs whose input keys could not be determined will not
+     * have this field.
+     */
+    InputFileKeys: z.array(z.string()).optional(),
     ExternalRunId: z.string().optional(),
     InputS3Url: z.string().optional(),
     OutputS3Url: z.string().optional(),
@@ -59,6 +73,8 @@ export const ReadLaboratoryRunSchema = z
     Owner: z.string(), // User Email for display purposes
     WorkflowName: z.string().optional(), // Seqera Pipeline Name or AWS HealthOmics Workflow Name
     WorkflowVersionName: z.string().optional(),
+    WorkflowExternalId: z.string().optional(),
+    InputFileKeys: z.array(z.string()).optional(),
     ExternalRunId: z.string().optional(),
     InputS3Url: z.string().optional(),
     OutputS3Url: z.string().optional(),
@@ -85,6 +101,10 @@ export const AddLaboratoryRunSchema = z
     Status: z.string(),
     WorkflowName: z.string().optional(), // Seqera Pipeline Name or AWS HealthOmics Workflow Name
     WorkflowVersionName: z.string().optional(),
+    /** HealthOmics workflowId or Seqera pipelineId; used to associate inputs with the workflow tag. */
+    WorkflowExternalId: z.string().optional(),
+    /** S3 object keys (within the laboratory bucket) used as inputs for this run. */
+    InputFileKeys: z.array(z.string()).optional(),
     ExternalRunId: z.string().optional(),
     InputS3Url: z.string().optional(),
     OutputS3Url: z.string().optional(),

--- a/packages/shared-lib/src/app/types/easy-genomics/data-collections.ts
+++ b/packages/shared-lib/src/app/types/easy-genomics/data-collections.ts
@@ -1,4 +1,6 @@
-export type LaboratoryDataTagKind = 'standard' | 'batch';
+export type LaboratoryDataTagKind = 'standard' | 'batch' | 'workflow';
+
+export type WorkflowPlatform = 'AWS HealthOmics' | 'Seqera Cloud';
 
 export type LaboratoryDataTag = {
   TagId: string;
@@ -7,6 +9,12 @@ export type LaboratoryDataTag = {
   /** Omitted or `standard` for legacy tag rows. */
   Kind?: LaboratoryDataTagKind;
   FileCount: number;
+  /** Set on workflow-kind tags. Identifies the platform that ran the workflow. */
+  Platform?: WorkflowPlatform;
+  /** Set on workflow-kind tags. HealthOmics workflowId or Seqera pipelineId. */
+  WorkflowExternalId?: string;
+  /** Set on workflow-kind tags. Empty string represents the default version. */
+  WorkflowVersionName?: string;
   CreatedAt?: string;
   CreatedBy?: string;
   ModifiedAt?: string;
@@ -19,10 +27,12 @@ export type ListLaboratoryDataTagsResponse = {
 
 export type FileTagAssignment = {
   Key: string;
-  /** Standard (non-batch) tags only. */
+  /** Standard (non-batch, non-workflow) tags only. */
   TagIds: string[];
   /** At most one batch tag id if the file is assigned to a batch. */
   BatchTagId?: string;
+  /** Workflow tag ids that have been associated with this file via run launches. */
+  WorkflowTagIds: string[];
 };
 
 export type ListFileTagsResponse = {

--- a/packages/shared-lib/src/app/types/easy-genomics/laboratory-run.d.ts
+++ b/packages/shared-lib/src/app/types/easy-genomics/laboratory-run.d.ts
@@ -43,6 +43,17 @@ export interface LaboratoryRun extends BaseAttributes {
   Owner: string; // User Email for display purposes
   WorkflowName?: string; // Seqera Pipeline Name or AWS HealthOmics Workflow Name
   WorkflowVersionName?: string;
+  /**
+   * Platform-side workflow identifier (HealthOmics workflowId or Seqera pipelineId).
+   * Used by the data tagging system to associate input files with a stable workflow identity.
+   */
+  WorkflowExternalId?: string;
+  /**
+   * S3 object keys (within the laboratory bucket) that were used as inputs for this run.
+   * Used by the data tagging system to record file -> workflow associations and (in a future
+   * ticket) to render per-file run history.
+   */
+  InputFileKeys?: string[];
   ExternalRunId?: string;
   InputS3Url?: string;
   OutputS3Url?: string;


### PR DESCRIPTION
## EGV-125: Workflow-based filters on Data Collections and file–workflow tagging from laboratory runs

## Type of Change*

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description

This work connects **laboratory runs** to the **data tagging** model so files can be associated with the workflow that processed them, and exposes that on the **Data Collections** page as **workflow filters** (grouped by workflow template with expandable versions).

**Shared contracts (`shared-lib`)**

- Extended `LaboratoryRun` / Zod schemas with optional `WorkflowExternalId` and `InputFileKeys` so runs can carry a stable platform workflow id and the S3 keys used as inputs.
- Extended data-collections types: `LaboratoryDataTagKind` includes `workflow`; workflow tags carry `Platform`, `WorkflowExternalId`, and `WorkflowVersionName`; `FileTagAssignment` includes `WorkflowTagIds` (separate from user `TagIds` and batch tags).

**Back-end**

- After a successful `create-laboratory-run`, a best-effort hook (`associate-laboratory-run-workflow-tagging`) creates or reuses a **workflow tag** and links lab-scoped input keys to it via `LaboratoryDataTaggingService` (failures are logged and do not block run creation).
- `LaboratoryDataTaggingService` gains workflow-tag support: deterministic colors aligned with the UI palette, GSI-oriented workflow identity, `getOrCreateWorkflowTag` / `applyWorkflowToFiles`, paginated `listTags` with **strongly consistent reads**, and robust mapping of DynamoDB rows to the API model (including legacy rows where `Kind` or scalars may be incomplete—identity can be inferred from `Gsi1Sk`).
- CDK: `create-laboratory-run` Lambda receives DynamoDB permissions on the **laboratory-data-tagging** table (and indexes) for those writes.
- **Developer tooling:** `seed-workflow-tagging-test-runs` creates twelve synthetic runs (no Omics/Seqera launch) and runs the same association path, with `--reset`, `--keys-file`, dry-run, and documented IAM/env expectations (`scripts/README.md`, Projen/npm scripts).

**Front-end**

- Data Collections (`EGDataCollectionsPage.vue` and related explorer wiring): left-rail **workflow** section (template grouping, version rows, “show more”), file list filtering by **all workflows / a template / a specific version**, and handling so workflow tags are not mixed into the generic user-tag row when API shape or `Kind` is ambiguous.
- Run creation path: WIP run state, upload/review components, and sample-sheet parsing populate **`inputFileKeys`** (and reviews surface them) so `AddLaboratoryRun` can send **`InputFileKeys`** and **`WorkflowExternalId`** for tagging.
- `env.nuxt.config.ts`: when `USE_LOCAL_BACKEND` is set, local API base URL handling clears `AWS_EASY_GENOMICS_API_URL` so split-stack deploy vars do not override the local server.

**Tests**

- New/updated coverage for `laboratory-data-tagging-service` and `create-laboratory-run` around workflow tagging behavior.

## Screenshots

https://github.com/user-attachments/assets/f024a4d7-18aa-4094-8b99-3f0f7fcafac4

## Testing*

- [ ] Automated: run the back-end test suite for the touched packages.
- [ ] Manual: create a run from the UI with known input files and confirm workflow tags and filters on Data Collections; try workflow template vs version filters and “all samples” / “not analyzed” interactions.
- [ ] Optional: run `pnpm run seed-workflow-tagging-test-runs` (and `:dry-run`) against a non-prod lab per `packages/back-end/scripts/README.md` to validate filters without platform cost.

## Impact

- **Behavior:** New workflow associations are written at run creation when `WorkflowExternalId` and lab-scoped `InputFileKeys` are present; the Data Collections UI can filter by workflow.
- **Storage:** Additional reads/writes on `laboratory-data-tagging-table` from `create-laboratory-run` (best-effort, non-blocking on failure).
- **Deploy:** IAM change required for the create-run Lambda; no new npm dependencies called out in the diff summary beyond existing patterns.

## Additional Information
N/A

## Checklist*

- [ ] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [ ] Code adheres to the coding and style guidelines of the project.
- [ ] Code has been commented in particularly hard-to-understand areas.