### PR TITLE
feat: Data Tagging - Permanent Tags

### DIFF
--- a/packages/back-end/scripts/backfill-run-usage-expires-at.ts
+++ b/packages/back-end/scripts/backfill-run-usage-expires-at.ts
@@ -1,0 +1,161 @@
+/**
+ * Backfill `ExpiresAt` on every per-file `LaboratoryRunUsages` entry from the corresponding
+ * `LaboratoryRun.ExpiresAt`. Earlier code paths recorded run usage without an `ExpiresAt`
+ * mirror, so the data collections "Expiring soon" filter can be sparse on legacy data until
+ * this script (or a natural status transition) refreshes them.
+ *
+ * Idempotent — re-runs simply re-write the same value. Runs in 0 retention months
+ * configurations are skipped (their run rows have no `ExpiresAt`).
+ *
+ * Run from packages/back-end:
+ *   pnpm exec esrun scripts/backfill-run-usage-expires-at.ts [-- --dry-run] [--lab <laboratoryId>]
+ *
+ * Options:
+ *   --dry-run            Print what would be updated without writing to DynamoDB.
+ *   --lab <id>           Limit the backfill to a single laboratory id (optional).
+ *
+ * Requires .env.local (or env) with: NAME_PREFIX, REGION. Uses default AWS credentials; your
+ * identity needs DynamoDB read/write on the laboratory data tagging table.
+ */
+
+import path from 'path';
+import dotenv from 'dotenv';
+import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
+import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory-run';
+import { LaboratoryDataTaggingService } from '../src/app/services/easy-genomics/laboratory-data-tagging-service';
+import { LaboratoryRunService } from '../src/app/services/easy-genomics/laboratory-run-service';
+import { LaboratoryService } from '../src/app/services/easy-genomics/laboratory-service';
+
+function loadEnv(): void {
+  const envPath = path.resolve(process.cwd(), '.env.local');
+  dotenv.config({ path: envPath });
+  if (process.env.REGION && !process.env.AWS_REGION) {
+    process.env.AWS_REGION = process.env.REGION;
+  }
+  const required = ['NAME_PREFIX', 'REGION'];
+  const missing = required.filter((k) => !process.env[k]);
+  if (missing.length > 0) {
+    console.error(`Missing required env: ${missing.join(', ')}. Set in .env.local or environment.`);
+    process.exit(1);
+  }
+}
+
+function getFlagValue(flag: string): string | undefined {
+  const i = process.argv.indexOf(flag);
+  if (i >= 0 && process.argv[i + 1] && !process.argv[i + 1].startsWith('--')) {
+    return process.argv[i + 1];
+  }
+  return undefined;
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes('--dry-run');
+  const labFilter = getFlagValue('--lab');
+
+  loadEnv();
+
+  if (dryRun) {
+    console.log('DRY RUN: no DynamoDB writes will be performed.\n');
+  }
+
+  const runService = new LaboratoryRunService();
+  const laboratoryService = new LaboratoryService();
+  const tagging = new LaboratoryDataTaggingService();
+
+  console.log('Scanning laboratory-run table...');
+  const allRuns = await runService.listAllLaboratoryRuns();
+  const candidateRuns = allRuns.filter(
+    (r: LaboratoryRun) =>
+      typeof r.ExpiresAt === 'number' &&
+      Array.isArray(r.InputFileKeys) &&
+      r.InputFileKeys.some((k) => typeof k === 'string' && k.length > 0),
+  );
+  console.log(
+    `Found ${candidateRuns.length} laboratory run(s) with ExpiresAt + InputFileKeys (of ${allRuns.length} total).\n`,
+  );
+
+  const runsByLab = new Map<string, LaboratoryRun[]>();
+  for (const run of candidateRuns) {
+    if (labFilter && run.LaboratoryId !== labFilter) continue;
+    const list = runsByLab.get(run.LaboratoryId) ?? [];
+    list.push(run);
+    runsByLab.set(run.LaboratoryId, list);
+  }
+
+  if (runsByLab.size === 0) {
+    console.log(
+      labFilter
+        ? `No runs with ExpiresAt for laboratory ${labFilter}.`
+        : 'No runs with ExpiresAt found in any laboratory.',
+    );
+    return;
+  }
+
+  let totalRuns = 0;
+  let skipped = 0;
+  let errors = 0;
+
+  for (const [laboratoryId, runs] of runsByLab) {
+    let laboratory: Laboratory;
+    try {
+      laboratory = await laboratoryService.queryByLaboratoryId(laboratoryId);
+    } catch (err) {
+      console.warn(`Skip lab ${laboratoryId}: failed to load laboratory record (${(err as Error).message ?? err}).`);
+      skipped += runs.length;
+      continue;
+    }
+    if (!laboratory.S3Bucket) {
+      console.warn(`Skip lab ${laboratoryId}: no S3Bucket configured.`);
+      skipped += runs.length;
+      continue;
+    }
+
+    const labPrefix = `${laboratory.OrganizationId}/${laboratory.LaboratoryId}/`;
+    console.log(`Lab ${laboratoryId} (${laboratory.S3Bucket}): ${runs.length} run(s)`);
+
+    for (const run of runs) {
+      const inputKeys = (run.InputFileKeys || []).filter(
+        (k: string): k is string => typeof k === 'string' && k.length > 0,
+      );
+      const labScopedKeys = inputKeys.filter((k) => k.startsWith(labPrefix));
+      if (!labScopedKeys.length || typeof run.ExpiresAt !== 'number') {
+        skipped++;
+        continue;
+      }
+
+      if (dryRun) {
+        console.log(
+          `  [dry-run] Would patch ExpiresAt=${run.ExpiresAt} onto run ${run.RunId} across ${labScopedKeys.length} file(s)`,
+        );
+        totalRuns++;
+        continue;
+      }
+
+      try {
+        await tagging.updateRunUsageExpiresAt(
+          laboratory,
+          laboratory.S3Bucket as string,
+          run.RunId,
+          labScopedKeys,
+          run.ExpiresAt,
+        );
+        totalRuns++;
+      } catch (err) {
+        console.error(`  Error patching ExpiresAt for run ${run.RunId}:`, (err as Error).message ?? err);
+        errors++;
+      }
+    }
+  }
+
+  console.log(
+    `\nDone. ${dryRun ? 'Would have patched' : 'Patched'} ${totalRuns} run(s), skipped ${skipped}, errors: ${errors}.`,
+  );
+  if (errors > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/back-end/src/app/controllers/easy-genomics/data-collections/list-tags.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/data-collections/list-tags.lambda.ts
@@ -33,6 +33,12 @@ export const handler: Handler = async (
       throw new UnauthorizedAccessError();
     }
 
+    // Lazy-create the laboratory's singleton permanent tag so the UI can always render the
+    // "Mark Permanent" affordance without a separate provisioning round trip. Idempotent and
+    // safe under concurrent first reads (deterministic id + conditional PutItem).
+    const userId = event.requestContext.authorizer?.claims?.['cognito:username'] || 'system';
+    await taggingService.ensurePermanentTag(laboratory, userId);
+
     const res = await taggingService.listTags(laboratoryId);
     return buildResponse(200, JSON.stringify(res), event);
   } catch (err: any) {

--- a/packages/back-end/src/app/controllers/easy-genomics/data-collections/process-expired-laboratory-data.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/data-collections/process-expired-laboratory-data.lambda.ts
@@ -1,0 +1,184 @@
+import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
+import { Handler, ScheduledEvent } from 'aws-lambda';
+import {
+  LaboratoryDataTaggingService,
+  permanentTagIdForLaboratory,
+} from '@BE/services/easy-genomics/laboratory-data-tagging-service';
+import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
+import { S3Service } from '@BE/services/s3-service';
+
+const laboratoryService = new LaboratoryService();
+const dataTaggingService = new LaboratoryDataTaggingService();
+const s3Service = new S3Service();
+
+const METRIC_NAMESPACE = 'EasyGenomics/DataRetention';
+
+/**
+ * Scheduled (daily) Lambda that performs the S3 deletion half of the run-retention cascade
+ * described in the "Permanent tag and S3 expiry" plan.
+ *
+ * Eligibility for deletion (per file row in the data tagging table):
+ *   1. `LaboratoryRunUsages` is empty or absent
+ *      (the DynamoDB-stream subscriber removes usages as their run rows TTL out).
+ *   2. The file row carries at least one workflow tag id in `TagIds`
+ *      — proves the file was once associated with a run; distinguishes "expired" from
+ *      "never-used orphan" (orphans are intentionally NOT auto-deleted per the plan).
+ *   3. The file row does NOT carry the laboratory's singleton permanent tag id.
+ *
+ * Honors a DRY_RUN env flag for safe initial deploys; emits CloudWatch metrics under the
+ * `EasyGenomics/DataRetention` namespace.
+ *
+ * Triggered by an EventBridge Scheduled Rule (see `easy-genomics-nested-stack.ts`).
+ */
+export const handler: Handler<ScheduledEvent, void> = async (event: ScheduledEvent): Promise<void> => {
+  const dryRun = (process.env.DRY_RUN ?? '').toLowerCase() === 'true';
+  console.log(`Starting expired laboratory data sweep (dryRun=${dryRun})`, {
+    eventId: event?.id,
+    time: event?.time,
+  });
+
+  let totalEligible = 0;
+  let totalDeleted = 0;
+  let totalPermanentProtected = 0;
+  let totalErrors = 0;
+
+  const laboratories = await laboratoryService.listAllLaboratories();
+  for (const lab of laboratories) {
+    try {
+      const stats = await sweepLaboratory(lab, dryRun);
+      totalEligible += stats.eligible;
+      totalDeleted += stats.deleted;
+      totalPermanentProtected += stats.permanentProtected;
+      totalErrors += stats.errors;
+    } catch (err) {
+      console.error(`Sweep failed for lab ${lab.LaboratoryId} (continuing):`, err);
+      totalErrors++;
+    }
+  }
+
+  console.log('Expired laboratory data sweep summary:', {
+    dryRun,
+    laboratories: laboratories.length,
+    eligible: totalEligible,
+    deleted: totalDeleted,
+    permanentProtected: totalPermanentProtected,
+    errors: totalErrors,
+  });
+
+  emitEmfMetrics({
+    Eligible: totalEligible,
+    Deleted: totalDeleted,
+    PermanentProtected: totalPermanentProtected,
+    Errors: totalErrors,
+  });
+};
+
+/**
+ * Lab-scoped sweep. Walks every FILE# row, evaluates eligibility, deletes the S3 object and
+ * tagging-table rows when applicable. Per-lab errors are counted but do not abort the rest of
+ * the sweep.
+ */
+async function sweepLaboratory(
+  laboratory: Laboratory,
+  dryRun: boolean,
+): Promise<{ eligible: number; deleted: number; permanentProtected: number; errors: number }> {
+  let eligible = 0;
+  let deleted = 0;
+  let permanentProtected = 0;
+  let errors = 0;
+
+  if (!laboratory.S3Bucket) {
+    return { eligible, deleted, permanentProtected, errors };
+  }
+
+  const labPermanentTagId = permanentTagIdForLaboratory(laboratory.LaboratoryId);
+  const { batchTagIds, workflowTagIds } = await loadKindIndexedTagIds(laboratory.LaboratoryId);
+
+  const rows = await dataTaggingService.listAllFileRowsForLab(laboratory.LaboratoryId);
+
+  for (const row of rows) {
+    const tagIds = new Set<string>(row.TagIds || []);
+    const isPermanent = tagIds.has(labPermanentTagId);
+    const hasUsages = !!row.LaboratoryRunUsages && Object.keys(row.LaboratoryRunUsages).length > 0;
+    const hasWorkflowTag = [...tagIds].some((id) => workflowTagIds.has(id));
+
+    if (!hasWorkflowTag) continue; // Never-used orphan: not in scope for auto-delete.
+    if (hasUsages) continue; // At least one run still retains this file.
+    if (isPermanent) {
+      permanentProtected++;
+      continue;
+    }
+
+    eligible++;
+
+    const bucket = row.S3Bucket || laboratory.S3Bucket;
+    const key = row.ObjectKey;
+    if (!bucket || !key) continue;
+
+    if (dryRun) {
+      console.log(`  [dry-run] Would delete s3://${bucket}/${key} (lab=${laboratory.LaboratoryId})`);
+      continue;
+    }
+
+    try {
+      await s3Service.deleteObject({ Bucket: bucket, Key: key });
+      // Standard tag and batch tag refs are also gone with the FILE# row; their MAP# rows are
+      // cleaned up inside `deleteFileRowAndAssociations`, which adjusts each TAG#'s FileCount.
+      void batchTagIds; // keep lint happy; batch ids are not consulted here but loaded above
+      await dataTaggingService.deleteFileRowAndAssociations(laboratory.LaboratoryId, row.Ref);
+      deleted++;
+    } catch (err) {
+      console.warn(`  Error deleting s3://${bucket}/${key} (lab=${laboratory.LaboratoryId}):`, err);
+      errors++;
+    }
+  }
+
+  console.log(
+    `Lab ${laboratory.LaboratoryId} sweep complete: eligible=${eligible} deleted=${deleted} permanentProtected=${permanentProtected} errors=${errors}`,
+  );
+
+  return { eligible, deleted, permanentProtected, errors };
+}
+
+/**
+ * Loads the laboratory's batch + workflow tag id sets so the sweep can identify
+ * workflow-tagged files without re-loading TAG# rows per file. Mirrors the partition logic in
+ * `LaboratoryDataTaggingService.listFileTags`.
+ */
+async function loadKindIndexedTagIds(
+  laboratoryId: string,
+): Promise<{ batchTagIds: Set<string>; workflowTagIds: Set<string> }> {
+  const { Tags } = await dataTaggingService.listTags(laboratoryId);
+  const batchTagIds = new Set<string>();
+  const workflowTagIds = new Set<string>();
+  for (const t of Tags) {
+    const kind = t.Kind ?? 'standard';
+    if (kind === 'batch') batchTagIds.add(t.TagId);
+    else if (kind === 'workflow' || !!(t.Platform && t.WorkflowExternalId)) workflowTagIds.add(t.TagId);
+  }
+  return { batchTagIds, workflowTagIds };
+}
+
+/**
+ * Emit a CloudWatch Embedded Metric Format (EMF) record so the metrics show up in CloudWatch
+ * without taking a runtime dependency on `@aws-sdk/client-cloudwatch`. EMF is just a JSON
+ * shape on a single log line that the CloudWatch agent recognises.
+ */
+function emitEmfMetrics(metrics: Record<string, number>): void {
+  const metricNames = Object.keys(metrics);
+  if (metricNames.length === 0) return;
+  const record = {
+    _aws: {
+      Timestamp: Date.now(),
+      CloudWatchMetrics: [
+        {
+          Namespace: METRIC_NAMESPACE,
+          Dimensions: [[]],
+          Metrics: metricNames.map((name) => ({ Name: name, Unit: 'Count' as const })),
+        },
+      ],
+    },
+    ...metrics,
+  };
+  console.log(JSON.stringify(record));
+}

--- a/packages/back-end/src/app/controllers/easy-genomics/data-collections/process-expired-laboratory-data.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/data-collections/process-expired-laboratory-data.lambda.ts
@@ -13,6 +13,15 @@ const s3Service = new S3Service();
 
 const METRIC_NAMESPACE = 'EasyGenomics/DataRetention';
 
+function parseMaxDeletesPerLabSweep(): number {
+  const raw = process.env.MAX_DELETES_PER_LAB_SWEEP;
+  if (raw == null || raw === '') return 25_000;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0) return 25_000;
+  // `0` disables all per-lab deletes for this invocation (useful in emergencies).
+  return n;
+}
+
 /**
  * Scheduled (daily) Lambda that performs the S3 deletion half of the run-retention cascade
  * described in the "Permanent tag and S3 expiry" plan.
@@ -25,14 +34,17 @@ const METRIC_NAMESPACE = 'EasyGenomics/DataRetention';
  *      "never-used orphan" (orphans are intentionally NOT auto-deleted per the plan).
  *   3. The file row does NOT carry the laboratory's singleton permanent tag id.
  *
- * Honors a DRY_RUN env flag for safe initial deploys; emits CloudWatch metrics under the
- * `EasyGenomics/DataRetention` namespace.
+ * Honors a DRY_RUN env flag for safe initial deploys: only the literal value `false` enables
+ * real S3 and tagging-table deletes (any other value, including unset, runs in dry-run mode).
+ * Optional `MAX_DELETES_PER_LAB_SWEEP` caps how many objects a single invocation may delete per
+ * lab (defense in depth). Emits CloudWatch EMF metrics under `EasyGenomics/DataRetention`.
  *
  * Triggered by an EventBridge Scheduled Rule (see `easy-genomics-nested-stack.ts`).
  */
 export const handler: Handler<ScheduledEvent, void> = async (event: ScheduledEvent): Promise<void> => {
-  const dryRun = (process.env.DRY_RUN ?? '').toLowerCase() === 'true';
-  console.log(`Starting expired laboratory data sweep (dryRun=${dryRun})`, {
+  const dryRun = process.env.DRY_RUN !== 'false';
+  const maxDeletesPerLab = parseMaxDeletesPerLabSweep();
+  console.log(`Starting expired laboratory data sweep (dryRun=${dryRun}, maxDeletesPerLab=${maxDeletesPerLab})`, {
     eventId: event?.id,
     time: event?.time,
   });
@@ -41,15 +53,17 @@ export const handler: Handler<ScheduledEvent, void> = async (event: ScheduledEve
   let totalDeleted = 0;
   let totalPermanentProtected = 0;
   let totalErrors = 0;
+  let totalLabsHitDeleteCap = 0;
 
   const laboratories = await laboratoryService.listAllLaboratories();
   for (const lab of laboratories) {
     try {
-      const stats = await sweepLaboratory(lab, dryRun);
+      const stats = await sweepLaboratory(lab, dryRun, maxDeletesPerLab);
       totalEligible += stats.eligible;
       totalDeleted += stats.deleted;
       totalPermanentProtected += stats.permanentProtected;
       totalErrors += stats.errors;
+      totalLabsHitDeleteCap += stats.hitDeleteCap ? 1 : 0;
     } catch (err) {
       console.error(`Sweep failed for lab ${lab.LaboratoryId} (continuing):`, err);
       totalErrors++;
@@ -63,6 +77,7 @@ export const handler: Handler<ScheduledEvent, void> = async (event: ScheduledEve
     deleted: totalDeleted,
     permanentProtected: totalPermanentProtected,
     errors: totalErrors,
+    labsHitDeleteCap: totalLabsHitDeleteCap,
   });
 
   emitEmfMetrics({
@@ -70,6 +85,7 @@ export const handler: Handler<ScheduledEvent, void> = async (event: ScheduledEve
     Deleted: totalDeleted,
     PermanentProtected: totalPermanentProtected,
     Errors: totalErrors,
+    LabsHitDeleteCap: totalLabsHitDeleteCap,
   });
 };
 
@@ -81,14 +97,23 @@ export const handler: Handler<ScheduledEvent, void> = async (event: ScheduledEve
 async function sweepLaboratory(
   laboratory: Laboratory,
   dryRun: boolean,
-): Promise<{ eligible: number; deleted: number; permanentProtected: number; errors: number }> {
+  maxDeletesPerLab: number,
+): Promise<{
+  eligible: number;
+  deleted: number;
+  permanentProtected: number;
+  errors: number;
+  hitDeleteCap: boolean;
+}> {
   let eligible = 0;
   let deleted = 0;
   let permanentProtected = 0;
   let errors = 0;
+  let hitDeleteCap = false;
+  let loggedDeleteCap = false;
 
   if (!laboratory.S3Bucket) {
-    return { eligible, deleted, permanentProtected, errors };
+    return { eligible, deleted, permanentProtected, errors, hitDeleteCap };
   }
 
   const labPermanentTagId = permanentTagIdForLaboratory(laboratory.LaboratoryId);
@@ -120,6 +145,29 @@ async function sweepLaboratory(
       continue;
     }
 
+    if (deleted >= maxDeletesPerLab) {
+      hitDeleteCap = true;
+      if (!loggedDeleteCap) {
+        loggedDeleteCap = true;
+        console.warn(
+          `Lab ${laboratory.LaboratoryId} reached MAX_DELETES_PER_LAB_SWEEP=${maxDeletesPerLab}; remaining eligible rows left for a future run.`,
+        );
+      }
+      continue;
+    }
+
+    try {
+      dataTaggingService.assertBucketMatchesLab(laboratory, bucket);
+      dataTaggingService.assertKeyUnderLabPrefix(laboratory, key);
+    } catch (guardErr) {
+      console.warn(
+        `  Skip delete s3://${bucket}/${key} (lab=${laboratory.LaboratoryId}): bucket/key guard failed:`,
+        guardErr,
+      );
+      errors++;
+      continue;
+    }
+
     try {
       await s3Service.deleteObject({ Bucket: bucket, Key: key });
       // Standard tag and batch tag refs are also gone with the FILE# row; their MAP# rows are
@@ -137,7 +185,7 @@ async function sweepLaboratory(
     `Lab ${laboratory.LaboratoryId} sweep complete: eligible=${eligible} deleted=${deleted} permanentProtected=${permanentProtected} errors=${errors}`,
   );
 
-  return { eligible, deleted, permanentProtected, errors };
+  return { eligible, deleted, permanentProtected, errors, hitDeleteCap };
 }
 
 /**

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/process-laboratory-run-stream.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/process-laboratory-run-stream.lambda.ts
@@ -1,0 +1,108 @@
+import type { AttributeValue as DDBAttributeValue } from '@aws-sdk/client-dynamodb';
+import { unmarshall } from '@aws-sdk/util-dynamodb';
+import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
+import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory-run';
+import { DynamoDBRecord, DynamoDBStreamEvent, Handler } from 'aws-lambda';
+import { LaboratoryDataTaggingService } from '@BE/services/easy-genomics/laboratory-data-tagging-service';
+import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
+
+const laboratoryService = new LaboratoryService();
+const laboratoryDataTaggingService = new LaboratoryDataTaggingService();
+
+/**
+ * DynamoDB Stream subscriber for the `laboratory-run-table`. Triggered on every change record;
+ * REMOVE events (manual delete or TTL expiry) drive the bookkeeping half of the S3 deletion
+ * cascade described in the "Permanent tag and S3 expiry" plan:
+ *
+ *   1. Unmarshal the OLD image of the removed run row.
+ *   2. Remove the run id from every input file's `LaboratoryRunUsages` map in the data
+ *      tagging table (via `removeLaboratoryRunUsageForRunIds`).
+ *   3. The scheduled `process-expired-laboratory-data` Lambda later picks up FILE# rows
+ *      that have been left with no remaining usages and deletes the underlying S3 object
+ *      (skipping anything marked Permanent).
+ *
+ * Distinguishing TTL vs manual delete: TTL removals are recorded with
+ * `userIdentity.principalId === 'dynamodb.amazonaws.com'`. We log the source but treat both
+ * the same way — the bookkeeping is identical.
+ *
+ * Idempotent and safe to retry: `removeLaboratoryRunUsageForRunIds` is conditional and silently
+ * no-ops when the run id is already absent. The Lambda is wired with a DLQ at the event source
+ * so poison records don't block the stream.
+ */
+export const handler: Handler<DynamoDBStreamEvent, void> = async (event: DynamoDBStreamEvent): Promise<void> => {
+  for (const record of event.Records || []) {
+    try {
+      await processRecord(record);
+    } catch (err) {
+      // Surface a structured log so CloudWatch alarms can target this path; rethrow so the
+      // event source can retry / route to the DLQ rather than silently dropping the change.
+      console.error('Failed to process laboratory-run stream record:', {
+        eventID: record.eventID,
+        eventName: record.eventName,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      throw err;
+    }
+  }
+};
+
+async function processRecord(record: DynamoDBRecord): Promise<void> {
+  if (record.eventName !== 'REMOVE') {
+    // INSERT/MODIFY events don't need handling here; tagging-side bookkeeping for new runs
+    // already happens synchronously from create-laboratory-run / update-laboratory-run.
+    return;
+  }
+
+  const oldImage = record.dynamodb?.OldImage;
+  if (!oldImage) {
+    console.warn(`REMOVE record without OldImage; skipping. eventID=${record.eventID}`);
+    return;
+  }
+
+  // The DynamoDB stream record's image uses the same attribute-value shape as the SDK, but
+  // typed as the `aws-lambda` package's local type. Cast through the SDK type so `unmarshall`
+  // accepts it without losing field-level safety.
+  const run = unmarshall(oldImage as Record<string, DDBAttributeValue>) as Partial<LaboratoryRun>;
+  const laboratoryId = run.LaboratoryId;
+  const runId = run.RunId;
+  const inputFileKeys = Array.isArray(run.InputFileKeys) ? run.InputFileKeys : [];
+
+  if (!laboratoryId || !runId) {
+    console.warn(`REMOVE record missing LaboratoryId/RunId; skipping. eventID=${record.eventID}`);
+    return;
+  }
+
+  const isTtlRemoval = record.userIdentity?.principalId === 'dynamodb.amazonaws.com';
+  console.log(
+    `Processing run-row REMOVE (${isTtlRemoval ? 'TTL' : 'manual/cascade'}): laboratoryId=${laboratoryId}, runId=${runId}, inputs=${inputFileKeys.length}`,
+  );
+
+  if (!inputFileKeys.length) {
+    // Nothing to unlink in the tagging table.
+    return;
+  }
+
+  let laboratory: Laboratory | undefined;
+  try {
+    laboratory = await laboratoryService.queryByLaboratoryId(laboratoryId);
+  } catch (err) {
+    console.warn(`Skip cascade for RunId=${runId}: failed to load Laboratory ${laboratoryId} (continuing):`, err);
+    return;
+  }
+  if (!laboratory?.S3Bucket) {
+    console.warn(`Skip cascade for RunId=${runId}: Laboratory ${laboratoryId} has no S3Bucket configured.`);
+    return;
+  }
+
+  await laboratoryDataTaggingService.removeLaboratoryRunUsageForRunIds(
+    laboratory,
+    laboratory.S3Bucket,
+    {
+      [runId]: inputFileKeys.filter((k): k is string => typeof k === 'string' && k.length > 0),
+    },
+    // Keep the FILE# row even when it ends up with no usages and no tags. The scheduled
+    // cleanup Lambda needs the row (S3Bucket + ObjectKey) to issue the s3:DeleteObject; we
+    // can't reconstruct it once both tables forget the file.
+    { preserveEmptyFileRow: true },
+  );
+}

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/process-laboratory-run-stream.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/process-laboratory-run-stream.lambda.ts
@@ -1,5 +1,6 @@
 import type { AttributeValue as DDBAttributeValue } from '@aws-sdk/client-dynamodb';
 import { unmarshall } from '@aws-sdk/util-dynamodb';
+import { LaboratoryNotFoundError } from '@easy-genomics/shared-lib/lib/app/utils/HttpError';
 import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
 import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory-run';
 import { DynamoDBRecord, DynamoDBStreamEvent, Handler } from 'aws-lambda';
@@ -86,8 +87,17 @@ async function processRecord(record: DynamoDBRecord): Promise<void> {
   try {
     laboratory = await laboratoryService.queryByLaboratoryId(laboratoryId);
   } catch (err) {
-    console.warn(`Skip cascade for RunId=${runId}: failed to load Laboratory ${laboratoryId} (continuing):`, err);
-    return;
+    if (err instanceof LaboratoryNotFoundError) {
+      console.warn(
+        `Skip cascade for RunId=${runId}: Laboratory ${laboratoryId} not found (run bookkeeping is a no-op).`,
+      );
+      return;
+    }
+    console.error(
+      `Failed to load Laboratory ${laboratoryId} for RunId=${runId} cascade (will retry via stream/DLQ):`,
+      err,
+    );
+    throw err;
   }
   if (!laboratory?.S3Bucket) {
     console.warn(`Skip cascade for RunId=${runId}: Laboratory ${laboratoryId} has no S3Bucket configured.`);

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.ts
@@ -12,6 +12,7 @@ import { DescribeWorkflowResponse } from '@easy-genomics/shared-lib/src/app/type
 import { APIGatewayProxyResult, Handler, SQSRecord } from 'aws-lambda';
 import { SQSEvent } from 'aws-lambda/trigger/sqs';
 //import { v4 as uuidv4 } from 'uuid';
+import { LaboratoryDataTaggingService } from '@BE/services/easy-genomics/laboratory-data-tagging-service';
 import { LaboratoryRunService } from '@BE/services/easy-genomics/laboratory-run-service';
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
 import { createOmicsServiceForLab } from '@BE/services/omics-lab-factory';
@@ -27,7 +28,34 @@ import { getNextFlowApiQueryParameters, httpRequest, REST_API_METHOD } from '@BE
 
 const laboratoryService = new LaboratoryService();
 const laboratoryRunService = new LaboratoryRunService();
+const laboratoryDataTaggingService = new LaboratoryDataTaggingService();
 const ssmService = new SsmService();
+
+/**
+ * Best-effort mirror of a run's ExpiresAt into each input file's `LaboratoryRunUsages` entry.
+ * Logs and swallows so tagging-side failures never break the status-check pipeline.
+ */
+async function safePropagateExpiresAt(
+  laboratory: Laboratory | undefined,
+  run: LaboratoryRun,
+  expiresAt: number | undefined,
+): Promise<void> {
+  if (expiresAt === undefined) return;
+  if (!laboratory?.S3Bucket) return;
+  const keys = run.InputFileKeys || [];
+  if (!keys.length) return;
+  try {
+    await laboratoryDataTaggingService.updateRunUsageExpiresAt(
+      laboratory,
+      laboratory.S3Bucket,
+      run.RunId,
+      keys,
+      expiresAt,
+    );
+  } catch (err) {
+    console.warn('Failed to propagate ExpiresAt to LaboratoryRunUsages (continuing):', err);
+  }
+}
 
 export const handler: Handler = async (event: SQSEvent): Promise<APIGatewayProxyResult> => {
   console.log('EVENT: \n' + JSON.stringify(event, null, 2));
@@ -106,12 +134,14 @@ export async function processStatusCheckEvent(operation: SnsProcessingOperation,
         }
       }
 
+      const backfilledExpiresAt = missingExpiresAt
+        ? calculateExpiresAtEpochSeconds(new Date(terminalAtIso), retentionMonths)
+        : undefined;
+
       const updated = await laboratoryRunService.update({
         ...existingRun,
         ...(missingTerminalAt ? { TerminalAt: terminalAtIso } : {}),
-        ...(missingExpiresAt
-          ? { ExpiresAt: calculateExpiresAtEpochSeconds(new Date(terminalAtIso), retentionMonths) }
-          : {}),
+        ...(backfilledExpiresAt !== undefined ? { ExpiresAt: backfilledExpiresAt } : {}),
         ...(snapshot?.durationSeconds != null && existingRun.RunDurationSeconds == null
           ? { RunDurationSeconds: snapshot.durationSeconds }
           : {}),
@@ -119,6 +149,7 @@ export async function processStatusCheckEvent(operation: SnsProcessingOperation,
         ModifiedBy: 'Status Check',
       });
       void updated;
+      await safePropagateExpiresAt(laboratory, updated, backfilledExpiresAt);
       return true;
     }
 
@@ -145,19 +176,23 @@ export async function processStatusCheckEvent(operation: SnsProcessingOperation,
         shouldExpireWithRetentionMonths(retentionMonths) &&
         terminalAtIso != null;
 
+      const newExpiresAt =
+        shouldSetExpiresAt && terminalAtIso
+          ? calculateExpiresAtEpochSeconds(new Date(terminalAtIso), retentionMonths)
+          : undefined;
+
       laboratoryRun = await laboratoryRunService.update({
         ...existingRun,
         Status: newStatusNormalized,
         ...(shouldSetTerminalAt ? { TerminalAt: terminalAtIso } : {}),
-        ...(shouldSetExpiresAt && terminalAtIso
-          ? { ExpiresAt: calculateExpiresAtEpochSeconds(new Date(terminalAtIso), retentionMonths) }
-          : {}),
+        ...(newExpiresAt !== undefined ? { ExpiresAt: newExpiresAt } : {}),
         ...(snapshot.durationSeconds != null && existingRun.RunDurationSeconds == null
           ? { RunDurationSeconds: snapshot.durationSeconds }
           : {}),
         ModifiedAt: now.toISOString(),
         ModifiedBy: 'Status Check',
       });
+      await safePropagateExpiresAt(laboratory, laboratoryRun, newExpiresAt);
     } else if (snapshot.durationSeconds != null && existingRun.RunDurationSeconds == null) {
       // No status change, but the platform now reports a duration we hadn't captured yet.
       const now = new Date();

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/request-apply-run-retention-policy.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/request-apply-run-retention-policy.lambda.ts
@@ -7,6 +7,7 @@ import {
   UnauthorizedAccessError,
 } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
 import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
+import { LaboratoryDataTaggingService } from '@BE/services/easy-genomics/laboratory-data-tagging-service';
 import { LaboratoryRunService } from '@BE/services/easy-genomics/laboratory-run-service';
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
 import {
@@ -24,6 +25,7 @@ import {
 
 const laboratoryRunService = new LaboratoryRunService();
 const laboratoryService = new LaboratoryService();
+const laboratoryDataTaggingService = new LaboratoryDataTaggingService();
 
 type RequestBody = {
   retentionMonths?: number;
@@ -110,6 +112,23 @@ export const handler: Handler = async (
         },
         remove: needsExpiresAtRemove ? ['ExpiresAt'] : [],
       });
+
+      // Mirror the new (or cleared) ExpiresAt onto each input file's LaboratoryRunUsages entry
+      // so the data collections UI reflects the policy change without re-reading the run table.
+      // Best-effort: tagging-side failures must not roll back the retention update.
+      if (laboratory.S3Bucket && (run.InputFileKeys || []).length > 0) {
+        try {
+          await laboratoryDataTaggingService.updateRunUsageExpiresAt(
+            laboratory,
+            laboratory.S3Bucket,
+            run.RunId,
+            run.InputFileKeys || [],
+            needsExpiresAtRemove ? undefined : desiredExpiresAt,
+          );
+        } catch (err) {
+          console.warn(`Failed to propagate ExpiresAt to tagging for RunId=${run.RunId} (continuing):`, err);
+        }
+      }
 
       if (needsExpiresAtRemove) removed++;
       if (needsTerminalAt || needsExpiresAtSet) updated++;

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/update-laboratory-run.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/update-laboratory-run.lambda.ts
@@ -13,6 +13,7 @@ import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-geno
 import { SnsProcessingEvent } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/sns-processing-event';
 import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
 import { v4 as uuidv4 } from 'uuid';
+import { LaboratoryDataTaggingService } from '@BE/services/easy-genomics/laboratory-data-tagging-service';
 import { LaboratoryRunService } from '@BE/services/easy-genomics/laboratory-run-service';
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
 import { SnsService } from '@BE/services/sns-service';
@@ -33,6 +34,7 @@ const snsService = new SnsService();
 
 const laboratoryRunService = new LaboratoryRunService();
 const laboratoryService = new LaboratoryService();
+const laboratoryDataTaggingService = new LaboratoryDataTaggingService();
 
 export const handler: Handler = async (
   event: APIGatewayProxyWithCognitoAuthorizerEvent,
@@ -100,6 +102,23 @@ export const handler: Handler = async (
       ModifiedAt: now.toISOString(),
       ModifiedBy: currentUserId,
     });
+
+    // Propagate the freshly computed `ExpiresAt` into every per-file LaboratoryRunUsages entry
+    // so the data collections page can power "Expiring soon" without re-reading the run table.
+    // Best-effort: tagging-side failures must not break the run update.
+    if (expiresAt !== undefined && laboratory?.S3Bucket && (response.InputFileKeys || []).length > 0) {
+      try {
+        await laboratoryDataTaggingService.updateRunUsageExpiresAt(
+          laboratory,
+          laboratory.S3Bucket,
+          response.RunId,
+          response.InputFileKeys || [],
+          expiresAt,
+        );
+      } catch (err) {
+        console.warn('Failed to propagate ExpiresAt to LaboratoryRunUsages (continuing):', err);
+      }
+    }
 
     //TODO: check if it is an active request
 

--- a/packages/back-end/src/app/services/easy-genomics/associate-laboratory-run-workflow-tagging.ts
+++ b/packages/back-end/src/app/services/easy-genomics/associate-laboratory-run-workflow-tagging.ts
@@ -49,6 +49,12 @@ export async function associateInputsWithWorkflowTag(args: {
       RunCreatedAt: run.CreatedAt ?? new Date().toISOString(),
       InputFileCount: labScopedKeys.length,
       InputFileKeys: labScopedKeys,
+      // Mirror the run's current `ExpiresAt` (when known) onto every per-file usage entry so
+      // the data collections page can compute "Expiring soon" without a second round trip
+      // to the run table. When the run is not yet terminal or retention is disabled this is
+      // left undefined; the value is patched on the file rows when the run later transitions
+      // to a terminal status (see `updateRunUsageExpiresAt`).
+      ...(typeof run.ExpiresAt === 'number' ? { ExpiresAt: run.ExpiresAt } : {}),
     };
 
     await tagging.recordLaboratoryRunInputUsage(laboratory, userId, laboratory.S3Bucket, labScopedKeys, summary);

--- a/packages/back-end/src/app/services/easy-genomics/laboratory-data-tagging-service.ts
+++ b/packages/back-end/src/app/services/easy-genomics/laboratory-data-tagging-service.ts
@@ -25,6 +25,27 @@ const GSI1_NAME = 'Gsi1Pk_Index';
 /** Namespace UUID for v5 workflow tag ids (stable per lab + platform + workflow identity). */
 const WORKFLOW_TAG_ID_NAMESPACE = 'a3d8f7e2-4c1b-5d6e-9f8a-0b1c2d3e4f5a';
 
+/**
+ * Namespace UUID for v5 permanent tag ids (one stable id per laboratory). The permanent tag is a
+ * lazily-created singleton per laboratory — its id is derived from the laboratory id under this
+ * namespace so the same id is recovered after stack rebuilds, restores, and concurrent first
+ * reads.
+ */
+const PERMANENT_TAG_ID_NAMESPACE = '7b2c6f81-9d3a-4e25-8f47-12a4d8b6e9c0';
+
+/** Fixed display name for every laboratory's singleton permanent tag. */
+const PERMANENT_TAG_NAME = 'Permanent';
+/** Fixed red palette used to distinguish the permanent tag chip in the UI from user tags. */
+const PERMANENT_TAG_COLOR = '#DC2626';
+
+function deterministicPermanentTagId(laboratoryId: string): string {
+  return uuidv5(laboratoryId, PERMANENT_TAG_ID_NAMESPACE);
+}
+
+export function permanentTagIdForLaboratory(laboratoryId: string): string {
+  return deterministicPermanentTagId(laboratoryId);
+}
+
 function isConditionalCheckFailed(e: unknown): boolean {
   return (
     e instanceof ConditionalCheckFailedException ||
@@ -169,6 +190,76 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
     return { Tags: tags };
   }
 
+  /**
+   * Lab-stable id of the singleton permanent tag for the given laboratory. The TAG# row itself
+   * is lazily created on first access via {@link ensurePermanentTag}; consumers that just need
+   * the id (e.g. to test membership on a FILE# row) can call this without a write.
+   */
+  public getPermanentTagId(laboratoryId: string): string {
+    return deterministicPermanentTagId(laboratoryId);
+  }
+
+  /**
+   * Returns the laboratory's singleton permanent tag, creating it on first call. Mirrors the
+   * lazy-creation pattern used by workflow tags so callers don't have to gate read paths on a
+   * separate provisioning step. Safe under concurrent creation: the deterministic id +
+   * conditional PutItem makes the second writer observe a `ConditionalCheckFailedException` and
+   * read the winning row back.
+   */
+  public async ensurePermanentTag(laboratory: Laboratory, userId: string): Promise<LaboratoryDataTag> {
+    const laboratoryId = laboratory.LaboratoryId;
+    const tagId = deterministicPermanentTagId(laboratoryId);
+    const existing = await this.getTagRow(laboratoryId, tagId);
+    if (existing) {
+      return existing;
+    }
+
+    const now = new Date().toISOString();
+    const tag: LaboratoryDataTag = {
+      TagId: tagId,
+      Name: PERMANENT_TAG_NAME,
+      ColorHex: PERMANENT_TAG_COLOR,
+      Kind: 'permanent',
+      FileCount: 0,
+      CreatedAt: now,
+      CreatedBy: userId,
+      ModifiedAt: now,
+      ModifiedBy: userId,
+    };
+
+    try {
+      await this.putItem({
+        TableName: TABLE_NAME,
+        Item: marshall(
+          {
+            LaboratoryId: laboratoryId,
+            Sk: skTag(tagId),
+            TagId: tagId,
+            Name: PERMANENT_TAG_NAME,
+            ColorHex: PERMANENT_TAG_COLOR,
+            Kind: 'permanent',
+            FileCount: 0,
+            CreatedAt: now,
+            CreatedBy: userId,
+            ModifiedAt: now,
+            ModifiedBy: userId,
+          },
+          { removeUndefinedValues: true },
+        ),
+        ConditionExpression: 'attribute_not_exists(#pk) AND attribute_not_exists(#sk)',
+        ExpressionAttributeNames: { '#pk': 'LaboratoryId', '#sk': 'Sk' },
+      });
+    } catch (e: unknown) {
+      if (isConditionalCheckFailed(e)) {
+        const won = await this.getTagRow(laboratoryId, tagId);
+        if (won) return won;
+      }
+      throw e;
+    }
+
+    return tag;
+  }
+
   /** Converts a raw TAG row from DynamoDB into the shared LaboratoryDataTag model. */
   private tagRowToModel(row: Record<string, unknown>): LaboratoryDataTag {
     /** Set on workflow TAG rows; Kind/Platform scalars may be missing on legacy or partially-projected items. */
@@ -176,14 +267,21 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
 
     const rawKindAttr = row.Kind ?? row.kind;
     const rawKind = typeof rawKindAttr === 'string' ? rawKindAttr : 'standard';
-    let kind: LaboratoryDataTagKind = rawKind === 'batch' ? 'batch' : rawKind === 'workflow' ? 'workflow' : 'standard';
+    let kind: LaboratoryDataTagKind =
+      rawKind === 'batch'
+        ? 'batch'
+        : rawKind === 'workflow'
+          ? 'workflow'
+          : rawKind === 'permanent'
+            ? 'permanent'
+            : 'standard';
     /** Workflow rows always carry platform + external id; infer Kind if an older row omitted it. */
     const hasWorkflowIdentity =
       typeof row.Platform === 'string' &&
       row.Platform.length > 0 &&
       typeof row.WorkflowExternalId === 'string' &&
       (row.WorkflowExternalId as string).length > 0;
-    if (kind !== 'batch' && hasWorkflowIdentity) {
+    if (kind !== 'batch' && kind !== 'permanent' && hasWorkflowIdentity) {
       kind = 'workflow';
     }
     /** Workflow tags are indexed under Gsi1Pk `{LaboratoryId}#WORKFLOW` — infer Kind when scalars were omitted. */
@@ -198,7 +296,7 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
      * Also infer from `Gsi1Sk` alone: some stored rows retain the workflow identity sort key but not Gsi1Pk/Kind
      * (e.g. partial updates). Pattern matches {@link workflowGsiSk} output only for workflow tags.
      */
-    if (kind !== 'batch' && (workflowIndexTag || gsiSkParsed)) {
+    if (kind !== 'batch' && kind !== 'permanent' && (workflowIndexTag || gsiSkParsed)) {
       kind = 'workflow';
     }
 
@@ -240,6 +338,9 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
   ): Promise<LaboratoryDataTag> {
     if (kind === 'workflow') {
       throw new Error('Workflow tags cannot be created directly; use getOrCreateWorkflowTag.');
+    }
+    if (kind === 'permanent') {
+      throw new Error('Permanent tags cannot be created directly; use getOrCreatePermanentTag.');
     }
     const laboratoryId = laboratory.LaboratoryId;
     const existing = await this.listTags(laboratoryId);
@@ -430,6 +531,9 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
     if (existingRow.Kind === 'workflow') {
       throw new Error('Workflow tags are auto-managed and cannot be edited');
     }
+    if (existingRow.Kind === 'permanent') {
+      throw new Error('Permanent tags are system-managed and cannot be edited');
+    }
 
     const nextName = name !== undefined ? name.trim() : existingRow.Name;
     const nextColor = colorHex !== undefined ? colorHex : existingRow.ColorHex;
@@ -488,6 +592,9 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
     const tagRow = await this.getTagRow(laboratoryId, tagId);
     if (!tagRow) {
       return;
+    }
+    if (tagRow.Kind === 'permanent') {
+      throw new Error('Permanent tags are system-managed and cannot be deleted');
     }
 
     const gsiPk = gsi1PkForTag(laboratoryId, tagId);
@@ -564,15 +671,18 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
   /**
    * For tag ids present on files but missing from the listTags-derived sets (e.g. eventual
    * consistency right after workflow tagging), load TAG# rows via BatchGetItem and add ids
-   * to batchTagIds / workflowTagIds so listFileTags partitions correctly.
+   * to batchTagIds / workflowTagIds / permanentTagIds so listFileTags partitions correctly.
    */
   private async hydrateKindSetsFromTagIds(
     laboratoryId: string,
     tagIds: Iterable<string>,
     batchTagIds: Set<string>,
     workflowTagIds: Set<string>,
+    permanentTagIds: Set<string>,
   ): Promise<void> {
-    const toResolve = [...new Set(tagIds)].filter((id) => !batchTagIds.has(id) && !workflowTagIds.has(id));
+    const toResolve = [...new Set(tagIds)].filter(
+      (id) => !batchTagIds.has(id) && !workflowTagIds.has(id) && !permanentTagIds.has(id),
+    );
     if (!toResolve.length) return;
 
     for (let i = 0; i < toResolve.length; i += 100) {
@@ -596,6 +706,8 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
         const isWorkflow = tag.Kind === 'workflow' || !!(tag.Platform && tag.WorkflowExternalId);
         if (tag.Kind === 'batch') {
           batchTagIds.add(tag.TagId);
+        } else if (tag.Kind === 'permanent') {
+          permanentTagIds.add(tag.TagId);
         } else if (isWorkflow) {
           workflowTagIds.add(tag.TagId);
         }
@@ -605,9 +717,16 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
 
   public async listFileTags(laboratoryId: string, bucket: string, keys: string[]): Promise<FileTagAssignment[]> {
     const out: FileTagAssignment[] = [];
-    const { batchTagIds, workflowTagIds } = await this.getKindIndexedTagIds(laboratoryId);
+    const { batchTagIds, workflowTagIds, permanentTagIds } = await this.getKindIndexedTagIds(laboratoryId);
     const batchTagIdsMutable = new Set(batchTagIds);
     const workflowTagIdsMutable = new Set(workflowTagIds);
+    const permanentTagIdsMutable = new Set(permanentTagIds);
+    /**
+     * Always treat the lab's deterministic permanent tag id as permanent, even if the TAG# row
+     * hasn't been provisioned yet (newer labs created before the first `listTags` lazy-create).
+     * This keeps file-row partitioning correct under any ordering.
+     */
+    permanentTagIdsMutable.add(deterministicPermanentTagId(laboratoryId));
 
     for (let i = 0; i < keys.length; i += 100) {
       const batchKeys = keys.slice(i, i + 100);
@@ -641,7 +760,13 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
         }
       }
 
-      await this.hydrateKindSetsFromTagIds(laboratoryId, chunkTagIds, batchTagIdsMutable, workflowTagIdsMutable);
+      await this.hydrateKindSetsFromTagIds(
+        laboratoryId,
+        chunkTagIds,
+        batchTagIdsMutable,
+        workflowTagIdsMutable,
+        permanentTagIdsMutable,
+      );
 
       for (let j = 0; j < batchKeys.length; j++) {
         const key = batchKeys[j];
@@ -650,8 +775,11 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
         const standard: string[] = [];
         const workflowIds: string[] = [];
         let batchTagId: string | undefined;
+        let isPermanent = false;
         for (const id of rawIds) {
-          if (batchTagIdsMutable.has(id)) {
+          if (permanentTagIdsMutable.has(id)) {
+            isPermanent = true;
+          } else if (batchTagIdsMutable.has(id)) {
             batchTagId = id;
           } else if (workflowTagIdsMutable.has(id)) {
             workflowIds.push(id);
@@ -668,6 +796,7 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
           TagIds: standard,
           WorkflowTagIds: workflowIds,
           ...(batchTagId ? { BatchTagId: batchTagId } : {}),
+          ...(isPermanent ? { IsPermanent: true } : {}),
           ...(usageList && usageList.length ? { LaboratoryRunUsages: usageList } : {}),
         });
       }
@@ -849,6 +978,68 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
   }
 
   /**
+   * Patches the `ExpiresAt` value on every `LaboratoryRunUsages` entry for the given `RunId`,
+   * across all of its recorded input file rows. Called when a laboratory run transitions to a
+   * terminal status and `ExpiresAt` is computed (or recomputed via the retention policy
+   * lambda), so the data collections page sees an up-to-date expiry without re-reading the
+   * run table.
+   *
+   * `expiresAt === undefined` clears the attribute (used when retention is disabled or the
+   * run leaves a terminal status). Silently skips file rows that no longer carry the run id
+   * (e.g. cleanup has already run), keeping the operation idempotent.
+   */
+  public async updateRunUsageExpiresAt(
+    laboratory: Laboratory,
+    bucket: string,
+    runId: string,
+    inputFileKeys: string[],
+    expiresAt: number | undefined,
+  ): Promise<void> {
+    const laboratoryId = laboratory.LaboratoryId;
+    this.assertBucketMatchesLab(laboratory, bucket);
+
+    for (const key of inputFileKeys) {
+      if (!key || !key.startsWith(`${laboratory.OrganizationId}/${laboratoryId}/`)) continue;
+      const ref = encodeS3ObjectRef(bucket, key);
+      const now = new Date().toISOString();
+      try {
+        if (expiresAt === undefined) {
+          await this.updateItem({
+            TableName: TABLE_NAME,
+            Key: marshall({ LaboratoryId: laboratoryId, Sk: skFile(ref) }),
+            UpdateExpression: 'REMOVE #lru.#rid.#exp SET ModifiedAt = :ma',
+            ExpressionAttributeNames: {
+              '#lru': 'LaboratoryRunUsages',
+              '#rid': runId,
+              '#exp': 'ExpiresAt',
+            },
+            ExpressionAttributeValues: marshall({ ':ma': now }),
+            ConditionExpression: 'attribute_exists(#lru) AND attribute_exists(#lru.#rid)',
+          });
+        } else {
+          await this.updateItem({
+            TableName: TABLE_NAME,
+            Key: marshall({ LaboratoryId: laboratoryId, Sk: skFile(ref) }),
+            UpdateExpression: 'SET #lru.#rid.#exp = :exp, ModifiedAt = :ma',
+            ExpressionAttributeNames: {
+              '#lru': 'LaboratoryRunUsages',
+              '#rid': runId,
+              '#exp': 'ExpiresAt',
+            },
+            ExpressionAttributeValues: marshall({ ':exp': expiresAt, ':ma': now }),
+            ConditionExpression: 'attribute_exists(#lru) AND attribute_exists(#lru.#rid)',
+          });
+        }
+      } catch (e: unknown) {
+        if (isConditionalCheckFailed(e)) {
+          continue;
+        }
+        throw e;
+      }
+    }
+  }
+
+  /**
    * Removes the given `RunId` entries from each file's `LaboratoryRunUsages` map. Used by
    * maintenance flows (seed reset, run deletion) that need to undo run history without
    * touching unrelated tags. If a FILE# row ends up with no tags **and** no usages after the
@@ -862,6 +1053,7 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
     laboratory: Laboratory,
     bucket: string,
     runIdToInputKeys: Record<string, string[]>,
+    options: { preserveEmptyFileRow?: boolean } = {},
   ): Promise<void> {
     const laboratoryId = laboratory.LaboratoryId;
     this.assertBucketMatchesLab(laboratory, bucket);
@@ -897,6 +1089,12 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
         // Re-read the row to decide whether it can be deleted entirely. The row may have other
         // tags, batch assignments, or remaining run usages — only delete when both TagIds and
         // LaboratoryRunUsages are empty.
+        //
+        // The DynamoDB-stream subscriber sets `preserveEmptyFileRow: true` so the row remains
+        // discoverable by the scheduled S3 cleanup job; otherwise we would lose the
+        // `S3Bucket`+`ObjectKey` pair needed to issue the `s3:DeleteObject`. Seed/maintenance
+        // callers leave the option unset and get the original cleanup behavior.
+        if (options.preserveEmptyFileRow) continue;
         const after = await this.getFileRow(laboratoryId, ref);
         if (!after) continue;
         const hasTags = (after.TagIds || []).length > 0;
@@ -909,6 +1107,79 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
         }
       }
     }
+  }
+
+  /**
+   * Internal shape used by maintenance flows (e.g. `process-expired-laboratory-data`) to walk
+   * every FILE# row in a laboratory partition without leaking the raw DynamoDB schema.
+   */
+  public async listAllFileRowsForLab(laboratoryId: string): Promise<
+    Array<{
+      Ref: string;
+      S3Bucket: string;
+      ObjectKey: string;
+      TagIds: string[];
+      LaboratoryRunUsages?: Record<string, LaboratoryRunUsageSummary>;
+    }>
+  > {
+    const out: Array<{
+      Ref: string;
+      S3Bucket: string;
+      ObjectKey: string;
+      TagIds: string[];
+      LaboratoryRunUsages?: Record<string, LaboratoryRunUsageSummary>;
+    }> = [];
+
+    let startKey: Record<string, unknown> | undefined;
+    do {
+      const response: QueryCommandOutput = await this.queryItems({
+        TableName: TABLE_NAME,
+        KeyConditionExpression: '#pk = :pk AND begins_with(#sk, :filePrefix)',
+        ExpressionAttributeNames: { '#pk': 'LaboratoryId', '#sk': 'Sk' },
+        ExpressionAttributeValues: {
+          ':pk': { S: laboratoryId },
+          ':filePrefix': { S: 'FILE#' },
+        },
+        ...(startKey ? { ExclusiveStartKey: startKey as never } : {}),
+      });
+      for (const item of response.Items || []) {
+        const row = unmarshall(item) as Record<string, unknown>;
+        const sk = row.Sk as string;
+        const ref = typeof sk === 'string' && sk.startsWith('FILE#') ? sk.slice('FILE#'.length) : '';
+        if (!ref) continue;
+        out.push({
+          Ref: ref,
+          S3Bucket: row.S3Bucket as string,
+          ObjectKey: row.ObjectKey as string,
+          TagIds: (row.TagIds as string[]) || [],
+          LaboratoryRunUsages: (row.LaboratoryRunUsages as Record<string, LaboratoryRunUsageSummary>) || undefined,
+        });
+      }
+      startKey = response.LastEvaluatedKey as Record<string, unknown> | undefined;
+    } while (startKey);
+
+    return out;
+  }
+
+  /**
+   * Deletes a FILE# row and all of its MAP# associations (one per tag id). Decrements
+   * `FileCount` on the affected TAG# rows so counts stay consistent with the data
+   * collections UI. Used by the scheduled S3 cleanup Lambda after the S3 object itself
+   * has been deleted.
+   */
+  public async deleteFileRowAndAssociations(laboratoryId: string, ref: string): Promise<void> {
+    const fileRow = await this.getFileRow(laboratoryId, ref);
+    if (!fileRow) return;
+
+    for (const tagId of fileRow.TagIds || []) {
+      await this.deleteMapIfExists(laboratoryId, tagId, ref);
+      await this.adjustTagFileCount(laboratoryId, tagId, -1);
+    }
+
+    await this.deleteItem({
+      TableName: TABLE_NAME,
+      Key: marshall({ LaboratoryId: laboratoryId, Sk: skFile(ref) }),
+    });
   }
 
   public async listFilesByTag(
@@ -1157,24 +1428,27 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
   }
 
   /**
-   * Single-pass tag listing that returns the batch and workflow tag id sets used to
+   * Single-pass tag listing that returns the batch / workflow / permanent tag id sets used to
    * partition file rows in `listFileTags`. Avoids two `listTags` round-trips on hot paths.
    */
   private async getKindIndexedTagIds(
     laboratoryId: string,
-  ): Promise<{ batchTagIds: Set<string>; workflowTagIds: Set<string> }> {
+  ): Promise<{ batchTagIds: Set<string>; workflowTagIds: Set<string>; permanentTagIds: Set<string> }> {
     const { Tags } = await this.listTags(laboratoryId);
     const batchTagIds = new Set<string>();
     const workflowTagIds = new Set<string>();
+    const permanentTagIds = new Set<string>();
     for (const t of Tags) {
       const kind = t.Kind ?? 'standard';
       if (kind === 'batch') {
         batchTagIds.add(t.TagId);
+      } else if (kind === 'permanent') {
+        permanentTagIds.add(t.TagId);
       } else if (kind === 'workflow' || !!(t.Platform && t.WorkflowExternalId)) {
         workflowTagIds.add(t.TagId);
       }
     }
-    return { batchTagIds, workflowTagIds };
+    return { batchTagIds, workflowTagIds, permanentTagIds };
   }
 
   private async putMapRow(

--- a/packages/back-end/src/app/services/easy-genomics/laboratory-data-tagging-service.ts
+++ b/packages/back-end/src/app/services/easy-genomics/laboratory-data-tagging-service.ts
@@ -1112,6 +1112,10 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
   /**
    * Internal shape used by maintenance flows (e.g. `process-expired-laboratory-data`) to walk
    * every FILE# row in a laboratory partition without leaking the raw DynamoDB schema.
+   *
+   * Consistency: this is a point-in-time snapshot. FILE# rows can appear/disappear while this
+   * query pages (e.g. concurrent tagging writes or another sweep instance). Callers must treat
+   * per-row follow-up operations as best-effort (conditional deletes / idempotent cleanup).
    */
   public async listAllFileRowsForLab(laboratoryId: string): Promise<
     Array<{

--- a/packages/back-end/src/app/services/easy-genomics/laboratory-run-service.ts
+++ b/packages/back-end/src/app/services/easy-genomics/laboratory-run-service.ts
@@ -244,6 +244,68 @@ export class LaboratoryRunService extends DynamoDBService implements Service<Lab
     }
   };
 
+  /**
+   * Targeted DynamoDB update for retention/TTL bookkeeping (`TerminalAt`, `ExpiresAt`,
+   * audit fields) without rewriting unrelated run attributes.
+   */
+  public async updateRetentionMetadata(input: {
+    LaboratoryId: string;
+    RunId: string;
+    set: {
+      TerminalAt?: string;
+      ExpiresAt?: number;
+      ModifiedAt: string;
+      ModifiedBy: string;
+    };
+    remove: string[];
+  }): Promise<LaboratoryRun> {
+    const expressionAttributeNames: Record<string, string> = {
+      '#ModifiedAt': 'ModifiedAt',
+      '#ModifiedBy': 'ModifiedBy',
+    };
+    const valuePayload: Record<string, unknown> = {
+      ':ModifiedAt': input.set.ModifiedAt,
+      ':ModifiedBy': input.set.ModifiedBy,
+    };
+    const setFragments = ['#ModifiedAt = :ModifiedAt', '#ModifiedBy = :ModifiedBy'];
+
+    if (input.set.TerminalAt !== undefined) {
+      expressionAttributeNames['#TerminalAt'] = 'TerminalAt';
+      valuePayload[':TerminalAt'] = input.set.TerminalAt;
+      setFragments.push('#TerminalAt = :TerminalAt');
+    }
+    if (input.set.ExpiresAt !== undefined) {
+      expressionAttributeNames['#ExpiresAt'] = 'ExpiresAt';
+      valuePayload[':ExpiresAt'] = input.set.ExpiresAt;
+      setFragments.push('#ExpiresAt = :ExpiresAt');
+    }
+
+    let updateExpression = `SET ${setFragments.join(', ')}`;
+    if (input.remove.includes('ExpiresAt')) {
+      expressionAttributeNames['#ExpRemove'] = 'ExpiresAt';
+      updateExpression += ' REMOVE #ExpRemove';
+    }
+
+    const response: UpdateItemCommandOutput = await this.updateItem({
+      TableName: this.LABORATORY_RUN_TABLE_NAME,
+      Key: {
+        LaboratoryId: { S: input.LaboratoryId },
+        RunId: { S: input.RunId },
+      },
+      UpdateExpression: updateExpression,
+      ExpressionAttributeNames: expressionAttributeNames,
+      ExpressionAttributeValues: marshall(valuePayload, { removeUndefinedValues: true }),
+      ReturnValues: 'ALL_NEW',
+    });
+
+    if (response.$metadata.httpStatusCode === 200 && response.Attributes) {
+      return withCoercedInputFileKeys(<LaboratoryRun>unmarshall(response.Attributes));
+    }
+    throw new Error(
+      `Update retention metadata for LaboratoryId=${input.LaboratoryId} RunId=${input.RunId} failed: HTTP ${response.$metadata.httpStatusCode}`,
+    );
+  }
+
   public delete = async (laboratoryRun: LaboratoryRun): Promise<boolean> => {
     const logRequestMessage = `Delete LaboratoryRun LaboratoryId=${laboratoryRun.LaboratoryId}, RunId=${laboratoryRun.RunId} request`;
     console.info(logRequestMessage);

--- a/packages/back-end/src/app/services/easy-genomics/laboratory-service.ts
+++ b/packages/back-end/src/app/services/easy-genomics/laboratory-service.ts
@@ -2,6 +2,7 @@ import {
   GetItemCommandOutput,
   PutItemCommandOutput,
   QueryCommandOutput,
+  ScanCommandOutput,
   TransactWriteItemsCommandOutput,
 } from '@aws-sdk/client-dynamodb';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
@@ -118,6 +119,27 @@ export class LaboratoryService extends DynamoDBService implements Service<Labora
     } else {
       throw new Error(`${logRequestMessage} unsuccessful: HTTP Status Code=${response.$metadata.httpStatusCode}`);
     }
+  };
+
+  /**
+   * Scans the entire laboratory table and returns all laboratory records. Used by maintenance
+   * lambdas/scripts (e.g. the scheduled S3 data-retention cleanup) that need to iterate every
+   * lab without a per-organization fan-out. Not intended for hot read paths.
+   */
+  public listAllLaboratories = async (): Promise<Laboratory[]> => {
+    const results: Laboratory[] = [];
+    let lastKey: Record<string, any> | undefined;
+    do {
+      const response: ScanCommandOutput = await this.findAll({
+        TableName: this.LABORATORY_TABLE_NAME,
+        ...(lastKey ? { ExclusiveStartKey: lastKey } : {}),
+      });
+      for (const item of response.Items || []) {
+        results.push(unmarshall(item) as Laboratory);
+      }
+      lastKey = response.LastEvaluatedKey as Record<string, any> | undefined;
+    } while (lastKey);
+    return results;
   };
 
   public queryByOrganizationId = async (organizationId: string): Promise<Laboratory[]> => {

--- a/packages/back-end/src/infra/constructs/dynamodb-construct.ts
+++ b/packages/back-end/src/infra/constructs/dynamodb-construct.ts
@@ -1,5 +1,5 @@
 import { CfnResource, RemovalPolicy } from 'aws-cdk-lib';
-import { Attribute, AttributeType, BillingMode, SchemaOptions, Table } from 'aws-cdk-lib/aws-dynamodb';
+import { Attribute, AttributeType, BillingMode, SchemaOptions, StreamViewType, Table } from 'aws-cdk-lib/aws-dynamodb';
 import { Construct } from 'constructs';
 
 export const baseLSIAttributes: Attribute[] = [
@@ -31,6 +31,12 @@ export type DynamoDBTableDetails = {
    * The attribute value must be a number representing epoch seconds.
    */
   timeToLiveAttribute?: string;
+  /**
+   * Optional DynamoDB Streams view type. When set, the table emits change events that
+   * downstream Lambdas can subscribe to (used by the laboratory-run table to drive the
+   * S3 deletion cascade when TTL removes a run row).
+   */
+  stream?: StreamViewType;
 };
 
 export interface DynamoConstructProps {
@@ -73,6 +79,7 @@ export class DynamoConstruct extends Construct {
       sortKey: sortKey,
       billingMode: BillingMode.PAY_PER_REQUEST,
       timeToLiveAttribute: settings.timeToLiveAttribute,
+      ...(settings.stream ? { stream: settings.stream } : {}),
       removalPolicy: removalPolicy,
       deletionProtection: true,
       pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },

--- a/packages/back-end/src/infra/stacks/easy-genomics-api-stack.ts
+++ b/packages/back-end/src/infra/stacks/easy-genomics-api-stack.ts
@@ -1,5 +1,5 @@
 import { CfnOutput, Stack } from 'aws-cdk-lib';
-import { AttributeType, Table } from 'aws-cdk-lib/aws-dynamodb';
+import { AttributeType, StreamViewType, Table } from 'aws-cdk-lib/aws-dynamodb';
 import { NagSuppressions } from 'cdk-nag';
 import { Construct } from 'constructs';
 import { DataProvisioningNestedStack } from './data-provisioning-nested-stack';
@@ -327,6 +327,12 @@ export class EasyGenomicsApiStack extends Stack {
         type: AttributeType.STRING,
       },
       timeToLiveAttribute: 'ExpiresAt',
+      // OLD_IMAGE stream drives the laboratory-run REMOVE subscriber that keeps the data
+      // tagging table's `LaboratoryRunUsages` map in sync when run rows disappear (via TTL
+      // or manual delete). OLD_IMAGE is sufficient — the subscriber needs the row's
+      // `InputFileKeys` from the deleted record, never the new image (none exists for
+      // REMOVE events).
+      stream: StreamViewType.OLD_IMAGE,
       gsi: [
         {
           partitionKey: {

--- a/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
@@ -1,7 +1,11 @@
 import { Duration, NestedStack } from 'aws-cdk-lib';
+import { Schedule, Rule } from 'aws-cdk-lib/aws-events';
+import { LambdaFunction } from 'aws-cdk-lib/aws-events-targets';
 import { Effect, PolicyStatement, StarPrincipal } from 'aws-cdk-lib/aws-iam';
-import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
+import { StartingPosition } from 'aws-cdk-lib/aws-lambda';
+import { DynamoEventSource, SqsDlq, SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
 import { Topic } from 'aws-cdk-lib/aws-sns';
+import { Queue } from 'aws-cdk-lib/aws-sqs';
 import { NagSuppressions } from 'cdk-nag';
 import { Construct } from 'constructs';
 import { IamConstruct, IamConstructProps } from '../constructs/iam-construct';
@@ -35,6 +39,12 @@ export class EasyGenomicsNestedStack extends NestedStack {
   ses: SesConstruct;
   sns: SnsConstruct;
   sqs: SqsConstruct;
+  /**
+   * DLQ for the laboratory-run DynamoDB Stream subscriber. Held as a class field so
+   * `setupIamPolicies` can grant `sqs:SendMessage` on it; the queue itself is wired into the
+   * Lambda's event source via `lambdaFunctionsResources` below.
+   */
+  laboratoryRunStreamDlq!: Queue;
 
   constructor(scope: Construct, id: string, props: EasyGenomicsNestedStackProps) {
     super(scope, id);
@@ -106,12 +116,30 @@ export class EasyGenomicsNestedStack extends NestedStack {
     this.iam = new IamConstruct(this, `${this.props.constructNamespace}-iam`, {
       ...(<IamConstructProps>props), // Typecast to IamConstructProps
     });
-    this.setupIamPolicies();
 
     // DynamoDB tables are created by the parent `EasyGenomicsApiStack` and
     // injected via `props.dynamoDBTables`. See class JSDoc for the rationale
     // (this layout is required for `cdk import` to be able to adopt the
     // tables during the documented split-stack migration).
+
+    // Dedicated dead-letter queue for the laboratory-run DynamoDB Stream subscriber. The stream
+    // subscriber drives bookkeeping for the TTL -> S3 deletion cascade; poison records here
+    // can't be retried from the stream itself (stream records age out), so we route failures
+    // here for manual inspection rather than blocking the stream.
+    this.laboratoryRunStreamDlq = new Queue(this, `${this.props.namePrefix}-laboratory-run-stream-dlq`, {
+      queueName: `${this.props.namePrefix}-laboratory-run-stream-dlq`,
+      retentionPeriod: Duration.days(14),
+      enforceSSL: true,
+    });
+
+    const laboratoryRunTable = this.props.dynamoDBTables.get(`${this.props.namePrefix}-laboratory-run-table`);
+    if (!laboratoryRunTable) {
+      throw new Error(
+        `EasyGenomicsNestedStack: missing required injected table "${this.props.namePrefix}-laboratory-run-table".`,
+      );
+    }
+
+    this.setupIamPolicies();
 
     this.lambda = new LambdaConstruct(this, `${this.props.constructNamespace}`, {
       ...this.props,
@@ -250,6 +278,23 @@ export class EasyGenomicsNestedStack extends NestedStack {
             SNS_LABORATORY_RUN_UPDATE_TOPIC: this.sns.snsTopics.get('laboratory-run-update-topic')?.topicArn || '',
           },
         },
+        // DynamoDB Stream subscriber on the laboratory-run table. Handles REMOVE events
+        // (TTL or manual delete) and updates the data tagging table so the scheduled
+        // cleanup Lambda can later GC orphaned S3 files (see plan: "Permanent tag and
+        // S3 expiry"). Stream view is OLD_IMAGE (configured on the table).
+        '/easy-genomics/laboratory/run/process-laboratory-run-stream': {
+          events: [
+            new DynamoEventSource(laboratoryRunTable, {
+              startingPosition: StartingPosition.TRIM_HORIZON,
+              batchSize: 100,
+              maxBatchingWindow: Duration.seconds(5),
+              retryAttempts: 3,
+              bisectBatchOnError: true,
+              onFailure: new SqsDlq(this.laboratoryRunStreamDlq),
+              reportBatchItemFailures: true,
+            }),
+          ],
+        },
         '/easy-genomics/laboratory/run/request-laboratory-run-status-check': {
           environment: {
             SNS_LABORATORY_RUN_UPDATE_TOPIC: this.sns.snsTopics.get('laboratory-run-update-topic')?.topicArn || '',
@@ -271,6 +316,28 @@ export class EasyGenomicsNestedStack extends NestedStack {
           events: [new SqsEventSource(this.sqs.sqsQueues.get('folder-download-queue')!, { batchSize: 1 })],
           timeoutSeconds: 900,
           memorySizeMb: 3008,
+        },
+        // Scheduled (daily) S3 deletion sweep that completes the run-retention cascade. Walks
+        // every lab's FILE# rows, deletes the underlying S3 object + tagging-table rows for
+        // files whose last referencing run has TTL'd out, and skips anything tagged Permanent.
+        // `DRY_RUN=true` is the safe initial-deploy setting; flip it to "false" once the
+        // CloudWatch metrics show the expected counts.
+        '/easy-genomics/data-collections/process-expired-laboratory-data': {
+          timeoutSeconds: 900,
+          memorySizeMb: 1024,
+          environment: {
+            DRY_RUN: 'true',
+          },
+          callbacks: [
+            (lambdaFunction) => {
+              new Rule(this, `${this.props.namePrefix}-expired-laboratory-data-schedule`, {
+                ruleName: `${this.props.namePrefix}-expired-laboratory-data-schedule`,
+                schedule: Schedule.cron({ minute: '0', hour: '4' }),
+                description: 'Daily sweep that deletes S3 objects whose last referencing run has expired.',
+                targets: [new LambdaFunction(lambdaFunction)],
+              });
+            },
+          ],
         },
       },
       environment: {
@@ -1040,6 +1107,17 @@ export class EasyGenomicsNestedStack extends NestedStack {
       }),
     ]);
 
+    // Data tagging table ARNs reused by run-side lambdas that propagate `ExpiresAt` into
+    // `LaboratoryRunUsages` entries. Re-declared inline because the canonical declaration of
+    // `laboratoryDataTaggingTableArn` lives further down in this method body for proximity to
+    // the data-collections route policies.
+    const laboratoryDataTaggingTableArnForRunLambdas = `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-data-tagging-table`;
+    const dataTaggingUsagePropagationStatement = new PolicyStatement({
+      resources: [laboratoryDataTaggingTableArnForRunLambdas],
+      actions: ['dynamodb:GetItem', 'dynamodb:UpdateItem'],
+      effect: Effect.ALLOW,
+    });
+
     // /easy-genomics/laboratory/run/request-apply-run-retention-policy
     this.iam.addPolicyStatements('/easy-genomics/laboratory/run/request-apply-run-retention-policy', [
       new PolicyStatement({
@@ -1058,6 +1136,7 @@ export class EasyGenomicsNestedStack extends NestedStack {
         actions: ['dynamodb:Query'],
         effect: Effect.ALLOW,
       }),
+      dataTaggingUsagePropagationStatement,
     ]);
 
     // /easy-genomics/laboratory/run/update-laboratory-run
@@ -1071,10 +1150,19 @@ export class EasyGenomicsNestedStack extends NestedStack {
         effect: Effect.ALLOW,
       }),
       new PolicyStatement({
+        resources: [
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table`,
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table/index/*`,
+        ],
+        actions: ['dynamodb:Query'],
+        effect: Effect.ALLOW,
+      }),
+      new PolicyStatement({
         resources: [`${this.sns.snsTopics.get('laboratory-run-update-topic')?.topicArn || ''}`],
         actions: ['sns:Publish'],
         effect: Effect.ALLOW,
       }),
+      dataTaggingUsagePropagationStatement,
     ]);
 
     // /easy-genomics/laboratory/run/process-update-laboratory-run
@@ -1117,6 +1205,44 @@ export class EasyGenomicsNestedStack extends NestedStack {
           `arn:aws:iam::${this.props.env.account!}:role/${this.props.namePrefix}-easy-genomics-omics-access-role`,
         ],
         actions: ['sts:AssumeRole', 'sts:TagSession'],
+        effect: Effect.ALLOW,
+      }),
+      dataTaggingUsagePropagationStatement,
+    ]);
+
+    // /easy-genomics/laboratory/run/process-laboratory-run-stream
+    // DynamoDB Stream subscriber: reads OLD images (no DDB Query/Get needed beyond stream
+    // permissions), looks up the parent Laboratory record, and patches LaboratoryRunUsages
+    // entries on the data-tagging table. DLQ + SendMessage cover the onFailure routing.
+    this.iam.addPolicyStatements('/easy-genomics/laboratory/run/process-laboratory-run-stream', [
+      new PolicyStatement({
+        resources: [
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-run-table/stream/*`,
+        ],
+        actions: [
+          'dynamodb:DescribeStream',
+          'dynamodb:GetRecords',
+          'dynamodb:GetShardIterator',
+          'dynamodb:ListStreams',
+        ],
+        effect: Effect.ALLOW,
+      }),
+      new PolicyStatement({
+        resources: [
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table`,
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table/index/*`,
+        ],
+        actions: ['dynamodb:Query'],
+        effect: Effect.ALLOW,
+      }),
+      new PolicyStatement({
+        resources: [laboratoryDataTaggingTableArnForRunLambdas],
+        actions: ['dynamodb:GetItem', 'dynamodb:UpdateItem', 'dynamodb:DeleteItem'],
+        effect: Effect.ALLOW,
+      }),
+      new PolicyStatement({
+        resources: [this.laboratoryRunStreamDlq.queueArn],
+        actions: ['sqs:SendMessage'],
         effect: Effect.ALLOW,
       }),
     ]);
@@ -1602,7 +1728,9 @@ export class EasyGenomicsNestedStack extends NestedStack {
       ...laboratoryReadForDataCollections,
       new PolicyStatement({
         resources: laboratoryDataTaggingDynamoResources,
-        actions: ['dynamodb:Query'],
+        // GetItem + PutItem cover the lazy-create of the lab's singleton permanent TAG# row on
+        // first listTags call (see `ensurePermanentTag` in `laboratory-data-tagging-service`).
+        actions: ['dynamodb:Query', 'dynamodb:GetItem', 'dynamodb:PutItem'],
       }),
     ]);
 
@@ -1675,6 +1803,31 @@ export class EasyGenomicsNestedStack extends NestedStack {
       new PolicyStatement({
         resources: ['arn:aws:s3:::*'],
         actions: ['s3:ListBucket'],
+        effect: Effect.ALLOW,
+      }),
+    ]);
+
+    // /easy-genomics/data-collections/process-expired-laboratory-data
+    // Daily scheduled S3 retention sweep. Needs to scan all laboratories, read+mutate the
+    // tagging table for every lab, and call s3:DeleteObject on the underlying objects.
+    this.iam.addPolicyStatements('/easy-genomics/data-collections/process-expired-laboratory-data', [
+      new PolicyStatement({
+        resources: [
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table`,
+          `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table/index/*`,
+        ],
+        actions: ['dynamodb:Scan', 'dynamodb:Query'],
+        effect: Effect.ALLOW,
+      }),
+      new PolicyStatement({
+        resources: laboratoryDataTaggingDynamoResources,
+        actions: laboratoryDataTaggingDynamoActions,
+      }),
+      new PolicyStatement({
+        // Wildcard bucket because labs are provisioned with arbitrary bucket names per
+        // organization; tightening this requires knowing every lab bucket at deploy time.
+        resources: ['arn:aws:s3:::*/*'],
+        actions: ['s3:DeleteObject'],
         effect: Effect.ALLOW,
       }),
     ]);

--- a/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
@@ -320,8 +320,9 @@ export class EasyGenomicsNestedStack extends NestedStack {
         // Scheduled (daily) S3 deletion sweep that completes the run-retention cascade. Walks
         // every lab's FILE# rows, deletes the underlying S3 object + tagging-table rows for
         // files whose last referencing run has TTL'd out, and skips anything tagged Permanent.
-        // `DRY_RUN=true` is the safe initial-deploy setting; flip it to "false" once the
-        // CloudWatch metrics show the expected counts.
+        // Only `DRY_RUN=false` enables real deletes (unset or any other value stays dry-run).
+        // Runtime `assertBucketMatchesLab` / `assertKeyUnderLabPrefix` bound blast radius; IAM
+        // still uses `s3://*/*` because lab buckets are provisioned per org at data-setup time.
         '/easy-genomics/data-collections/process-expired-laboratory-data': {
           timeoutSeconds: 900,
           memorySizeMb: 1024,
@@ -1824,8 +1825,8 @@ export class EasyGenomicsNestedStack extends NestedStack {
         actions: laboratoryDataTaggingDynamoActions,
       }),
       new PolicyStatement({
-        // Wildcard bucket because labs are provisioned with arbitrary bucket names per
-        // organization; tightening this requires knowing every lab bucket at deploy time.
+        // Wildcard bucket: lab S3Bucket values come from org provisioning. The sweep Lambda
+        // calls `assertBucketMatchesLab` + `assertKeyUnderLabPrefix` before each delete.
         resources: ['arn:aws:s3:::*/*'],
         actions: ['s3:DeleteObject'],
         effect: Effect.ALLOW,

--- a/packages/back-end/test/app/controllers/easy-genomics/data-collections/process-expired-laboratory-data.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/data-collections/process-expired-laboratory-data.lambda.test.ts
@@ -1,0 +1,142 @@
+process.env.NAME_PREFIX = 'unit-test';
+
+import { Context, ScheduledEvent } from 'aws-lambda';
+
+const mockListLabs: jest.Mock = jest.fn();
+const mockListFileRows: jest.Mock = jest.fn();
+const mockDeleteRow: jest.Mock = jest.fn();
+const mockDeleteObject: jest.Mock = jest.fn();
+const mockListTags: jest.Mock = jest.fn();
+
+jest.mock('../../../../../src/app/services/easy-genomics/laboratory-service', () => ({
+  LaboratoryService: jest.fn().mockImplementation(() => ({
+    listAllLaboratories: mockListLabs,
+  })),
+}));
+
+jest.mock('../../../../../src/app/services/easy-genomics/laboratory-data-tagging-service', () => {
+  const actual = jest.requireActual('../../../../../src/app/services/easy-genomics/laboratory-data-tagging-service');
+  return {
+    ...actual,
+    LaboratoryDataTaggingService: jest.fn().mockImplementation(() => ({
+      listAllFileRowsForLab: mockListFileRows,
+      deleteFileRowAndAssociations: mockDeleteRow,
+      listTags: mockListTags,
+    })),
+  };
+});
+
+jest.mock('../../../../../src/app/services/s3-service', () => ({
+  S3Service: jest.fn().mockImplementation(() => ({
+    deleteObject: mockDeleteObject,
+  })),
+}));
+
+import { handler } from '../../../../../src/app/controllers/easy-genomics/data-collections/process-expired-laboratory-data.lambda';
+import { permanentTagIdForLaboratory } from '../../../../../src/app/services/easy-genomics/laboratory-data-tagging-service';
+
+const ctx = {} as Context;
+const event = {} as ScheduledEvent;
+
+describe('process-expired-laboratory-data.lambda eligibility', () => {
+  const lab = {
+    LaboratoryId: 'lab-1',
+    OrganizationId: 'org-1',
+    S3Bucket: 'my-bucket',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.DRY_RUN = 'false';
+
+    mockListLabs.mockReset().mockResolvedValue([lab]);
+    mockListFileRows.mockReset();
+    mockDeleteRow.mockReset().mockResolvedValue(undefined);
+    mockDeleteObject.mockReset().mockResolvedValue({});
+    mockListTags.mockReset().mockResolvedValue({
+      Tags: [
+        { TagId: 'wf-1', Name: 'WF One', ColorHex: '#000000', Kind: 'workflow', FileCount: 0 },
+        { TagId: 'batch-1', Name: 'B1', ColorHex: '#000000', Kind: 'batch', FileCount: 0 },
+      ],
+    });
+  });
+
+  it('deletes the S3 object and tagging rows for files with no usages and a workflow tag', async () => {
+    mockListFileRows.mockResolvedValueOnce([
+      {
+        Ref: 'r1',
+        S3Bucket: 'my-bucket',
+        ObjectKey: 'org-1/lab-1/a.fq.gz',
+        TagIds: ['wf-1'],
+        LaboratoryRunUsages: undefined,
+      },
+    ]);
+
+    await handler(event, ctx, jest.fn());
+
+    expect(mockDeleteObject).toHaveBeenCalledWith({ Bucket: 'my-bucket', Key: 'org-1/lab-1/a.fq.gz' });
+    expect(mockDeleteRow).toHaveBeenCalledWith('lab-1', 'r1');
+  });
+
+  it('skips files that still have at least one referencing run', async () => {
+    mockListFileRows.mockResolvedValueOnce([
+      {
+        Ref: 'r1',
+        S3Bucket: 'my-bucket',
+        ObjectKey: 'org-1/lab-1/a.fq.gz',
+        TagIds: ['wf-1'],
+        LaboratoryRunUsages: { 'run-1': { RunId: 'run-1' } },
+      },
+    ]);
+    await handler(event, ctx, jest.fn());
+    expect(mockDeleteObject).not.toHaveBeenCalled();
+    expect(mockDeleteRow).not.toHaveBeenCalled();
+  });
+
+  it('skips never-used orphans (no workflow tag, no usages)', async () => {
+    mockListFileRows.mockResolvedValueOnce([
+      {
+        Ref: 'r1',
+        S3Bucket: 'my-bucket',
+        ObjectKey: 'org-1/lab-1/orphan.fq.gz',
+        TagIds: ['some-standard'],
+        LaboratoryRunUsages: undefined,
+      },
+    ]);
+    await handler(event, ctx, jest.fn());
+    expect(mockDeleteObject).not.toHaveBeenCalled();
+    expect(mockDeleteRow).not.toHaveBeenCalled();
+  });
+
+  it('protects files tagged Permanent from deletion', async () => {
+    const permanentTagId = permanentTagIdForLaboratory(lab.LaboratoryId);
+    mockListFileRows.mockResolvedValueOnce([
+      {
+        Ref: 'r1',
+        S3Bucket: 'my-bucket',
+        ObjectKey: 'org-1/lab-1/locked.fq.gz',
+        TagIds: ['wf-1', permanentTagId],
+        LaboratoryRunUsages: undefined,
+      },
+    ]);
+    await handler(event, ctx, jest.fn());
+    expect(mockDeleteObject).not.toHaveBeenCalled();
+    expect(mockDeleteRow).not.toHaveBeenCalled();
+  });
+
+  it('honors DRY_RUN=true by skipping S3 and tagging-row deletion', async () => {
+    process.env.DRY_RUN = 'true';
+    mockListFileRows.mockResolvedValueOnce([
+      {
+        Ref: 'r1',
+        S3Bucket: 'my-bucket',
+        ObjectKey: 'org-1/lab-1/a.fq.gz',
+        TagIds: ['wf-1'],
+        LaboratoryRunUsages: undefined,
+      },
+    ]);
+    await handler(event, ctx, jest.fn());
+    expect(mockDeleteObject).not.toHaveBeenCalled();
+    expect(mockDeleteRow).not.toHaveBeenCalled();
+  });
+});

--- a/packages/back-end/test/app/controllers/easy-genomics/data-collections/process-expired-laboratory-data.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/data-collections/process-expired-laboratory-data.lambda.test.ts
@@ -16,12 +16,20 @@ jest.mock('../../../../../src/app/services/easy-genomics/laboratory-service', ()
 
 jest.mock('../../../../../src/app/services/easy-genomics/laboratory-data-tagging-service', () => {
   const actual = jest.requireActual('../../../../../src/app/services/easy-genomics/laboratory-data-tagging-service');
+  const proto = actual.LaboratoryDataTaggingService.prototype as {
+    assertBucketMatchesLab: (laboratory: unknown, bucket: string) => void;
+    assertKeyUnderLabPrefix: (laboratory: unknown, key: string) => void;
+  };
   return {
     ...actual,
     LaboratoryDataTaggingService: jest.fn().mockImplementation(() => ({
       listAllFileRowsForLab: mockListFileRows,
       deleteFileRowAndAssociations: mockDeleteRow,
       listTags: mockListTags,
+      assertBucketMatchesLab: (laboratory: unknown, bucket: string) =>
+        proto.assertBucketMatchesLab(laboratory as never, bucket),
+      assertKeyUnderLabPrefix: (laboratory: unknown, key: string) =>
+        proto.assertKeyUnderLabPrefix(laboratory as never, key),
     })),
   };
 });
@@ -48,6 +56,7 @@ describe('process-expired-laboratory-data.lambda eligibility', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     process.env.DRY_RUN = 'false';
+    delete process.env.MAX_DELETES_PER_LAB_SWEEP;
 
     mockListLabs.mockReset().mockResolvedValue([lab]);
     mockListFileRows.mockReset();
@@ -138,5 +147,59 @@ describe('process-expired-laboratory-data.lambda eligibility', () => {
     await handler(event, ctx, jest.fn());
     expect(mockDeleteObject).not.toHaveBeenCalled();
     expect(mockDeleteRow).not.toHaveBeenCalled();
+  });
+
+  it('defaults to dry-run when DRY_RUN is unset (only false enables deletes)', async () => {
+    delete process.env.DRY_RUN;
+    mockListFileRows.mockResolvedValueOnce([
+      {
+        Ref: 'r1',
+        S3Bucket: 'my-bucket',
+        ObjectKey: 'org-1/lab-1/a.fq.gz',
+        TagIds: ['wf-1'],
+        LaboratoryRunUsages: undefined,
+      },
+    ]);
+    await handler(event, ctx, jest.fn());
+    expect(mockDeleteObject).not.toHaveBeenCalled();
+    expect(mockDeleteRow).not.toHaveBeenCalled();
+  });
+
+  it('skips deletes when the FILE row bucket does not match the laboratory configuration', async () => {
+    mockListFileRows.mockResolvedValueOnce([
+      {
+        Ref: 'r1',
+        S3Bucket: 'wrong-bucket',
+        ObjectKey: 'org-1/lab-1/a.fq.gz',
+        TagIds: ['wf-1'],
+        LaboratoryRunUsages: undefined,
+      },
+    ]);
+    await handler(event, ctx, jest.fn());
+    expect(mockDeleteObject).not.toHaveBeenCalled();
+    expect(mockDeleteRow).not.toHaveBeenCalled();
+  });
+
+  it('respects MAX_DELETES_PER_LAB_SWEEP across multiple eligible rows', async () => {
+    process.env.MAX_DELETES_PER_LAB_SWEEP = '1';
+    mockListFileRows.mockResolvedValueOnce([
+      {
+        Ref: 'r1',
+        S3Bucket: 'my-bucket',
+        ObjectKey: 'org-1/lab-1/a.fq.gz',
+        TagIds: ['wf-1'],
+        LaboratoryRunUsages: undefined,
+      },
+      {
+        Ref: 'r2',
+        S3Bucket: 'my-bucket',
+        ObjectKey: 'org-1/lab-1/b.fq.gz',
+        TagIds: ['wf-1'],
+        LaboratoryRunUsages: undefined,
+      },
+    ]);
+    await handler(event, ctx, jest.fn());
+    expect(mockDeleteObject).toHaveBeenCalledTimes(1);
+    expect(mockDeleteRow).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/process-laboratory-run-stream.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/process-laboratory-run-stream.lambda.test.ts
@@ -1,0 +1,143 @@
+process.env.NAME_PREFIX = 'unit-test';
+
+import { marshall } from '@aws-sdk/util-dynamodb';
+import { Context, DynamoDBStreamEvent } from 'aws-lambda';
+
+const mockRemove: jest.Mock = jest.fn().mockResolvedValue(undefined);
+const mockQueryByLaboratoryId: jest.Mock = jest.fn();
+
+jest.mock('../../../../../../src/app/services/easy-genomics/laboratory-service', () => ({
+  LaboratoryService: jest.fn().mockImplementation(() => ({
+    queryByLaboratoryId: mockQueryByLaboratoryId,
+  })),
+}));
+
+jest.mock('../../../../../../src/app/services/easy-genomics/laboratory-data-tagging-service', () => ({
+  LaboratoryDataTaggingService: jest.fn().mockImplementation(() => ({
+    removeLaboratoryRunUsageForRunIds: mockRemove,
+  })),
+}));
+
+import { handler } from '../../../../../../src/app/controllers/easy-genomics/laboratory/run/process-laboratory-run-stream.lambda';
+
+function buildEvent(
+  records: Array<{
+    eventName: 'INSERT' | 'MODIFY' | 'REMOVE';
+    oldImage?: Record<string, unknown>;
+    principalId?: string;
+  }>,
+): DynamoDBStreamEvent {
+  return {
+    Records: records.map((r, idx) => ({
+      eventID: `evt-${idx}`,
+      eventName: r.eventName,
+      eventSource: 'aws:dynamodb',
+      dynamodb: {
+        OldImage: r.oldImage ? (marshall(r.oldImage, { removeUndefinedValues: true }) as any) : undefined,
+      },
+      userIdentity: r.principalId ? { principalId: r.principalId, type: 'Service' } : undefined,
+    })),
+  } as DynamoDBStreamEvent;
+}
+
+const ctx = {} as Context;
+
+describe('process-laboratory-run-stream.lambda', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRemove.mockResolvedValue(undefined);
+    mockQueryByLaboratoryId.mockReset().mockResolvedValue({
+      LaboratoryId: 'lab-1',
+      OrganizationId: 'org-1',
+      S3Bucket: 'my-bucket',
+    });
+  });
+
+  it('removes per-file run usage entries on REMOVE events with preserveEmptyFileRow', async () => {
+    const event = buildEvent([
+      {
+        eventName: 'REMOVE',
+        oldImage: {
+          LaboratoryId: 'lab-1',
+          RunId: 'run-1',
+          InputFileKeys: ['org-1/lab-1/a.fq.gz', 'org-1/lab-1/b.fq.gz'],
+        },
+      },
+    ]);
+
+    await handler(event, ctx, jest.fn());
+
+    expect(mockRemove).toHaveBeenCalledTimes(1);
+    const [, , runIdMap, options] = mockRemove.mock.calls[0];
+    expect(runIdMap).toEqual({ 'run-1': ['org-1/lab-1/a.fq.gz', 'org-1/lab-1/b.fq.gz'] });
+    expect(options).toEqual({ preserveEmptyFileRow: true });
+  });
+
+  it('logs TTL provenance when principalId === dynamodb.amazonaws.com', async () => {
+    const event = buildEvent([
+      {
+        eventName: 'REMOVE',
+        principalId: 'dynamodb.amazonaws.com',
+        oldImage: {
+          LaboratoryId: 'lab-1',
+          RunId: 'run-2',
+          InputFileKeys: ['org-1/lab-1/c.fq.gz'],
+        },
+      },
+    ]);
+
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    await handler(event, ctx, jest.fn());
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('TTL'));
+    consoleLogSpy.mockRestore();
+  });
+
+  it('ignores INSERT and MODIFY records', async () => {
+    const event = buildEvent([
+      { eventName: 'INSERT', oldImage: undefined },
+      { eventName: 'MODIFY', oldImage: { LaboratoryId: 'lab-1', RunId: 'run-3' } },
+    ]);
+    await handler(event, ctx, jest.fn());
+    expect(mockRemove).not.toHaveBeenCalled();
+  });
+
+  it('skips REMOVE records that lack LaboratoryId or RunId in OldImage', async () => {
+    const event = buildEvent([
+      { eventName: 'REMOVE', oldImage: { InputFileKeys: ['org-1/lab-1/a.fq.gz'] } },
+      { eventName: 'REMOVE', oldImage: { LaboratoryId: 'lab-1' } },
+    ]);
+    await handler(event, ctx, jest.fn());
+    expect(mockRemove).not.toHaveBeenCalled();
+  });
+
+  it('skips REMOVE records with empty InputFileKeys without calling the tagging service', async () => {
+    const event = buildEvent([
+      { eventName: 'REMOVE', oldImage: { LaboratoryId: 'lab-1', RunId: 'run-4', InputFileKeys: [] } },
+    ]);
+    await handler(event, ctx, jest.fn());
+    expect(mockRemove).not.toHaveBeenCalled();
+  });
+
+  it('skips when the lab cannot be loaded (no throw)', async () => {
+    mockQueryByLaboratoryId.mockRejectedValueOnce(new Error('lab gone'));
+    const event = buildEvent([
+      {
+        eventName: 'REMOVE',
+        oldImage: { LaboratoryId: 'lab-1', RunId: 'run-5', InputFileKeys: ['org-1/lab-1/a.fq.gz'] },
+      },
+    ]);
+    await expect(handler(event, ctx, jest.fn())).resolves.toBeUndefined();
+    expect(mockRemove).not.toHaveBeenCalled();
+  });
+
+  it('rethrows errors from the tagging service so the event source can retry / DLQ', async () => {
+    mockRemove.mockRejectedValueOnce(new Error('ddb explode'));
+    const event = buildEvent([
+      {
+        eventName: 'REMOVE',
+        oldImage: { LaboratoryId: 'lab-1', RunId: 'run-6', InputFileKeys: ['org-1/lab-1/a.fq.gz'] },
+      },
+    ]);
+    await expect(handler(event, ctx, jest.fn())).rejects.toThrow(/ddb explode/);
+  });
+});

--- a/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/process-laboratory-run-stream.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/process-laboratory-run-stream.lambda.test.ts
@@ -18,6 +18,7 @@ jest.mock('../../../../../../src/app/services/easy-genomics/laboratory-data-tagg
   })),
 }));
 
+import { LaboratoryNotFoundError } from '@easy-genomics/shared-lib/lib/app/utils/HttpError';
 import { handler } from '../../../../../../src/app/controllers/easy-genomics/laboratory/run/process-laboratory-run-stream.lambda';
 
 function buildEvent(
@@ -118,8 +119,8 @@ describe('process-laboratory-run-stream.lambda', () => {
     expect(mockRemove).not.toHaveBeenCalled();
   });
 
-  it('skips when the lab cannot be loaded (no throw)', async () => {
-    mockQueryByLaboratoryId.mockRejectedValueOnce(new Error('lab gone'));
+  it('skips when the laboratory row is missing (LaboratoryNotFoundError) without throwing', async () => {
+    mockQueryByLaboratoryId.mockRejectedValueOnce(new LaboratoryNotFoundError());
     const event = buildEvent([
       {
         eventName: 'REMOVE',
@@ -127,6 +128,18 @@ describe('process-laboratory-run-stream.lambda', () => {
       },
     ]);
     await expect(handler(event, ctx, jest.fn())).resolves.toBeUndefined();
+    expect(mockRemove).not.toHaveBeenCalled();
+  });
+
+  it('rethrows when loading the laboratory fails for a non-404 reason', async () => {
+    mockQueryByLaboratoryId.mockRejectedValueOnce(new Error('lab gone'));
+    const event = buildEvent([
+      {
+        eventName: 'REMOVE',
+        oldImage: { LaboratoryId: 'lab-1', RunId: 'run-5', InputFileKeys: ['org-1/lab-1/a.fq.gz'] },
+      },
+    ]);
+    await expect(handler(event, ctx, jest.fn())).rejects.toThrow(/lab gone/);
     expect(mockRemove).not.toHaveBeenCalled();
   });
 

--- a/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/request-apply-run-retention-policy.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/request-apply-run-retention-policy.lambda.test.ts
@@ -35,7 +35,7 @@ describe('request-apply-run-retention-policy.lambda', () => {
       requestContext: {
         authorizer: {
           claims: {
-            email: 'user@example.com',
+            'email': 'user@example.com',
             'cognito:username': 'user-1',
           },
         },

--- a/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/request-apply-run-retention-policy.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/request-apply-run-retention-policy.lambda.test.ts
@@ -1,0 +1,117 @@
+process.env.NAME_PREFIX = 'unit-test';
+
+import { APIGatewayProxyWithCognitoAuthorizerEvent, Context } from 'aws-lambda';
+
+jest.mock('../../../../../../src/app/services/easy-genomics/laboratory-run-service');
+jest.mock('../../../../../../src/app/services/easy-genomics/laboratory-service');
+jest.mock('../../../../../../src/app/utils/auth-utils', () => ({
+  validateOrganizationAdminAccess: jest.fn(() => true),
+  validateLaboratoryManagerAccess: jest.fn(() => false),
+  validateLaboratoryTechnicianAccess: jest.fn(() => false),
+}));
+
+import { handler } from '../../../../../../src/app/controllers/easy-genomics/laboratory/run/request-apply-run-retention-policy.lambda';
+import { LaboratoryDataTaggingService } from '../../../../../../src/app/services/easy-genomics/laboratory-data-tagging-service';
+import { LaboratoryRunService } from '../../../../../../src/app/services/easy-genomics/laboratory-run-service';
+import { LaboratoryService } from '../../../../../../src/app/services/easy-genomics/laboratory-service';
+
+describe('request-apply-run-retention-policy.lambda', () => {
+  const LAB_ID = '00000000-0000-0000-0000-000000000002';
+  const ORG_ID = '00000000-0000-0000-0000-000000000001';
+  const inputKey = `${ORG_ID}/${LAB_ID}/sample.fq.gz`;
+
+  let mockQueryRuns: jest.Mock;
+  let mockUpdateRetention: jest.Mock;
+  let mockQueryLab: jest.Mock;
+  let propagateSpy: jest.SpyInstance;
+
+  const createEvent = (body: object, query: Record<string, string> = { laboratoryId: LAB_ID }) =>
+    ({
+      body: JSON.stringify(body),
+      isBase64Encoded: false,
+      httpMethod: 'POST',
+      path: '/laboratory/run/request-apply-run-retention-policy',
+      headers: {},
+      requestContext: {
+        authorizer: {
+          claims: {
+            email: 'user@example.com',
+            'cognito:username': 'user-1',
+          },
+        },
+      },
+      resource: '',
+      queryStringParameters: query,
+      multiValueQueryStringParameters: null,
+      pathParameters: null,
+      stageVariables: null,
+      multiValueHeaders: {},
+    }) as unknown as APIGatewayProxyWithCognitoAuthorizerEvent;
+
+  const createContext = (): Context =>
+    ({
+      functionName: 'request-apply-run-retention-policy',
+      functionVersion: '$LATEST',
+      invokedFunctionArn: 'arn:aws:lambda:region:acct:function:request-apply-run-retention-policy',
+      memoryLimitInMB: '128',
+      awsRequestId: 'req-id',
+      logGroupName: '/aws/lambda/request-apply-run-retention-policy',
+      logStreamName: '2026/03/11/[$LATEST]test',
+      identity: undefined,
+      clientContext: undefined,
+      callbackWaitsForEmptyEventLoop: true,
+      getRemainingTimeInMillis: () => 30000,
+      done: jest.fn(),
+      fail: jest.fn(),
+      succeed: jest.fn(),
+    }) as unknown as Context;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockQueryRuns = jest.fn();
+    mockUpdateRetention = jest.fn().mockResolvedValue({});
+    mockQueryLab = jest.fn();
+
+    (LaboratoryRunService as jest.MockedClass<typeof LaboratoryRunService>).prototype.queryByLaboratoryId =
+      mockQueryRuns;
+    (LaboratoryRunService as jest.MockedClass<typeof LaboratoryRunService>).prototype.updateRetentionMetadata =
+      mockUpdateRetention;
+    (LaboratoryService as jest.MockedClass<typeof LaboratoryService>).prototype.queryByLaboratoryId = mockQueryLab;
+
+    mockQueryLab.mockResolvedValue({
+      LaboratoryId: LAB_ID,
+      OrganizationId: ORG_ID,
+      RunRetentionMonths: 6,
+      S3Bucket: 'lab-bucket',
+    });
+
+    propagateSpy = jest
+      .spyOn(LaboratoryDataTaggingService.prototype, 'updateRunUsageExpiresAt')
+      .mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    propagateSpy.mockRestore();
+  });
+
+  it('does not call updateRunUsageExpiresAt on a dry run even when runs would be updated', async () => {
+    mockQueryRuns.mockResolvedValue([
+      {
+        RunId: 'run-1',
+        LaboratoryId: LAB_ID,
+        OrganizationId: ORG_ID,
+        Status: 'COMPLETED',
+        TerminalAt: null,
+        ExpiresAt: null,
+        CreatedAt: '2024-01-01T00:00:00.000Z',
+        InputFileKeys: [inputKey],
+      },
+    ]);
+
+    const result = await handler(createEvent({ retentionMonths: 6, dryRun: true }), createContext(), () => {});
+
+    expect(result.statusCode).toBe(200);
+    expect(mockUpdateRetention).not.toHaveBeenCalled();
+    expect(propagateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/update-laboratory-run.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/update-laboratory-run.lambda.test.ts
@@ -6,6 +6,8 @@ jest.mock('../../../../../../src/app/services/easy-genomics/laboratory-service')
 jest.mock('../../../../../../src/app/services/sns-service');
 jest.mock('../../../../../../src/app/utils/auth-utils');
 
+import { LaboratoryDataTaggingService } from '../../../../../../src/app/services/easy-genomics/laboratory-data-tagging-service';
+
 import { LaboratoryRunService } from '../../../../../../src/app/services/easy-genomics/laboratory-run-service';
 import { LaboratoryService } from '../../../../../../src/app/services/easy-genomics/laboratory-service';
 import { SnsService } from '../../../../../../src/app/services/sns-service';
@@ -30,6 +32,7 @@ describe('update-laboratory-run.lambda', () => {
   let mockQueryByLaboratoryId: jest.Mock;
   let mockUpdateRun: jest.Mock;
   let mockPublish: jest.Mock;
+  let propagateExpiresSpy: jest.SpyInstance;
 
   const createEvent = (
     id: string | undefined,
@@ -112,6 +115,14 @@ describe('update-laboratory-run.lambda', () => {
     });
 
     process.env.SNS_LABORATORY_RUN_UPDATE_TOPIC = 'arn:aws:sns:region:acct:lab-run-update';
+
+    propagateExpiresSpy = jest
+      .spyOn(LaboratoryDataTaggingService.prototype, 'updateRunUsageExpiresAt')
+      .mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    propagateExpiresSpy.mockRestore();
   });
 
   it('returns 400 when id path parameter is missing', async () => {
@@ -177,5 +188,101 @@ describe('update-laboratory-run.lambda', () => {
     expect(mockSnsService.prototype.publish).toHaveBeenCalled();
     expect(mockUpdateRun).toHaveBeenCalled();
     expect(mockPublish).toHaveBeenCalled();
+  });
+
+  it('propagates ExpiresAt to LaboratoryRunUsages when a terminal transition sets a new TTL', async () => {
+    const orgId = '00000000-0000-0000-0000-000000000001';
+    const inputKey = `${orgId}/${LAB_ID}/input.fq.gz`;
+    mockQueryByLaboratoryId.mockResolvedValue({
+      LaboratoryId: LAB_ID,
+      OrganizationId: orgId,
+      RunRetentionMonths: 6,
+      S3Bucket: 'lab-bucket',
+    });
+    mockQueryByRunId.mockResolvedValue({
+      RunId: RUN_ID,
+      LaboratoryId: LAB_ID,
+      OrganizationId: orgId,
+      Status: 'PENDING',
+      ExpiresAt: undefined,
+      TerminalAt: undefined,
+      CreatedAt: '2024-01-01T00:00:00.000Z',
+      InputFileKeys: [inputKey],
+      Settings: '{}',
+    });
+    mockUpdateRun.mockImplementation(async (run: unknown) => ({ ...(run as object) }));
+
+    const result = await handler(
+      createEvent(RUN_ID, { Status: 'COMPLETED', Settings: { k: 1 } }),
+      createContext(),
+      () => {},
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(propagateExpiresSpy).toHaveBeenCalledTimes(1);
+    const [, bucket, runId, keys, expiresAt] = propagateExpiresSpy.mock.calls[0];
+    expect(bucket).toBe('lab-bucket');
+    expect(runId).toBe(RUN_ID);
+    expect(keys).toEqual([inputKey]);
+    expect(typeof expiresAt).toBe('number');
+  });
+
+  it('does not propagate ExpiresAt when the run already carries TTL metadata', async () => {
+    const orgId = '00000000-0000-0000-0000-000000000001';
+    const inputKey = `${orgId}/${LAB_ID}/input.fq.gz`;
+    mockQueryByLaboratoryId.mockResolvedValue({
+      LaboratoryId: LAB_ID,
+      OrganizationId: orgId,
+      RunRetentionMonths: 6,
+      S3Bucket: 'lab-bucket',
+    });
+    mockQueryByRunId.mockResolvedValue({
+      RunId: RUN_ID,
+      LaboratoryId: LAB_ID,
+      OrganizationId: orgId,
+      Status: 'COMPLETED',
+      ExpiresAt: 1_700_000_000,
+      TerminalAt: '2024-02-01T00:00:00.000Z',
+      InputFileKeys: [inputKey],
+      Settings: '{}',
+    });
+    mockUpdateRun.mockImplementation(async (run: unknown) => ({ ...(run as object) }));
+
+    const result = await handler(
+      createEvent(RUN_ID, { Status: 'COMPLETED', Settings: { k: 2 } }),
+      createContext(),
+      () => {},
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(propagateExpiresSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not propagate ExpiresAt when laboratory retention disables TTL', async () => {
+    const orgId = '00000000-0000-0000-0000-000000000001';
+    const inputKey = `${orgId}/${LAB_ID}/input.fq.gz`;
+    mockQueryByLaboratoryId.mockResolvedValue({
+      LaboratoryId: LAB_ID,
+      OrganizationId: orgId,
+      RunRetentionMonths: 0,
+      S3Bucket: 'lab-bucket',
+    });
+    mockQueryByRunId.mockResolvedValue({
+      RunId: RUN_ID,
+      LaboratoryId: LAB_ID,
+      OrganizationId: orgId,
+      Status: 'PENDING',
+      ExpiresAt: undefined,
+      TerminalAt: undefined,
+      CreatedAt: '2024-01-01T00:00:00.000Z',
+      InputFileKeys: [inputKey],
+      Settings: '{}',
+    });
+    mockUpdateRun.mockImplementation(async (run: unknown) => ({ ...(run as object) }));
+
+    const result = await handler(createEvent(RUN_ID, { Status: 'COMPLETED', Settings: {} }), createContext(), () => {});
+
+    expect(result.statusCode).toBe(200);
+    expect(propagateExpiresSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/back-end/test/app/services/easy-genomics/laboratory-data-tagging-service.test.ts
+++ b/packages/back-end/test/app/services/easy-genomics/laboratory-data-tagging-service.test.ts
@@ -694,3 +694,196 @@ describe('LaboratoryDataTaggingService preserves FILE rows when run usage histor
     expect(filePut!.LaboratoryRunUsages).toBeDefined();
   });
 });
+
+describe('LaboratoryDataTaggingService.ensurePermanentTag', () => {
+  let svc: LaboratoryDataTaggingService;
+  let mockGetItem: jest.Mock;
+  let mockPutItem: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    svc = new LaboratoryDataTaggingService();
+    mockGetItem = jest.fn();
+    mockPutItem = jest.fn().mockResolvedValue({});
+    (svc as unknown as { getItem: typeof mockGetItem }).getItem = mockGetItem;
+    (svc as unknown as { putItem: typeof mockPutItem }).putItem = mockPutItem;
+  });
+
+  it('returns the existing row when the singleton permanent tag is already provisioned', async () => {
+    const lab = labFixture();
+    const existingId = svc.getPermanentTagId(lab.LaboratoryId);
+    mockGetItem.mockResolvedValueOnce({
+      Item: marshall({
+        LaboratoryId: lab.LaboratoryId,
+        Sk: `TAG#${existingId}`,
+        TagId: existingId,
+        Name: 'Permanent',
+        ColorHex: '#DC2626',
+        Kind: 'permanent',
+        FileCount: 3,
+      }),
+    });
+    const tag = await svc.ensurePermanentTag(lab, 'user-1');
+    expect(tag.Kind).toBe('permanent');
+    expect(tag.TagId).toBe(existingId);
+    expect(tag.Name).toBe('Permanent');
+    expect(mockPutItem).not.toHaveBeenCalled();
+  });
+
+  it('lazy-creates the permanent tag with deterministic id when missing', async () => {
+    const lab = labFixture();
+    const expectedId = svc.getPermanentTagId(lab.LaboratoryId);
+    mockGetItem.mockResolvedValueOnce({});
+
+    const tag = await svc.ensurePermanentTag(lab, 'user-1');
+    expect(tag.TagId).toBe(expectedId);
+    expect(tag.Kind).toBe('permanent');
+    expect(tag.ColorHex).toBe('#DC2626');
+    expect(mockPutItem).toHaveBeenCalledTimes(1);
+    const item = unmarshall(mockPutItem.mock.calls[0][0].Item) as { Kind: string; Sk: string; Name: string };
+    expect(item.Kind).toBe('permanent');
+    expect(item.Sk).toBe(`TAG#${expectedId}`);
+    expect(item.Name).toBe('Permanent');
+  });
+
+  it('returns the winning row when a concurrent creator wins the ConditionalCheckFailed race', async () => {
+    const lab = labFixture();
+    const expectedId = svc.getPermanentTagId(lab.LaboratoryId);
+    mockGetItem
+      .mockResolvedValueOnce({}) // initial getTagRow: not found
+      .mockResolvedValueOnce({
+        // post-conflict re-read: returns the winning row
+        Item: marshall({
+          LaboratoryId: lab.LaboratoryId,
+          Sk: `TAG#${expectedId}`,
+          TagId: expectedId,
+          Name: 'Permanent',
+          ColorHex: '#DC2626',
+          Kind: 'permanent',
+          FileCount: 0,
+        }),
+      });
+    mockPutItem.mockImplementationOnce(async () => {
+      throw Object.assign(new Error('Conditional check failed'), {
+        name: 'ConditionalCheckFailedException',
+      });
+    });
+
+    const tag = await svc.ensurePermanentTag(lab, 'user-1');
+    expect(tag.TagId).toBe(expectedId);
+    expect(tag.Kind).toBe('permanent');
+  });
+});
+
+describe('LaboratoryDataTaggingService.createTag / deleteTag reject permanent kind', () => {
+  let svc: LaboratoryDataTaggingService;
+  let mockGetItem: jest.Mock;
+  let mockQueryItems: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    svc = new LaboratoryDataTaggingService();
+    mockGetItem = jest.fn();
+    mockQueryItems = jest.fn().mockResolvedValue({ Items: [] });
+    (svc as unknown as { getItem: typeof mockGetItem }).getItem = mockGetItem;
+    (svc as unknown as { queryItems: typeof mockQueryItems }).queryItems = mockQueryItems;
+    (svc as unknown as { putItem: jest.Mock }).putItem = jest.fn().mockResolvedValue({});
+    (svc as unknown as { deleteItem: jest.Mock }).deleteItem = jest.fn().mockResolvedValue({});
+  });
+
+  it('createTag rejects kind="permanent"', async () => {
+    const lab = labFixture();
+    await expect(svc.createTag(lab, 'user-1', 'Whatever', '#DC2626', 'permanent')).rejects.toThrow(
+      /Permanent tags cannot be created directly/,
+    );
+  });
+
+  it('deleteTag rejects an existing permanent tag', async () => {
+    const lab = labFixture();
+    const pid = svc.getPermanentTagId(lab.LaboratoryId);
+    mockGetItem.mockResolvedValueOnce({
+      Item: marshall({
+        LaboratoryId: lab.LaboratoryId,
+        Sk: `TAG#${pid}`,
+        TagId: pid,
+        Name: 'Permanent',
+        ColorHex: '#DC2626',
+        Kind: 'permanent',
+        FileCount: 0,
+      }),
+    });
+    await expect(svc.deleteTag(lab.LaboratoryId, pid)).rejects.toThrow(/Permanent tags are system-managed/);
+  });
+});
+
+describe('LaboratoryDataTaggingService.updateRunUsageExpiresAt', () => {
+  let svc: LaboratoryDataTaggingService;
+  let mockUpdateItem: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    svc = new LaboratoryDataTaggingService();
+    mockUpdateItem = jest.fn().mockResolvedValue({});
+    (svc as unknown as { updateItem: typeof mockUpdateItem }).updateItem = mockUpdateItem;
+  });
+
+  it('SETs ExpiresAt onto each input file row when a value is supplied', async () => {
+    const lab = labFixture();
+    const bucket = lab.S3Bucket!;
+    await svc.updateRunUsageExpiresAt(
+      lab,
+      bucket,
+      'run-7',
+      ['org-1/lab-1/a.fq.gz', 'org-1/lab-1/b.fq.gz'],
+      1_900_000_000,
+    );
+    expect(mockUpdateItem).toHaveBeenCalledTimes(2);
+    const update = mockUpdateItem.mock.calls[0][0];
+    expect(update.UpdateExpression).toMatch(/SET #lru.#rid.#exp = :exp/);
+    const values = unmarshall(update.ExpressionAttributeValues) as { ':exp': number };
+    expect(values[':exp']).toBe(1_900_000_000);
+  });
+
+  it('REMOVEs the ExpiresAt sub-attribute when value is undefined', async () => {
+    const lab = labFixture();
+    await svc.updateRunUsageExpiresAt(lab, lab.S3Bucket!, 'run-7', ['org-1/lab-1/a.fq.gz'], undefined);
+    expect(mockUpdateItem).toHaveBeenCalledTimes(1);
+    expect(mockUpdateItem.mock.calls[0][0].UpdateExpression).toMatch(/REMOVE #lru.#rid.#exp/);
+  });
+
+  it('skips keys that fall outside the laboratory prefix', async () => {
+    const lab = labFixture();
+    await svc.updateRunUsageExpiresAt(lab, lab.S3Bucket!, 'run-7', ['other-org/lab-1/x.fq.gz'], 1_900_000_000);
+    expect(mockUpdateItem).not.toHaveBeenCalled();
+  });
+});
+
+describe('LaboratoryDataTaggingService.removeLaboratoryRunUsageForRunIds preserveEmptyFileRow', () => {
+  let svc: LaboratoryDataTaggingService;
+  let mockGetItem: jest.Mock;
+  let mockDeleteItem: jest.Mock;
+  let mockUpdateItem: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    svc = new LaboratoryDataTaggingService();
+    mockGetItem = jest.fn().mockResolvedValue({});
+    mockDeleteItem = jest.fn().mockResolvedValue({});
+    mockUpdateItem = jest.fn().mockResolvedValue({});
+    (svc as unknown as { getItem: typeof mockGetItem }).getItem = mockGetItem;
+    (svc as unknown as { deleteItem: typeof mockDeleteItem }).deleteItem = mockDeleteItem;
+    (svc as unknown as { updateItem: typeof mockUpdateItem }).updateItem = mockUpdateItem;
+  });
+
+  it('with preserveEmptyFileRow=true never deletes the FILE# row even when it ends up empty', async () => {
+    const lab = labFixture();
+    const bucket = lab.S3Bucket!;
+    const key = 'org-1/lab-1/last-usage.fq.gz';
+
+    await svc.removeLaboratoryRunUsageForRunIds(lab, bucket, { 'run-1': [key] }, { preserveEmptyFileRow: true });
+
+    expect(mockUpdateItem).toHaveBeenCalledTimes(1);
+    expect(mockGetItem).not.toHaveBeenCalled();
+    expect(mockDeleteItem).not.toHaveBeenCalled();
+  });
+});

--- a/packages/back-end/test/app/services/easy-genomics/laboratory-data-tagging-service.test.ts
+++ b/packages/back-end/test/app/services/easy-genomics/laboratory-data-tagging-service.test.ts
@@ -1,6 +1,6 @@
 process.env.NAME_PREFIX = 'unit-test';
 
-import type { AttributeValue } from '@aws-sdk/client-dynamodb';
+import { ConditionalCheckFailedException, type AttributeValue } from '@aws-sdk/client-dynamodb';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
 import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
 import {
@@ -855,6 +855,36 @@ describe('LaboratoryDataTaggingService.updateRunUsageExpiresAt', () => {
     const lab = labFixture();
     await svc.updateRunUsageExpiresAt(lab, lab.S3Bucket!, 'run-7', ['other-org/lab-1/x.fq.gz'], 1_900_000_000);
     expect(mockUpdateItem).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when the FILE row has no LaboratoryRunUsages entry for the RunId (conditional failure)', async () => {
+    const lab = labFixture();
+    mockUpdateItem.mockRejectedValueOnce(new ConditionalCheckFailedException({ message: 'c', $metadata: {} }));
+    await expect(
+      svc.updateRunUsageExpiresAt(lab, lab.S3Bucket!, 'run-7', ['org-1/lab-1/a.fq.gz'], 1_900_000_000),
+    ).resolves.toBeUndefined();
+    expect(mockUpdateItem).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('LaboratoryDataTaggingService.deleteFileRowAndAssociations', () => {
+  let svc: LaboratoryDataTaggingService;
+  let mockGetItem: jest.Mock;
+  let mockDeleteItem: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    svc = new LaboratoryDataTaggingService();
+    mockGetItem = jest.fn().mockResolvedValue({});
+    mockDeleteItem = jest.fn().mockResolvedValue({});
+    (svc as unknown as { getItem: typeof mockGetItem }).getItem = mockGetItem;
+    (svc as unknown as { deleteItem: typeof mockDeleteItem }).deleteItem = mockDeleteItem;
+  });
+
+  it('returns without deleting when the FILE# row is already gone (idempotent)', async () => {
+    await svc.deleteFileRowAndAssociations('lab-1', 'ref-1');
+    expect(mockGetItem).toHaveBeenCalled();
+    expect(mockDeleteItem).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/back-end/test/app/services/easy-genomics/laboratory-service.test.ts
+++ b/packages/back-end/test/app/services/easy-genomics/laboratory-service.test.ts
@@ -1,0 +1,33 @@
+process.env.NAME_PREFIX = 'unit-test';
+
+import { marshall } from '@aws-sdk/util-dynamodb';
+import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
+import { LaboratoryService } from '../../../../src/app/services/easy-genomics/laboratory-service';
+
+describe('LaboratoryService.listAllLaboratories', () => {
+  it('follows LastEvaluatedKey until the scan is complete', async () => {
+    const svc = new LaboratoryService();
+    const lab1 = { LaboratoryId: 'l1', OrganizationId: 'o1', Name: 'Lab A' } as Laboratory;
+    const lab2 = { LaboratoryId: 'l2', OrganizationId: 'o2', Name: 'Lab B' } as Laboratory;
+
+    const findAll = jest.spyOn(svc as unknown as { findAll: jest.Mock }, 'findAll');
+    findAll
+      .mockResolvedValueOnce({
+        Items: [marshall(lab1)],
+        LastEvaluatedKey: { OrganizationId: { S: 'o1' }, LaboratoryId: { S: 'l1' } },
+      })
+      .mockResolvedValueOnce({
+        Items: [marshall(lab2)],
+      });
+
+    const rows = await svc.listAllLaboratories();
+
+    expect(findAll).toHaveBeenCalledTimes(2);
+    expect(findAll.mock.calls[1][0]).toMatchObject({
+      ExclusiveStartKey: { OrganizationId: { S: 'o1' }, LaboratoryId: { S: 'l1' } },
+    });
+    expect(rows.map((r) => r.LaboratoryId)).toEqual(['l1', 'l2']);
+
+    findAll.mockRestore();
+  });
+});

--- a/packages/back-end/test/infra/stacks/easy-genomics-nested-stack.test.ts
+++ b/packages/back-end/test/infra/stacks/easy-genomics-nested-stack.test.ts
@@ -6,6 +6,8 @@ import { EasyGenomicsNestedStack } from '../../../src/infra/stacks/easy-genomics
 
 jest.mock('aws-cdk-lib/aws-lambda-event-sources', () => ({
   SqsEventSource: jest.fn().mockImplementation(() => ({})),
+  SqsDlq: jest.fn().mockImplementation(() => ({})),
+  DynamoEventSource: jest.fn().mockImplementation(() => ({})),
 }));
 
 jest.mock('../../../src/infra/constructs/iam-construct', () => ({
@@ -55,8 +57,10 @@ jest.mock('../../../src/infra/constructs/sqs-construct', () => ({
 describe('EasyGenomicsNestedStack environment wiring', () => {
   // Tables live on the parent `EasyGenomicsApiStack` and are injected via
   // props (see that stack's JSDoc for the rationale tied to `cdk import`).
-  // The wiring tests below don't exercise table identity, so an empty map
-  // is sufficient to satisfy the prop contract.
+  // The wiring tests below don't exercise table identity, but the nested stack
+  // does require `laboratory-run-table` for the DynamoDB-stream event source it
+  // wires up; we inject a minimal fake here that satisfies the surface area used
+  // (DynamoEventSource calls `tableStreamArn` / `grantStreamRead`).
   const createProps = () =>
     ({
       env: { account: '123456789012', region: 'us-west-2' },
@@ -73,7 +77,18 @@ describe('EasyGenomicsNestedStack environment wiring', () => {
       cognitoIdpKmsKey: { keyArn: 'arn:aws:kms:us-west-2:123456789012:key/abc', keyId: 'abc' } as any,
       userPool: { userPoolId: 'pool-id' } as any,
       userPoolClient: { userPoolClientId: 'client-id' } as any,
-      dynamoDBTables: new Map(),
+      dynamoDBTables: new Map<string, any>([
+        [
+          'easy-genomics-laboratory-run-table',
+          {
+            tableName: 'easy-genomics-laboratory-run-table',
+            tableArn: 'arn:aws:dynamodb:us-west-2:123456789012:table/easy-genomics-laboratory-run-table',
+            tableStreamArn:
+              'arn:aws:dynamodb:us-west-2:123456789012:table/easy-genomics-laboratory-run-table/stream/2026-01-01T00:00:00.000',
+            grantStreamRead: jest.fn(),
+          },
+        ],
+      ]),
     }) as any;
 
   beforeEach(() => {

--- a/packages/front-end/src/app/components/EGDataCollectionsExplorer.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsExplorer.vue
@@ -26,6 +26,12 @@
      * (Not yet analyzed / Analyzed / Analyzed Nx) and the analysis history tooltip.
      */
     keyToRunUsages?: Record<string, LaboratoryRunUsageSummary[]>;
+    /**
+     * Per-file flag indicating the lab's system-managed Permanent tag is applied. Rendered as
+     * a dedicated red lock affordance on each card / table row; never appears in the standard
+     * tag pill rail.
+     */
+    keyToIsPermanent?: Record<string, boolean>;
     batchTags?: LaboratoryDataTag[];
     tags: LaboratoryDataTag[];
     selectedKeys: string[];
@@ -97,6 +103,39 @@
   function fileName(key: string): string {
     const parts = key.split('/').filter(Boolean);
     return parts[parts.length - 1] || key;
+  }
+
+  function isFilePermanent(key: string): boolean {
+    return !!(props.keyToIsPermanent && props.keyToIsPermanent[key]);
+  }
+
+  /**
+   * Soonest run-retention expiry (epoch seconds) recorded against the file, or undefined if
+   * no usages carry an `ExpiresAt`. Used by the table view's Expires column.
+   */
+  function soonestRunExpiresAt(key: string): number | undefined {
+    const usages = props.keyToRunUsages?.[key];
+    if (!usages || !usages.length) return undefined;
+    let soonest: number | undefined;
+    for (const u of usages) {
+      if (typeof u.ExpiresAt === 'number' && (soonest === undefined || u.ExpiresAt < soonest)) {
+        soonest = u.ExpiresAt;
+      }
+    }
+    return soonest;
+  }
+
+  function formatExpiresLabel(key: string): string {
+    if (isFilePermanent(key)) return 'Never';
+    const epoch = soonestRunExpiresAt(key);
+    if (epoch === undefined) return '—';
+    const now = Math.floor(Date.now() / 1000);
+    const diffDays = Math.round((epoch - now) / 86400);
+    if (diffDays <= 0) return 'Expired';
+    if (diffDays === 1) return 'in 1 day';
+    if (diffDays < 30) return `in ${diffDays} days`;
+    const months = Math.round(diffDays / 30);
+    return months <= 1 ? 'in ~1 month' : `in ~${months} months`;
   }
 
   /** Folder path under the lab root (for flat recursive listings). */
@@ -486,7 +525,15 @@
             @dragleave="onCardDragLeave"
             @drop="onCardDrop($event)"
           >
-            <div class="absolute right-2 top-2" @mousedown.stop @click.stop>
+            <div class="absolute right-2 top-2 flex items-center gap-1.5" @mousedown.stop @click.stop>
+              <span
+                v-if="isFilePermanent(f.Key)"
+                class="inline-flex items-center gap-0.5 rounded-full bg-red-50 px-1.5 py-0.5 text-[10px] font-semibold text-red-700 ring-1 ring-inset ring-red-200"
+                title="Permanent files are never auto-deleted, even after their run retention expires."
+              >
+                <UIcon name="i-heroicons-lock-closed" class="h-3 w-3" aria-hidden="true" />
+                <span>Permanent</span>
+              </span>
               <UCheckbox :model-value="selectedKeys.includes(f.Key)" @update:model-value="emit('toggleKey', f.Key)" />
             </div>
             <div class="absolute left-0 top-0 z-[1]" @mousedown.stop @click.stop>
@@ -612,7 +659,16 @@
                   />
                 </td>
                 <td class="max-w-[14rem] px-3 py-2 align-middle">
-                  <div class="font-medium text-gray-900">{{ fileName(f.Key) }}</div>
+                  <div class="flex items-center gap-1.5">
+                    <UIcon
+                      v-if="isFilePermanent(f.Key)"
+                      name="i-heroicons-lock-closed"
+                      class="h-3.5 w-3.5 shrink-0 text-red-600"
+                      :title="'Permanent: never auto-deleted'"
+                      aria-label="Permanent"
+                    />
+                    <span class="truncate font-medium text-gray-900">{{ fileName(f.Key) }}</span>
+                  </div>
                   <div v-if="folderPathUnderLab(f.Key)" class="text-muted truncate text-xs">
                     {{ folderPathUnderLab(f.Key) }}
                   </div>
@@ -654,7 +710,16 @@
                     <span v-else class="text-muted text-[10px] italic">No tags</span>
                   </div>
                 </td>
-                <td class="text-muted px-3 py-2 align-middle">—</td>
+                <td class="text-muted px-3 py-2 align-middle">
+                  <span
+                    v-if="isFilePermanent(f.Key)"
+                    class="inline-flex items-center gap-1 rounded-full bg-red-50 px-2 py-0.5 text-[11px] font-medium text-red-700 ring-1 ring-inset ring-red-200"
+                  >
+                    <UIcon name="i-heroicons-lock-closed" class="h-3 w-3" aria-hidden="true" />
+                    Never
+                  </span>
+                  <span v-else class="tabular-nums">{{ formatExpiresLabel(f.Key) }}</span>
+                </td>
               </tr>
             </template>
           </tbody>

--- a/packages/front-end/src/app/components/EGDataCollectionsExplorer.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsExplorer.vue
@@ -526,14 +526,13 @@
             @drop="onCardDrop($event)"
           >
             <div class="absolute right-2 top-2 flex items-center gap-1.5" @mousedown.stop @click.stop>
-              <span
+              <UIcon
                 v-if="isFilePermanent(f.Key)"
-                class="inline-flex items-center gap-0.5 rounded-full bg-red-50 px-1.5 py-0.5 text-[10px] font-semibold text-red-700 ring-1 ring-inset ring-red-200"
-                title="Permanent files are never auto-deleted, even after their run retention expires."
-              >
-                <UIcon name="i-heroicons-lock-closed" class="h-3 w-3" aria-hidden="true" />
-                <span>Permanent</span>
-              </span>
+                name="i-heroicons-lock-closed"
+                class="h-3.5 w-3.5 shrink-0 text-red-600"
+                title="This file is protected from auto-deletion when run retention expires."
+                aria-label="Protected from auto-deletion"
+              />
               <UCheckbox :model-value="selectedKeys.includes(f.Key)" @update:model-value="emit('toggleKey', f.Key)" />
             </div>
             <div class="absolute left-0 top-0 z-[1]" @mousedown.stop @click.stop>
@@ -664,8 +663,8 @@
                       v-if="isFilePermanent(f.Key)"
                       name="i-heroicons-lock-closed"
                       class="h-3.5 w-3.5 shrink-0 text-red-600"
-                      :title="'Permanent: never auto-deleted'"
-                      aria-label="Permanent"
+                      title="This file is protected from auto-deletion when run retention expires."
+                      aria-label="Protected from auto-deletion"
                     />
                     <span class="truncate font-medium text-gray-900">{{ fileName(f.Key) }}</span>
                   </div>
@@ -711,13 +710,13 @@
                   </div>
                 </td>
                 <td class="text-muted px-3 py-2 align-middle">
-                  <span
+                  <UIcon
                     v-if="isFilePermanent(f.Key)"
-                    class="inline-flex items-center gap-1 rounded-full bg-red-50 px-2 py-0.5 text-[11px] font-medium text-red-700 ring-1 ring-inset ring-red-200"
-                  >
-                    <UIcon name="i-heroicons-lock-closed" class="h-3 w-3" aria-hidden="true" />
-                    Never
-                  </span>
+                    name="i-heroicons-lock-closed"
+                    class="inline-block h-3.5 w-3.5 text-red-600"
+                    title="This file is protected from auto-deletion when run retention expires. It does not expire with run retention."
+                    aria-label="Protected from auto-deletion; does not expire with run retention"
+                  />
                   <span v-else class="tabular-nums">{{ formatExpiresLabel(f.Key) }}</span>
                 </td>
               </tr>

--- a/packages/front-end/src/app/components/EGDataCollectionsPage.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsPage.vue
@@ -5,6 +5,7 @@
     LaboratoryRunUsageSummary,
   } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/data-collections';
   import { useLabsStore, useToastStore, useUiStore } from '@FE/stores';
+  import { isExpiringSoon } from '@FE/utils/data-collections-filters';
 
   const props = defineProps<{
     labId: string;
@@ -29,6 +30,13 @@
    */
   const keyToWorkflowTagIds = ref<Record<string, string[]>>({});
   /**
+   * Whether each file carries the lab's system-managed permanent tag. Sourced from the
+   * `IsPermanent` field on `FileTagAssignment` so the UI doesn't need to cross-reference
+   * `tags.value` to know. Files marked Permanent are never auto-deleted by the run-retention
+   * cleanup job and are excluded from the "Expiring soon" filter.
+   */
+  const keyToIsPermanent = ref<Record<string, boolean>>({});
+  /**
    * Per-file laboratory run usage history, sorted newest first by `RunCreatedAt` (see
    * `listFileTags` on the back end). Drives the per-file Analysis History tooltip and the
    * orange/green/indigo status dot. Empty array means the file has never been used in a run.
@@ -39,16 +47,56 @@
   const selectedKeys = ref<string[]>([]);
 
   /**
-   * Scope rail filter: at most one of all | not-yet-analyzed | workflow template | workflow version.
+   * Scope rail filter: at most one of all | not-yet-analyzed | expiring-soon | workflow template | workflow version.
    * Tags section (untagged + multiple standard tags) applies on top with OR semantics among selected tags.
    */
   type ScopeFilter =
     | { kind: 'all' }
     | { kind: 'not-analyzed' }
+    | { kind: 'expiring-soon' }
     | { kind: 'workflow-template'; templateKey: string }
     | { kind: 'workflow-version'; tagId: string };
 
   const scopeFilter = ref<ScopeFilter>({ kind: 'all' });
+
+  /**
+   * User-adjustable threshold (in days) for the "Expiring soon" filter. A file is "expiring
+   * soon" iff at least one of its referencing runs has an `ExpiresAt` within this many days
+   * from now AND the file is not marked Permanent. Persisted per-lab to localStorage so the
+   * setting survives reloads but doesn't bleed across labs.
+   */
+  const EXPIRING_SOON_DEFAULT_DAYS = 30;
+  const EXPIRING_SOON_MIN_DAYS = 1;
+  const EXPIRING_SOON_MAX_DAYS = 365;
+
+  function readPersistedExpiringSoonDays(labId: string): number {
+    if (typeof window === 'undefined') return EXPIRING_SOON_DEFAULT_DAYS;
+    try {
+      const raw = window.localStorage?.getItem(`eg.dataCollections.${labId}.expiringSoonDays`);
+      const n = raw != null ? Number(raw) : NaN;
+      if (!Number.isFinite(n)) return EXPIRING_SOON_DEFAULT_DAYS;
+      return Math.min(EXPIRING_SOON_MAX_DAYS, Math.max(EXPIRING_SOON_MIN_DAYS, Math.floor(n)));
+    } catch {
+      return EXPIRING_SOON_DEFAULT_DAYS;
+    }
+  }
+  const expiringSoonThresholdDays = ref<number>(readPersistedExpiringSoonDays(props.labId));
+  watch(expiringSoonThresholdDays, (next) => {
+    if (typeof window === 'undefined') return;
+    try {
+      const clamped = Math.min(EXPIRING_SOON_MAX_DAYS, Math.max(EXPIRING_SOON_MIN_DAYS, Math.floor(Number(next) || 0)));
+      if (clamped !== next) expiringSoonThresholdDays.value = clamped;
+      window.localStorage?.setItem(`eg.dataCollections.${props.labId}.expiringSoonDays`, String(clamped));
+    } catch {
+      // localStorage unavailable (private mode, quota); state still lives in-memory.
+    }
+  });
+  watch(
+    () => props.labId,
+    (next) => {
+      expiringSoonThresholdDays.value = readPersistedExpiringSoonDays(next);
+    },
+  );
   /** Tags section: untagged is mutually exclusive with selecting specific standard tags. */
   const tagsFilterUntagged = ref(false);
   /** Multiple standard tags combine with OR (file matches if it has any selected tag). */
@@ -95,6 +143,19 @@
     return !!(t.Platform && t.WorkflowExternalId);
   }
 
+  /** Singleton permanent tag for this lab (lazy-created server-side on first listTags). */
+  const permanentTag = computed<LaboratoryDataTag | undefined>(() => tags.value.find((t) => t.Kind === 'permanent'));
+  const permanentTagId = computed<string | undefined>(() => permanentTag.value?.TagId);
+
+  function isFilePermanent(key: string): boolean {
+    if (keyToIsPermanent.value[key]) return true;
+    const pid = permanentTagId.value;
+    if (!pid) return false;
+    // Fall back to the raw TagIds list when `IsPermanent` was missing from the API payload
+    // (defensive — older list-file-tags responses may not project the field).
+    return (keyToTagIds.value[key] || []).includes(pid);
+  }
+
   /**
    * Workflow tag ids for a file: prefer API `WorkflowTagIds`, else infer from raw `TagIds` using
    * tag metadata (needed when list-file-tags mis-buckets or tags load after file assignments).
@@ -124,13 +185,18 @@
   /**
    * Tag ids that belong in the generic (user) tag pill row. The API splits workflow ids into
    * `WorkflowTagIds`, but mis-partitioning or missing `Kind` on list-tags must not show workflow
-   * chips in the standard row.
+   * chips in the standard row. The permanent tag is rendered as a dedicated lock affordance
+   * elsewhere and is also excluded from this list.
    */
   function standardTagIdsForFileKey(key: string): string[] {
     const wf = new Set(workflowTagIdsForFileKey(key));
+    const pid = permanentTagId.value;
     return (keyToTagIds.value[key] || []).filter((tid: string) => {
       if (wf.has(tid)) return false;
       if (isWorkflowLaboratoryTag(tagById(tid))) return false;
+      if (pid && tid === pid) return false;
+      const tag = tagById(tid);
+      if (tag?.Kind === 'permanent') return false;
       return true;
     });
   }
@@ -144,7 +210,9 @@
   });
 
   const standardTags = computed(() =>
-    tags.value.filter((t) => (t.Kind ?? 'standard') === 'standard' && !isWorkflowLaboratoryTag(t)),
+    tags.value.filter(
+      (t) => (t.Kind ?? 'standard') === 'standard' && t.Kind !== 'permanent' && !isWorkflowLaboratoryTag(t),
+    ),
   );
 
   const batchTags = computed(() => tags.value.filter((t) => (t.Kind ?? 'standard') === 'batch'));
@@ -218,6 +286,10 @@
     return scopeFilter.value.kind === 'not-analyzed';
   }
 
+  function isExpiringSoonScopeActive(): boolean {
+    return scopeFilter.value.kind === 'expiring-soon';
+  }
+
   function isWorkflowTemplateScopeActive(templateKey: string): boolean {
     const s = scopeFilter.value;
     return s.kind === 'workflow-template' && s.templateKey === templateKey;
@@ -251,6 +323,14 @@
       return;
     }
     scopeFilter.value = { kind: 'not-analyzed' };
+  }
+
+  function onExpiringSoonScopeClick(): void {
+    if (scopeFilter.value.kind === 'expiring-soon') {
+      scopeFilter.value = { kind: 'all' };
+      return;
+    }
+    scopeFilter.value = { kind: 'expiring-soon' };
   }
 
   function onWorkflowTemplateScopeClick(templateKey: string): void {
@@ -362,6 +442,7 @@
       const map: Record<string, string[]> = {};
       const batchMap: Record<string, string | undefined> = {};
       const workflowMap: Record<string, string[]> = {};
+      const permanentMap: Record<string, boolean> = {};
       const runUsagesMap: Record<string, LaboratoryRunUsageSummary[]> = {};
       if (keys.length) {
         for (let i = 0; i < keys.length; i += KEYS_CHUNK) {
@@ -375,6 +456,7 @@
             map[f.Key] = f.TagIds;
             batchMap[f.Key] = f.BatchTagId;
             workflowMap[f.Key] = f.WorkflowTagIds ?? [];
+            permanentMap[f.Key] = !!f.IsPermanent;
             runUsagesMap[f.Key] = f.LaboratoryRunUsages ?? [];
           }
         }
@@ -384,6 +466,7 @@
       keyToTagIds.value = map;
       keyToBatchTagId.value = batchMap;
       keyToWorkflowTagIds.value = workflowMap;
+      keyToIsPermanent.value = permanentMap;
       keyToRunUsages.value = runUsagesMap;
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
@@ -416,6 +499,15 @@
     return keyToRunUsages.value[key]?.length ?? 0;
   }
 
+  function isFileExpiringSoon(key: string): boolean {
+    return isExpiringSoon({
+      isPermanent: isFilePermanent(key),
+      usages: keyToRunUsages.value[key],
+      thresholdDays: expiringSoonThresholdDays.value,
+      nowEpoch: Math.floor(Date.now() / 1000),
+    });
+  }
+
   const visibleFiles = computed(() => {
     let list = filesMatchingSearch.value;
     const sf = scopeFilter.value;
@@ -425,6 +517,9 @@
       case 'not-analyzed':
         // Run-history-based: a file is "not yet analyzed" iff it has zero recorded run usages.
         list = list.filter((f) => runCountForFileKey(f.Key) === 0);
+        break;
+      case 'expiring-soon':
+        list = list.filter((f) => isFileExpiringSoon(f.Key));
         break;
       case 'workflow-template': {
         const tmpl = workflowTemplates.value.find((t) => t.key === sf.templateKey);
@@ -454,6 +549,10 @@
     () => filesMatchingSearch.value.filter((f) => runCountForFileKey(f.Key) === 0).length,
   );
 
+  const expiringSoonChipCount = computed(
+    () => filesMatchingSearch.value.filter((f) => isFileExpiringSoon(f.Key)).length,
+  );
+
   /** Per standard-tag file counts among `filesMatchingSearch` (matches `case 'tag'` in `visibleFiles`). */
   const standardTagIdToChipCount = computed((): Record<string, number> => {
     const tagIds = new Set<string>(standardTags.value.map((t: LaboratoryDataTag) => t.TagId));
@@ -471,6 +570,7 @@
 
   /** Explorer dismiss chips — ids must stay in sync with `clearExplorerFilter`. */
   const CHIP_SCOPE_NOT_ANALYZED = 'chip-scope-not-analyzed';
+  const CHIP_SCOPE_EXPIRING_SOON = 'chip-scope-expiring-soon';
   const CHIP_TAG_UNTAGGED = 'chip-tag-untagged';
 
   function chipIdWorkflowTemplate(templateKey: string): string {
@@ -490,6 +590,11 @@
     const sf = scopeFilter.value;
     if (sf.kind === 'not-analyzed') {
       chips.push({ chipId: CHIP_SCOPE_NOT_ANALYZED, label: 'Not yet analyzed' });
+    } else if (sf.kind === 'expiring-soon') {
+      chips.push({
+        chipId: CHIP_SCOPE_EXPIRING_SOON,
+        label: `Expiring soon (≤ ${expiringSoonThresholdDays.value}d)`,
+      });
     } else if (sf.kind === 'workflow-template') {
       const tmpl = workflowTemplates.value.find((t) => t.key === sf.templateKey);
       chips.push({
@@ -516,6 +621,10 @@
   function clearExplorerFilter(chipId: string): void {
     if (chipId === CHIP_SCOPE_NOT_ANALYZED) {
       if (scopeFilter.value.kind === 'not-analyzed') scopeFilter.value = { kind: 'all' };
+      return;
+    }
+    if (chipId === CHIP_SCOPE_EXPIRING_SOON) {
+      if (scopeFilter.value.kind === 'expiring-soon') scopeFilter.value = { kind: 'all' };
       return;
     }
     if (chipId.startsWith('chip-wft:')) {
@@ -705,6 +814,75 @@
     }
   }
 
+  /**
+   * Counts of permanent / non-permanent files in the current selection, used to decide
+   * whether to render Mark/Unmark Permanent (and to keep the affordance disabled when the
+   * lab's permanent tag hasn't been provisioned yet — `listTags` lazy-creates it server-side,
+   * so this state is transient).
+   */
+  const selectionPermanentStats = computed(() => {
+    const sel = selectedKeys.value;
+    let permanent = 0;
+    let nonPermanent = 0;
+    for (const key of sel) {
+      if (isFilePermanent(key)) permanent++;
+      else nonPermanent++;
+    }
+    return { permanent, nonPermanent, total: sel.length };
+  });
+
+  async function markSelectionPermanent(): Promise<void> {
+    if (!lab.value?.S3Bucket || !selectedKeys.value.length) return;
+    const pid = permanentTagId.value;
+    if (!pid) {
+      toast.error('Permanent tag is still being provisioned; please retry in a moment.');
+      await loadTags();
+      return;
+    }
+    const keys = selectedKeys.value.filter((k) => !isFilePermanent(k));
+    if (!keys.length) {
+      toast.info('All selected files are already Permanent.');
+      return;
+    }
+    uiStore.setRequestPending('dataCollectionsMutate');
+    try {
+      await addTagsToFilesInChunks(keys, [pid], []);
+      await loadTags();
+      await loadListing();
+      await nextTick();
+      toast.success('Marked as Permanent');
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      toast.error(`Mark Permanent failed: ${msg}`);
+    } finally {
+      uiStore.setRequestComplete('dataCollectionsMutate');
+    }
+  }
+
+  async function unmarkSelectionPermanent(): Promise<void> {
+    if (!lab.value?.S3Bucket || !selectedKeys.value.length) return;
+    const pid = permanentTagId.value;
+    if (!pid) return;
+    const keys = selectedKeys.value.filter((k) => isFilePermanent(k));
+    if (!keys.length) {
+      toast.info('No selected files are Permanent.');
+      return;
+    }
+    uiStore.setRequestPending('dataCollectionsMutate');
+    try {
+      await addTagsToFilesInChunks(keys, [], [pid]);
+      await loadTags();
+      await loadListing();
+      await nextTick();
+      toast.success('Removed Permanent flag');
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      toast.error(`Unmark Permanent failed: ${msg}`);
+    } finally {
+      uiStore.setRequestComplete('dataCollectionsMutate');
+    }
+  }
+
   async function applyTagToKeys(tagId: string, keys: string[]): Promise<void> {
     if (!lab.value?.S3Bucket || !keys.length) return;
     uiStore.setRequestPending('dataCollectionsMutate');
@@ -887,6 +1065,40 @@
               {{ notAnalyzedChipCount }}
             </UBadge>
           </button>
+          <button
+            type="button"
+            class="hover:bg-primary-muted flex w-full items-center justify-between gap-2 rounded-lg px-2 py-2 text-left text-sm"
+            :class="{ 'bg-primary-muted font-medium': isExpiringSoonScopeActive() }"
+            :title="`Files whose soonest run-retention ExpiresAt is within ${expiringSoonThresholdDays} days. Permanent files are excluded.`"
+            @click="onExpiringSoonScopeClick"
+          >
+            <span class="flex items-center gap-2">
+              <UIcon name="i-heroicons-clock" class="h-4 w-4 shrink-0 text-amber-600" aria-hidden="true" />
+              <span>Expiring soon</span>
+            </span>
+            <UBadge
+              size="xs"
+              class="bg-primary-muted text-primary-dark shrink-0 rounded-xl border-0 font-serif tabular-nums ring-0"
+            >
+              {{ expiringSoonChipCount }}
+            </UBadge>
+          </button>
+          <div
+            v-if="isExpiringSoonScopeActive()"
+            class="text-muted mt-1 flex items-center justify-between gap-2 rounded-lg px-2 py-1.5 text-xs"
+          >
+            <label :for="`expiring-soon-days-${props.labId}`">Days ahead</label>
+            <input
+              :id="`expiring-soon-days-${props.labId}`"
+              v-model.number="expiringSoonThresholdDays"
+              type="number"
+              :min="EXPIRING_SOON_MIN_DAYS"
+              :max="EXPIRING_SOON_MAX_DAYS"
+              step="1"
+              class="focus:border-primary w-16 rounded border border-gray-300 px-2 py-1 text-right text-xs tabular-nums focus:outline-none"
+              @click.stop
+            />
+          </div>
         </div>
 
         <div class="border-border-muted border-b p-2">
@@ -1078,6 +1290,7 @@
         :key-to-batch-tag-id="keyToBatchTagId"
         :key-to-workflow-tag-ids="keyToWorkflowTagIdsEffective"
         :key-to-run-usages="keyToRunUsages"
+        :key-to-is-permanent="keyToIsPermanent"
         :batch-tags="batchTags"
         :tags="tags"
         :selected-keys="selectedKeys"
@@ -1103,6 +1316,30 @@
         <span v-else class="text-muted text-xs">Select files in the grid to add or remove tags in bulk.</span>
         <div v-if="hasSelection" class="ml-auto flex flex-wrap items-center gap-2">
           <UIcon v-if="bulkPanelBusy" name="i-heroicons-arrow-path" class="text-muted h-5 w-5 shrink-0 animate-spin" />
+          <UButton
+            v-if="selectionPermanentStats.nonPermanent > 0"
+            size="sm"
+            variant="outline"
+            color="red"
+            :disabled="bulkPanelBusy || !permanentTagId"
+            :title="`Mark ${selectionPermanentStats.nonPermanent} file(s) as Permanent so they are never auto-deleted, even after their run retention expires.`"
+            @click="markSelectionPermanent"
+          >
+            <UIcon name="i-heroicons-lock-closed" class="mr-1 h-4 w-4" aria-hidden="true" />
+            Mark Permanent
+          </UButton>
+          <UButton
+            v-if="selectionPermanentStats.permanent > 0"
+            size="sm"
+            variant="outline"
+            color="red"
+            :disabled="bulkPanelBusy || !permanentTagId"
+            :title="`Remove the Permanent flag from ${selectionPermanentStats.permanent} file(s). They will again follow the lab's run retention policy.`"
+            @click="unmarkSelectionPermanent"
+          >
+            <UIcon name="i-heroicons-lock-open" class="mr-1 h-4 w-4" aria-hidden="true" />
+            Unmark Permanent
+          </UButton>
           <UButton size="sm" variant="soft" :disabled="bulkPanelBusy" @click="openAddBulkPanel">Add Tags</UButton>
           <UButton size="sm" variant="outline" :disabled="bulkPanelBusy" @click="openRemoveBulkPanel">
             Remove Tags

--- a/packages/front-end/src/app/components/EGDataCollectionsPage.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsPage.vue
@@ -215,6 +215,13 @@
     ),
   );
 
+  /** Standard tags plus the system Permanent tag for the bulk add/remove tray only (left rail still omits Permanent). */
+  const bulkPanelAssignableTags = computed(() => {
+    const std = standardTags.value;
+    const p = permanentTag.value;
+    return p ? [...std, p] : std;
+  });
+
   const batchTags = computed(() => tags.value.filter((t) => (t.Kind ?? 'standard') === 'batch'));
 
   const workflowTags = computed(() => tags.value.filter((t) => isWorkflowLaboratoryTag(t)));
@@ -397,9 +404,13 @@
     const sel = selectedKeys.value;
     if (!sel.length) return [] as { tagId: string; count: number }[];
     const counts = new Map<string, number>();
+    const pid = permanentTagId.value;
     for (const key of sel) {
       for (const tid of standardTagIdsForFileKey(key)) {
         counts.set(tid, (counts.get(tid) || 0) + 1);
+      }
+      if (pid && isFilePermanent(key)) {
+        counts.set(pid, (counts.get(pid) || 0) + 1);
       }
     }
     return [...counts.entries()]
@@ -534,10 +545,15 @@
         break;
     }
     if (tagsFilterUntagged.value) {
-      list = list.filter((f) => !standardTagIdsForFileKey(f.Key).length);
+      list = list.filter((f) => !standardTagIdsForFileKey(f.Key).length && !isFilePermanent(f.Key));
     } else if (tagsFilterTagIds.value.length > 0) {
       const selected = new Set(tagsFilterTagIds.value);
-      list = list.filter((f) => standardTagIdsForFileKey(f.Key).some((tid: string) => selected.has(tid)));
+      const pid = permanentTagId.value;
+      list = list.filter(
+        (f) =>
+          standardTagIdsForFileKey(f.Key).some((tid: string) => selected.has(tid)) ||
+          (!!pid && selected.has(pid) && isFilePermanent(f.Key)),
+      );
     }
     return list;
   });
@@ -566,6 +582,29 @@
     const out: Record<string, number> = {};
     for (const [k, v] of counts) out[k] = v;
     return out;
+  });
+
+  /** Listed files (current search scope) that carry the Permanent tag — drives left-rail Permanent filter visibility. */
+  const permanentTaggedFileCountInSearch = computed(
+    () => filesMatchingSearch.value.filter((f) => isFilePermanent(f.Key)).length,
+  );
+
+  /**
+   * Left-rail tag filters: all standard tags, plus Permanent only when at least one file in the
+   * current listing/search has it (same universe as chip counts).
+   */
+  const leftRailTagFilterTags = computed(() => {
+    const std = standardTags.value;
+    const p = permanentTag.value;
+    if (!p || permanentTaggedFileCountInSearch.value === 0) return std;
+    return [...std, p];
+  });
+
+  watch(permanentTaggedFileCountInSearch, (n) => {
+    const pid = permanentTagId.value;
+    if (pid && n === 0 && tagsFilterTagIds.value.includes(pid)) {
+      tagsFilterTagIds.value = tagsFilterTagIds.value.filter((id) => id !== pid);
+    }
   });
 
   /** Explorer dismiss chips — ids must stay in sync with `clearExplorerFilter`. */
@@ -809,75 +848,6 @@
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
       toast.error(`Update failed: ${msg}`);
-    } finally {
-      uiStore.setRequestComplete('dataCollectionsMutate');
-    }
-  }
-
-  /**
-   * Counts of permanent / non-permanent files in the current selection, used to decide
-   * whether to render Mark/Unmark Permanent (and to keep the affordance disabled when the
-   * lab's permanent tag hasn't been provisioned yet — `listTags` lazy-creates it server-side,
-   * so this state is transient).
-   */
-  const selectionPermanentStats = computed(() => {
-    const sel = selectedKeys.value;
-    let permanent = 0;
-    let nonPermanent = 0;
-    for (const key of sel) {
-      if (isFilePermanent(key)) permanent++;
-      else nonPermanent++;
-    }
-    return { permanent, nonPermanent, total: sel.length };
-  });
-
-  async function markSelectionPermanent(): Promise<void> {
-    if (!lab.value?.S3Bucket || !selectedKeys.value.length) return;
-    const pid = permanentTagId.value;
-    if (!pid) {
-      toast.error('Permanent tag is still being provisioned; please retry in a moment.');
-      await loadTags();
-      return;
-    }
-    const keys = selectedKeys.value.filter((k) => !isFilePermanent(k));
-    if (!keys.length) {
-      toast.info('All selected files are already Permanent.');
-      return;
-    }
-    uiStore.setRequestPending('dataCollectionsMutate');
-    try {
-      await addTagsToFilesInChunks(keys, [pid], []);
-      await loadTags();
-      await loadListing();
-      await nextTick();
-      toast.success('Marked as Permanent');
-    } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : String(e);
-      toast.error(`Mark Permanent failed: ${msg}`);
-    } finally {
-      uiStore.setRequestComplete('dataCollectionsMutate');
-    }
-  }
-
-  async function unmarkSelectionPermanent(): Promise<void> {
-    if (!lab.value?.S3Bucket || !selectedKeys.value.length) return;
-    const pid = permanentTagId.value;
-    if (!pid) return;
-    const keys = selectedKeys.value.filter((k) => isFilePermanent(k));
-    if (!keys.length) {
-      toast.info('No selected files are Permanent.');
-      return;
-    }
-    uiStore.setRequestPending('dataCollectionsMutate');
-    try {
-      await addTagsToFilesInChunks(keys, [], [pid]);
-      await loadTags();
-      await loadListing();
-      await nextTick();
-      toast.success('Removed Permanent flag');
-    } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : String(e);
-      toast.error(`Unmark Permanent failed: ${msg}`);
     } finally {
       uiStore.setRequestComplete('dataCollectionsMutate');
     }
@@ -1212,7 +1182,7 @@
               <span>Untagged</span>
             </button>
             <button
-              v-for="t in standardTags"
+              v-for="t in leftRailTagFilterTags"
               :key="t.TagId"
               class="hover:bg-primary-muted flex w-full cursor-pointer items-center justify-between gap-2 rounded-lg px-2 py-2 text-left text-sm"
               :class="{ 'bg-primary-muted font-medium': isStandardTagFilterActive(t.TagId) }"
@@ -1220,15 +1190,27 @@
               @dragover.prevent="onCardDragOverTag"
               @drop="onTagRowDrop($event, t.TagId)"
             >
-              <span class="flex min-w-0 items-center gap-2">
+              <span class="flex min-w-0 flex-1 items-center gap-2">
                 <span class="inline-block h-2.5 w-2.5 shrink-0 rounded-full" :style="{ background: t.ColorHex }" />
-                <span class="truncate">{{ t.Name }}</span>
+                <span class="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0.5">
+                  <span class="truncate">{{ t.Name }}</span>
+                  <span
+                    v-if="(t.Kind ?? 'standard') === 'permanent'"
+                    class="text-muted shrink-0 text-[10px] font-normal"
+                  >
+                    Protect from expiry
+                  </span>
+                </span>
               </span>
               <UBadge
                 size="xs"
                 class="bg-primary-muted text-primary-dark shrink-0 rounded-xl border-0 font-serif tabular-nums ring-0"
               >
-                {{ standardTagIdToChipCount[t.TagId] ?? 0 }}
+                {{
+                  (t.Kind ?? 'standard') === 'permanent'
+                    ? permanentTaggedFileCountInSearch
+                    : (standardTagIdToChipCount[t.TagId] ?? 0)
+                }}
               </UBadge>
             </button>
 
@@ -1316,30 +1298,6 @@
         <span v-else class="text-muted text-xs">Select files in the grid to add or remove tags in bulk.</span>
         <div v-if="hasSelection" class="ml-auto flex flex-wrap items-center gap-2">
           <UIcon v-if="bulkPanelBusy" name="i-heroicons-arrow-path" class="text-muted h-5 w-5 shrink-0 animate-spin" />
-          <UButton
-            v-if="selectionPermanentStats.nonPermanent > 0"
-            size="sm"
-            variant="outline"
-            color="red"
-            :disabled="bulkPanelBusy || !permanentTagId"
-            :title="`Mark ${selectionPermanentStats.nonPermanent} file(s) as Permanent so they are never auto-deleted, even after their run retention expires.`"
-            @click="markSelectionPermanent"
-          >
-            <UIcon name="i-heroicons-lock-closed" class="mr-1 h-4 w-4" aria-hidden="true" />
-            Mark Permanent
-          </UButton>
-          <UButton
-            v-if="selectionPermanentStats.permanent > 0"
-            size="sm"
-            variant="outline"
-            color="red"
-            :disabled="bulkPanelBusy || !permanentTagId"
-            :title="`Remove the Permanent flag from ${selectionPermanentStats.permanent} file(s). They will again follow the lab's run retention policy.`"
-            @click="unmarkSelectionPermanent"
-          >
-            <UIcon name="i-heroicons-lock-open" class="mr-1 h-4 w-4" aria-hidden="true" />
-            Unmark Permanent
-          </UButton>
           <UButton size="sm" variant="soft" :disabled="bulkPanelBusy" @click="openAddBulkPanel">Add Tags</UButton>
           <UButton size="sm" variant="outline" :disabled="bulkPanelBusy" @click="openRemoveBulkPanel">
             Remove Tags
@@ -1376,12 +1334,20 @@
                 :key="row.tagId"
                 class="flex items-center justify-between gap-2 rounded-lg border border-gray-100 bg-gray-50/80 px-3 py-2"
               >
-                <span class="flex min-w-0 items-center gap-2">
+                <span class="flex min-w-0 flex-1 items-center gap-2">
                   <span
                     class="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
                     :style="{ background: tagById(row.tagId)?.ColorHex || '#ccc' }"
                   />
-                  <span class="truncate font-medium">{{ tagById(row.tagId)?.Name ?? row.tagId }}</span>
+                  <span class="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0.5">
+                    <span class="truncate font-medium">{{ tagById(row.tagId)?.Name ?? row.tagId }}</span>
+                    <span
+                      v-if="tagById(row.tagId)?.Kind === 'permanent'"
+                      class="text-muted shrink-0 text-[10px] font-normal"
+                    >
+                      Protect from expiry
+                    </span>
+                  </span>
                 </span>
                 <span class="text-muted shrink-0 text-xs tabular-nums">
                   {{ row.count }} / {{ selectedKeys.length }}
@@ -1394,7 +1360,7 @@
             <h3 class="text-muted mb-3 text-xs font-semibold uppercase tracking-wide">Add Tags</h3>
             <ul class="max-h-56 space-y-2 overflow-y-auto pr-1 text-sm">
               <li
-                v-for="t in standardTags"
+                v-for="t in bulkPanelAssignableTags"
                 :key="'add-' + t.TagId"
                 class="flex items-center gap-2 rounded-lg border border-transparent px-2 py-1.5 hover:bg-gray-50"
               >
@@ -1403,7 +1369,15 @@
                   @update:model-value="toggleBulkAddTag(t.TagId)"
                 />
                 <span class="inline-block h-2.5 w-2.5 shrink-0 rounded-full" :style="{ background: t.ColorHex }" />
-                <span class="truncate">{{ t.Name }}</span>
+                <span class="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-2 gap-y-0.5">
+                  <span class="truncate">{{ t.Name }}</span>
+                  <span
+                    v-if="(t.Kind ?? 'standard') === 'permanent'"
+                    class="text-muted shrink-0 text-[10px] font-normal"
+                  >
+                    Protect from expiry
+                  </span>
+                </span>
               </li>
             </ul>
             <div class="mt-3 border-t border-gray-100 pt-3">
@@ -1456,7 +1430,12 @@
                   class="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
                   :style="{ background: tagById(tid)?.ColorHex || '#ccc' }"
                 />
-                <span class="truncate">{{ tagById(tid)?.Name ?? tid }}</span>
+                <span class="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-2 gap-y-0.5">
+                  <span class="truncate">{{ tagById(tid)?.Name ?? tid }}</span>
+                  <span v-if="tagById(tid)?.Kind === 'permanent'" class="text-muted shrink-0 text-[10px] font-normal">
+                    Protect from expiry
+                  </span>
+                </span>
               </li>
             </ul>
           </div>

--- a/packages/front-end/src/app/utils/data-collections-filters.ts
+++ b/packages/front-end/src/app/utils/data-collections-filters.ts
@@ -1,0 +1,47 @@
+import type { LaboratoryRunUsageSummary } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/data-collections';
+
+/**
+ * Pure helpers backing the Data Collections page scope filters. Extracted from the Vue SFC so
+ * they can be unit-tested without booting a Vue test runner. The Vue component imports these
+ * directly and provides its own reactive state.
+ *
+ * Conventions:
+ *   - All `expiresAt` values are epoch seconds (matching the DynamoDB TTL attribute on the
+ *     `laboratory-run-table`).
+ *   - "Permanent" is determined by `keyToIsPermanent[key]`; the shape mirrors the map populated
+ *     from `listFileTags` (`FileTagAssignment.IsPermanent`).
+ *   - `nowEpoch` is parameterised so tests get deterministic behaviour.
+ */
+
+export function soonestExpiresAtForUsages(usages: LaboratoryRunUsageSummary[] | undefined): number | undefined {
+  if (!usages || !usages.length) return undefined;
+  let soonest: number | undefined;
+  for (const u of usages) {
+    if (typeof u.ExpiresAt === 'number') {
+      if (soonest === undefined || u.ExpiresAt < soonest) soonest = u.ExpiresAt;
+    }
+  }
+  return soonest;
+}
+
+/**
+ * A file is "expiring soon" iff:
+ *   1. it is NOT marked permanent (permanent files are protected from auto-deletion);
+ *   2. it has at least one recorded run usage with a defined `ExpiresAt`;
+ *   3. that soonest `ExpiresAt` falls within `thresholdDays` of `nowEpoch`.
+ *
+ * Files whose run usages all lack `ExpiresAt` (non-expiring lab, or run not yet terminal) are
+ * intentionally excluded — they have no schedule to compare against.
+ */
+export function isExpiringSoon(opts: {
+  isPermanent: boolean;
+  usages: LaboratoryRunUsageSummary[] | undefined;
+  thresholdDays: number;
+  nowEpoch: number;
+}): boolean {
+  if (opts.isPermanent) return false;
+  const soonest = soonestExpiresAtForUsages(opts.usages);
+  if (soonest === undefined) return false;
+  const horizonSeconds = opts.thresholdDays * 86400;
+  return soonest - opts.nowEpoch <= horizonSeconds;
+}

--- a/packages/front-end/test/app/utils/data-collections-filters.test.ts
+++ b/packages/front-end/test/app/utils/data-collections-filters.test.ts
@@ -1,0 +1,107 @@
+import type { LaboratoryRunUsageSummary } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/data-collections';
+import { isExpiringSoon, soonestExpiresAtForUsages } from '../../../src/app/utils/data-collections-filters';
+
+const NOW = 1_777_000_000;
+const DAY = 86_400;
+
+function usage(runId: string, expiresAt?: number): LaboratoryRunUsageSummary {
+  return {
+    RunId: runId,
+    RunName: `Run ${runId}`,
+    ExpiresAt: expiresAt,
+  } as LaboratoryRunUsageSummary;
+}
+
+describe('soonestExpiresAtForUsages', () => {
+  it('returns undefined when usages is undefined or empty', () => {
+    expect(soonestExpiresAtForUsages(undefined)).toBeUndefined();
+    expect(soonestExpiresAtForUsages([])).toBeUndefined();
+  });
+
+  it('returns undefined when no usages carry an ExpiresAt (non-expiring lab)', () => {
+    expect(soonestExpiresAtForUsages([usage('r1'), usage('r2')])).toBeUndefined();
+  });
+
+  it('returns the minimum ExpiresAt across mixed usages', () => {
+    const result = soonestExpiresAtForUsages([
+      usage('r1', NOW + 90 * DAY),
+      usage('r2'),
+      usage('r3', NOW + 10 * DAY),
+      usage('r4', NOW + 45 * DAY),
+    ]);
+    expect(result).toBe(NOW + 10 * DAY);
+  });
+});
+
+describe('isExpiringSoon', () => {
+  it('always returns false for Permanent-tagged files even when very near expiry', () => {
+    expect(
+      isExpiringSoon({
+        isPermanent: true,
+        usages: [usage('r1', NOW + 1)],
+        thresholdDays: 30,
+        nowEpoch: NOW,
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when there are no recorded run usages', () => {
+    expect(isExpiringSoon({ isPermanent: false, usages: undefined, thresholdDays: 30, nowEpoch: NOW })).toBe(false);
+    expect(isExpiringSoon({ isPermanent: false, usages: [], thresholdDays: 30, nowEpoch: NOW })).toBe(false);
+  });
+
+  it('returns false when usages exist but none carry an ExpiresAt (non-expiring runs)', () => {
+    expect(
+      isExpiringSoon({
+        isPermanent: false,
+        usages: [usage('r1'), usage('r2')],
+        thresholdDays: 30,
+        nowEpoch: NOW,
+      }),
+    ).toBe(false);
+  });
+
+  it('returns true when soonest ExpiresAt is within the threshold window', () => {
+    expect(
+      isExpiringSoon({
+        isPermanent: false,
+        usages: [usage('r1', NOW + 60 * DAY), usage('r2', NOW + 20 * DAY)],
+        thresholdDays: 30,
+        nowEpoch: NOW,
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when the soonest ExpiresAt is beyond the threshold window', () => {
+    expect(
+      isExpiringSoon({
+        isPermanent: false,
+        usages: [usage('r1', NOW + 60 * DAY)],
+        thresholdDays: 30,
+        nowEpoch: NOW,
+      }),
+    ).toBe(false);
+  });
+
+  it('returns true when ExpiresAt is already in the past (overdue but not yet swept)', () => {
+    expect(
+      isExpiringSoon({
+        isPermanent: false,
+        usages: [usage('r1', NOW - 5 * DAY)],
+        thresholdDays: 30,
+        nowEpoch: NOW,
+      }),
+    ).toBe(true);
+  });
+
+  it('treats the threshold as inclusive (soonest - now === thresholdDays * 86400)', () => {
+    expect(
+      isExpiringSoon({
+        isPermanent: false,
+        usages: [usage('r1', NOW + 30 * DAY)],
+        thresholdDays: 30,
+        nowEpoch: NOW,
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/shared-lib/src/app/types/easy-genomics/data-collections.ts
+++ b/packages/shared-lib/src/app/types/easy-genomics/data-collections.ts
@@ -1,4 +1,4 @@
-export type LaboratoryDataTagKind = 'standard' | 'batch' | 'workflow';
+export type LaboratoryDataTagKind = 'standard' | 'batch' | 'workflow' | 'permanent';
 
 export type WorkflowPlatform = 'AWS HealthOmics' | 'Seqera Cloud';
 
@@ -27,12 +27,18 @@ export type ListLaboratoryDataTagsResponse = {
 
 export type FileTagAssignment = {
   Key: string;
-  /** Standard (non-batch, non-workflow) tags only. */
+  /** Standard (non-batch, non-workflow, non-permanent) tags only. */
   TagIds: string[];
   /** At most one batch tag id if the file is assigned to a batch. */
   BatchTagId?: string;
   /** Workflow tag ids that have been associated with this file via run launches. */
   WorkflowTagIds: string[];
+  /**
+   * True when the file carries the laboratory's system-managed `permanent` tag. Files marked
+   * permanent are never auto-deleted by the run-retention cleanup job (see
+   * `process-expired-laboratory-data` Lambda).
+   */
+  IsPermanent?: boolean;
   /**
    * Per-laboratory-run usage history for this file, sorted newest first by `RunCreatedAt`.
    * Each entry records that the file appeared in a run's `InputFileKeys` at run creation time,
@@ -53,6 +59,14 @@ export type LaboratoryRunUsageSummary = {
   InputFileCount: number;
   /** Full list of S3 object keys (lab-scoped) for the run, used by the tooltip's "select samples" action. */
   InputFileKeys: string[];
+  /**
+   * Mirror of the laboratory run's `ExpiresAt` (epoch seconds, DynamoDB TTL) at the time this
+   * usage entry was recorded or last refreshed. Undefined when the run is non-expiring
+   * (`Laboratory.RunRetentionMonths === 0`) or when the run had not yet reached a terminal
+   * status. Surfaced to the front-end so the data collections page can power the
+   * "Expiring soon" scope filter without an extra round trip to the run table.
+   */
+  ExpiresAt?: number;
 };
 
 export type ListFileTagsResponse = {


### PR DESCRIPTION
## Permanent tag, run-retention S3 cascade, and “Expiring soon” on Data Collections

## Type of Change*
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
This change implements the Data Tagging “Permanent” workflow and connects laboratory run retention (DynamoDB TTL on `laboratory-run-table`) to eventual cleanup of **input** files in the lab S3 bucket, while giving users a way to protect specific files from automated deletion.

**Permanent tag (system-managed)**
- Shared types: `LaboratoryDataTagKind` includes `permanent`; `FileTagAssignment` exposes `IsPermanent`; `LaboratoryRunUsageSummary` includes optional `ExpiresAt` (epoch seconds) for UI and bookkeeping.
- `LaboratoryDataTaggingService`: deterministic permanent tag id per lab, lazy provisioning on `listTags`, `createTag` / `deleteTag` / `updateTag` reject user management of permanent tags, `applyTagsToFiles` can add/remove permanent like other user-facing tags, `listFileTags` sets `IsPermanent`, `updateRunUsageExpiresAt` patches usage entries, `removeLaboratoryRunUsageForRunIds` supports `preserveEmptyFileRow` so stream-driven unlinking can leave a `FILE#` row for the scheduled cleanup pass, plus helpers to list file rows and delete file rows/associations for cleanup.
- `list-tags` lambda ensures the permanent tag exists when tags are listed.

**Run usage `ExpiresAt` propagation**
- Run–file association records `ExpiresAt` on usage at association time (`associate-laboratory-run-workflow-tagging`).
- `update-laboratory-run`, `process-update-laboratory-run`, and `request-apply-run-retention-policy` propagate `ExpiresAt` into tagging-table usage entries after run updates / retention policy application.

**Hybrid S3 deletion cascade**
- **DynamoDB stream** (`OLD_IMAGE`) enabled on `laboratory-run-table` via `DynamoDBTableDetails.stream` and API stack wiring.
- **`process-laboratory-run-stream`**: on `REMOVE` (TTL or manual), unmarshals old image, loads lab for bucket, calls `removeLaboratoryRunUsageForRunIds` with `preserveEmptyFileRow: true`; logs TTL vs manual via `userIdentity.principalId`; errors rethrow for retries/DLQ.
- **`process-expired-laboratory-data`**: daily scheduled sweep per lab; deletes S3 objects and removes tagging rows for files that have **no** remaining `LaboratoryRunUsages`, **have** at least one workflow tag id (proxy for “was used by a run”), and **do not** carry the permanent tag. Supports `DRY_RUN` and emits CloudWatch Embedded Metric Format (EMF) metrics.
- **`LaboratoryService.listAllLaboratories`**: supports the scheduled job iterating labs.
- **Nested stack**: DLQ for the stream consumer, `DynamoEventSource` + `SqsDlq`, EventBridge schedule for cleanup, IAM for stream read, tagging table, S3 delete, and related Lambdas.

**Backfill**
- `scripts/backfill-run-usage-expires-at.ts` to backfill `ExpiresAt` on existing `LaboratoryRunUsages` entries from current run rows.

**Frontend (Data Collections)**
- Permanent: hide permanent tag from the standard tags rail; lock/chip treatment in `EGDataCollectionsExplorer`; Mark / Unmark Permanent bulk actions on `EGDataCollectionsPage`.
- “Expiring soon” scope filter below “Not yet analyzed”, with threshold days (default 30, persisted per lab in `localStorage`), chip count, and `visibleFiles` wiring. Core date logic lives in `data-collections-filters.ts` with unit tests; the page calls `isExpiringSoon` with live `Date.now()`.

**Orphans / outputs**
- Auto-delete applies only to workflow-tagged inputs with no remaining usages; never-used orphans and run outputs remain out of scope as agreed in the product plan.

## Testing*
- `pnpm --filter=@easy-genomics/back-end test` — full back-end suite (including new/updated tests for tagging service permanent paths, `updateRunUsageExpiresAt`, `preserveEmptyFileRow`, `process-laboratory-run-stream`, `process-expired-laboratory-data`, and nested stack wiring mocks).
- `pnpm --filter=@easy-genomics/front-end test` — includes new `data-collections-filters.test.ts` (10 cases, 100% coverage on the helper module).
- Manual smoke recommended after deploy: list tags (permanent appears), mark/unmark permanent on a file, verify “Expiring soon” with a lab that has non-zero retention and terminal runs with `ExpiresAt` on usages.

## Impact
- **Infrastructure**: `laboratory-run-table` gains a DynamoDB stream (`OLD_IMAGE`); new Lambdas, SQS DLQ, EventBridge rule, and expanded IAM. Existing environments need a coordinated CDK deploy; stream enablement on an existing table is a configuration change only (no data rewrite).
- **Behavior**: When run rows expire (TTL) or are removed, input files can eventually be deleted from S3 and removed from the tagging table unless marked Permanent. TTL remains eventually consistent (up to ~48h lag is normal).
- **Operational**: Set `DRY_RUN=true` on `process-expired-laboratory-data` initially if you want metrics and logs without deletes; run the backfill script once per environment if historical “Expiring soon” accuracy matters before new writes propagate `ExpiresAt`.
- **Performance / cost**: Stream consumer per run removal; daily full-lab file row scan for cleanup — monitor Lambda duration and S3 delete volume in lower environments first.

## Additional Information
- Branch: `feat/egv-126-data-tagging-permanent-tags` (vs `development`).
- JIRA: EGV-126 (from branch naming; adjust if the ticket id differs).
- No `packages/shared-lib/.../create-tag.ts` changes in this diff vs `development`; API restrictions for permanent tags are enforced in the tagging service rather than via a schema delta in this branch.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.