### PR TITLE
feat: add more error handling in the backend

### DIFF
--- a/packages/back-end/src/app/controllers/auth/process-post-authentication.lambda.ts
+++ b/packages/back-end/src/app/controllers/auth/process-post-authentication.lambda.ts
@@ -1,5 +1,5 @@
 import { AuthenticationLogEvent } from '@easy-genomics/shared-lib/src/app/types/auth/authentication-log-event';
-import { APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
+import { PostAuthenticationTriggerEvent, PostAuthenticationTriggerHandler } from 'aws-lambda';
 import { AuthenticationLogService } from '../../services/auth/authentication-log-service';
 
 const authenticationLogService = new AuthenticationLogService();
@@ -17,17 +17,17 @@ const authenticationLogService = new AuthenticationLogService();
  *
  * @param event
  */
-export const handler: Handler = async (
-  event: APIGatewayProxyWithCognitoAuthorizerEvent,
-): Promise<APIGatewayProxyWithCognitoAuthorizerEvent> => {
+export const handler: PostAuthenticationTriggerHandler = async (
+  event: PostAuthenticationTriggerEvent,
+): Promise<PostAuthenticationTriggerEvent> => {
   console.log('EVENT: \n' + JSON.stringify(event, null, 2));
-  // @ts-ignore
   await authenticationLogService
     .add(<AuthenticationLogEvent>{
       UserName: event.userName,
       DateTime: Date.now(), // UNIX timestamp
       Event: JSON.stringify(event),
     })
+    // Intentional: auth must not fail if audit logging fails — swallow and log only.
     .catch((err) => {
       console.error(err);
     });

--- a/packages/back-end/src/app/controllers/easy-genomics/list-buckets.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/list-buckets.lambda.ts
@@ -1,5 +1,5 @@
 import { Bucket, GetBucketTaggingCommandOutput, ListBucketsCommandOutput, Tag } from '@aws-sdk/client-s3';
-import { buildResponse } from '@easy-genomics/shared-lib/lib/app/utils/common';
+import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/lib/app/utils/common';
 import { S3Bucket } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/s3-bucket';
 import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
 import { S3Service } from '../../services/s3-service';
@@ -52,10 +52,6 @@ export const handler: Handler = async (
       throw new Error(`Unable to list Buckets: ${JSON.stringify(response)}`);
     }
   } catch (err: any) {
-    console.error(err);
-    return {
-      statusCode: 400,
-      body: `Error: ${err.message}`,
-    };
+    return buildErrorResponse(err, event);
   }
 };

--- a/packages/back-end/src/app/controllers/easy-genomics/user/create-bulk-user-invitation-requests.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/user/create-bulk-user-invitation-requests.lambda.ts
@@ -1,5 +1,5 @@
 import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/lib/app/utils/common';
-import { UnauthorizedAccessError } from '@easy-genomics/shared-lib/lib/app/utils/HttpError';
+import { InvalidRequestError, UnauthorizedAccessError } from '@easy-genomics/shared-lib/lib/app/utils/HttpError';
 import { CreateBulkUserInvitationRequestSchema } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/user-invitation';
 import { Organization } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/organization';
 import { SnsProcessingEvent } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/sns-processing-event';
@@ -28,7 +28,7 @@ export const handler: Handler = async (
       : JSON.parse(event.body!);
 
     // Data validation safety check
-    if (!CreateBulkUserInvitationRequestSchema.safeParse(request).success) throw new Error('Invalid request');
+    if (!CreateBulkUserInvitationRequestSchema.safeParse(request).success) throw new InvalidRequestError();
 
     // Only the SystemAdmin or any User with access to the Organization is allowed access to this API
     if (!(validateSystemAdminAccess(event) || validateOrganizationAdminAccess(event, request.OrganizationId))) {

--- a/packages/back-end/src/app/services/easy-genomics/laboratory-service.ts
+++ b/packages/back-end/src/app/services/easy-genomics/laboratory-service.ts
@@ -6,7 +6,7 @@ import {
   TransactWriteItemsCommandOutput,
 } from '@aws-sdk/client-dynamodb';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
-import { LaboratoryNotFoundError } from '@easy-genomics/shared-lib/lib/app/utils/HttpError';
+import { InvalidRequestError, LaboratoryNotFoundError } from '@easy-genomics/shared-lib/lib/app/utils/HttpError';
 import { LaboratorySchema } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/laboratory';
 import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
 import { Service } from '../../types/service';
@@ -25,7 +25,7 @@ export class LaboratoryService extends DynamoDBService implements Service<Labora
     console.info(logRequestMessage);
 
     // Data validation safety check
-    if (!LaboratorySchema.safeParse(laboratory).success) throw new Error('Invalid request');
+    if (!LaboratorySchema.safeParse(laboratory).success) throw new InvalidRequestError();
 
     const response = await this.transactWriteItems({
       TransactItems: [
@@ -174,7 +174,7 @@ export class LaboratoryService extends DynamoDBService implements Service<Labora
     console.info(logRequestMessage);
 
     // Data validation safety check
-    if (!LaboratorySchema.safeParse(laboratory).success) throw new Error('Invalid request');
+    if (!LaboratorySchema.safeParse(laboratory).success) throw new InvalidRequestError();
 
     // Check if Laboratory Name is unchanged
     if (laboratory.Name === existing.Name) {

--- a/packages/back-end/src/app/services/easy-genomics/organization-service.ts
+++ b/packages/back-end/src/app/services/easy-genomics/organization-service.ts
@@ -5,6 +5,7 @@ import {
   UpdateItemCommandOutput,
 } from '@aws-sdk/client-dynamodb';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
+import { InvalidRequestError } from '@easy-genomics/shared-lib/lib/app/utils/HttpError';
 import { OrganizationSchema } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/organization';
 import { Organization } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/organization';
 import { Service } from '../../types/service';
@@ -23,7 +24,7 @@ export class OrganizationService extends DynamoDBService implements Service<Orga
     console.info(logRequestMessage);
 
     // Data validation safety check
-    if (!OrganizationSchema.safeParse(organization).success) throw new Error('Invalid request');
+    if (!OrganizationSchema.safeParse(organization).success) throw new InvalidRequestError();
 
     const response = await this.transactWriteItems({
       TransactItems: [
@@ -103,7 +104,7 @@ export class OrganizationService extends DynamoDBService implements Service<Orga
     console.info(logRequestMessage);
 
     // Data validation safety check
-    if (!OrganizationSchema.safeParse(organization).success) throw new Error('Invalid request');
+    if (!OrganizationSchema.safeParse(organization).success) throw new InvalidRequestError();
 
     const updateExclusions: string[] = ['OrganizationId', 'CreatedAt', 'CreatedBy'];
 

--- a/packages/back-end/src/app/services/easy-genomics/user-service.ts
+++ b/packages/back-end/src/app/services/easy-genomics/user-service.ts
@@ -7,6 +7,7 @@ import {
   TransactWriteItemsCommandOutput,
 } from '@aws-sdk/client-dynamodb';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
+import { InvalidRequestError } from '@easy-genomics/shared-lib/lib/app/utils/HttpError';
 import { UserSchema } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/user';
 import { User } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/user';
 import { Service } from '../../types/service';
@@ -23,7 +24,7 @@ export class UserService extends DynamoDBService implements Service<User> {
   /** Validates and returns a canonical user shape (unknown keys removed — see UserSchema in shared-lib). */
   private validatedUserForWrite(user: User): User {
     const parsed = UserSchema.safeParse(user);
-    if (!parsed.success) throw new Error('Invalid request');
+    if (!parsed.success) throw new InvalidRequestError();
     return parsed.data;
   }
 

--- a/packages/back-end/test/app/controllers/auth/process-post-authentication.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/auth/process-post-authentication.lambda.test.ts
@@ -1,0 +1,57 @@
+import { PostAuthenticationTriggerEvent } from 'aws-lambda';
+import { handler } from '../../../../src/app/controllers/auth/process-post-authentication.lambda';
+
+jest.mock('../../../../src/app/services/auth/authentication-log-service');
+
+import { AuthenticationLogService } from '../../../../src/app/services/auth/authentication-log-service';
+
+const createMockEvent = (): PostAuthenticationTriggerEvent => ({
+  version: '1',
+  triggerSource: 'PostAuthentication_Authentication',
+  region: 'us-east-1',
+  userPoolId: 'us-east-1_TestPool',
+  userName: 'test-user-id',
+  callerContext: {
+    awsSdkVersion: '1.0.0',
+    clientId: 'test-client-id',
+  },
+  request: {
+    userAttributes: { sub: 'test-user-id', email: 'user@example.com' },
+    newDeviceUsed: false,
+  },
+  response: {},
+});
+
+describe('process-post-authentication Lambda', () => {
+  let mockAdd: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const MockAuthLogService = AuthenticationLogService as jest.MockedClass<typeof AuthenticationLogService>;
+    mockAdd = jest.fn();
+    MockAuthLogService.prototype.add = mockAdd;
+  });
+
+  it('returns the event unchanged when audit logging succeeds', async () => {
+    mockAdd.mockResolvedValue(undefined);
+    const event = createMockEvent();
+
+    const result = await handler(event, {} as any, () => {});
+
+    expect(result).toEqual(event);
+    expect(mockAdd).toHaveBeenCalledWith(expect.objectContaining({ UserName: 'test-user-id' }));
+  });
+
+  it('swallows audit log errors and still returns the event so auth is not blocked', async () => {
+    mockAdd.mockRejectedValue(new Error('DynamoDB down'));
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const event = createMockEvent();
+
+    const result = await handler(event, {} as any, () => {});
+
+    expect(result).toEqual(event);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.any(Error));
+  });
+});

--- a/packages/back-end/test/app/controllers/easy-genomics/list-buckets.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/list-buckets.lambda.test.ts
@@ -1,0 +1,105 @@
+import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent } from 'aws-lambda';
+import { handler } from '../../../../src/app/controllers/easy-genomics/list-buckets.lambda';
+
+jest.mock('../../../../src/app/services/s3-service');
+
+import { S3Service } from '../../../../src/app/services/s3-service';
+
+const createMockEvent = (): APIGatewayProxyWithCognitoAuthorizerEvent => ({
+  body: null,
+  isBase64Encoded: false,
+  httpMethod: 'GET',
+  path: '/list-buckets',
+  headers: {},
+  requestContext: { authorizer: { claims: {} } } as any,
+  resource: '',
+  queryStringParameters: null,
+  multiValueQueryStringParameters: null,
+  pathParameters: null,
+  stageVariables: null,
+  multiValueHeaders: {},
+});
+
+describe('list-buckets Lambda', () => {
+  let mockListBuckets: jest.Mock;
+  let mockGetBucketTagging: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const MockS3Service = S3Service as jest.MockedClass<typeof S3Service>;
+    mockListBuckets = jest.fn();
+    mockGetBucketTagging = jest.fn();
+    MockS3Service.prototype.listBuckets = mockListBuckets;
+    MockS3Service.prototype.getBucketTagging = mockGetBucketTagging;
+  });
+
+  describe('error handling', () => {
+    it('returns buildErrorResponse with EG-100 when listBuckets throws', async () => {
+      mockListBuckets.mockRejectedValue(new Error('S3 down'));
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      const result = (await handler(createMockEvent(), {} as any, () => {})) as APIGatewayProxyResult;
+
+      expect(result.statusCode).toBe(400);
+      expect(JSON.parse(result.body)).toMatchObject({ ErrorCode: 'EG-100' });
+      expect(consoleSpy).toHaveBeenCalled();
+    });
+
+    it('returns buildErrorResponse with EG-100 when Buckets is null', async () => {
+      mockListBuckets.mockResolvedValue({ Buckets: null });
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      const result = (await handler(createMockEvent(), {} as any, () => {})) as APIGatewayProxyResult;
+
+      expect(result.statusCode).toBe(400);
+      expect(JSON.parse(result.body)).toMatchObject({ ErrorCode: 'EG-100' });
+      expect(consoleSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('happy path', () => {
+    it('returns only buckets with the easy-genomics:s3-bucket-type data tag', async () => {
+      mockListBuckets.mockResolvedValue({
+        Buckets: [{ Name: 'my-data-bucket' }, { Name: 'other-bucket' }],
+      });
+      mockGetBucketTagging
+        .mockResolvedValueOnce({ TagSet: [{ Key: 'easy-genomics:s3-bucket-type', Value: 'data' }] })
+        .mockResolvedValueOnce({ TagSet: [{ Key: 'other-key', Value: 'other-value' }] });
+
+      const result = (await handler(createMockEvent(), {} as any, () => {})) as APIGatewayProxyResult;
+
+      expect(result.statusCode).toBe(200);
+      expect(JSON.parse(result.body)).toEqual([{ Name: 'my-data-bucket' }]);
+    });
+
+    it('excludes CDK and Amplify buckets by name prefix', async () => {
+      mockListBuckets.mockResolvedValue({
+        Buckets: [{ Name: 'cdk-bootstrap-bucket' }, { Name: 'amplify-app-bucket' }, { Name: 'valid-bucket' }],
+      });
+      mockGetBucketTagging.mockResolvedValue({
+        TagSet: [{ Key: 'easy-genomics:s3-bucket-type', Value: 'data' }],
+      });
+
+      const result = (await handler(createMockEvent(), {} as any, () => {})) as APIGatewayProxyResult;
+
+      expect(result.statusCode).toBe(200);
+      expect(JSON.parse(result.body)).toEqual([{ Name: 'valid-bucket' }]);
+    });
+
+    it('excludes cross-region buckets where getBucketTagging returns undefined', async () => {
+      mockListBuckets.mockResolvedValue({
+        Buckets: [{ Name: 'cross-region-bucket' }, { Name: 'local-bucket' }],
+      });
+      mockGetBucketTagging
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce({ TagSet: [{ Key: 'easy-genomics:s3-bucket-type', Value: 'data' }] });
+
+      const result = (await handler(createMockEvent(), {} as any, () => {})) as APIGatewayProxyResult;
+
+      expect(result.statusCode).toBe(200);
+      expect(JSON.parse(result.body)).toEqual([{ Name: 'local-bucket' }]);
+    });
+  });
+});

--- a/packages/back-end/test/app/controllers/easy-genomics/user/create-bulk-user-invitation-requests.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/user/create-bulk-user-invitation-requests.lambda.test.ts
@@ -1,0 +1,114 @@
+import { OrganizationNotFoundError } from '@easy-genomics/shared-lib/lib/app/utils/HttpError';
+import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent } from 'aws-lambda';
+import { handler } from '../../../../../src/app/controllers/easy-genomics/user/create-bulk-user-invitation-requests.lambda';
+
+jest.mock('../../../../../src/app/services/easy-genomics/organization-service');
+jest.mock('../../../../../src/app/services/sns-service');
+jest.mock('../../../../../src/app/utils/auth-utils');
+
+import { OrganizationService } from '../../../../../src/app/services/easy-genomics/organization-service';
+import { SnsService } from '../../../../../src/app/services/sns-service';
+import { validateSystemAdminAccess, validateOrganizationAdminAccess } from '../../../../../src/app/utils/auth-utils';
+
+const ORG_ID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+
+const createMockEvent = (
+  body: any,
+  overrides: Partial<APIGatewayProxyWithCognitoAuthorizerEvent> = {},
+): APIGatewayProxyWithCognitoAuthorizerEvent => ({
+  body: JSON.stringify(body),
+  isBase64Encoded: false,
+  httpMethod: 'POST',
+  path: '/user/create-bulk-user-invitation-requests',
+  headers: {},
+  requestContext: {
+    authorizer: { claims: { 'cognito:username': 'test-user-id' } },
+  } as any,
+  resource: '',
+  queryStringParameters: null,
+  multiValueQueryStringParameters: null,
+  pathParameters: null,
+  stageVariables: null,
+  multiValueHeaders: {},
+  ...overrides,
+});
+
+describe('create-bulk-user-invitation-requests Lambda', () => {
+  let mockValidateSysAdmin: jest.MockedFunction<typeof validateSystemAdminAccess>;
+  let mockValidateOrgAdmin: jest.MockedFunction<typeof validateOrganizationAdminAccess>;
+  let mockOrgGet: jest.Mock;
+  let mockSnsPublish: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    process.env.SNS_USER_INVITE_TOPIC = 'arn:aws:sns:us-east-1:123456789012:test-topic.fifo';
+
+    mockValidateSysAdmin = validateSystemAdminAccess as jest.MockedFunction<typeof validateSystemAdminAccess>;
+    mockValidateOrgAdmin = validateOrganizationAdminAccess as jest.MockedFunction<
+      typeof validateOrganizationAdminAccess
+    >;
+
+    const MockOrgService = OrganizationService as jest.MockedClass<typeof OrganizationService>;
+    mockOrgGet = jest.fn();
+    MockOrgService.prototype.get = mockOrgGet;
+
+    const MockSnsService = SnsService as jest.MockedClass<typeof SnsService>;
+    mockSnsPublish = jest.fn();
+    MockSnsService.prototype.publish = mockSnsPublish;
+  });
+
+  it('returns EG-102 when the request body fails Zod validation', async () => {
+    const result = (await handler(createMockEvent({}), {} as any, () => {})) as APIGatewayProxyResult;
+
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body)).toMatchObject({ ErrorCode: 'EG-102' });
+  });
+
+  it('returns EG-103 when caller is neither system admin nor org admin', async () => {
+    mockValidateSysAdmin.mockReturnValue(false);
+    mockValidateOrgAdmin.mockReturnValue(false);
+
+    const result = (await handler(
+      createMockEvent({ OrganizationId: ORG_ID, Emails: ['user@example.com'] }),
+      {} as any,
+      () => {},
+    )) as APIGatewayProxyResult;
+
+    expect(result.statusCode).toBe(403);
+    expect(JSON.parse(result.body)).toMatchObject({ ErrorCode: 'EG-103' });
+  });
+
+  it('returns EG-203 when the organization is not found', async () => {
+    mockValidateSysAdmin.mockReturnValue(true);
+    mockOrgGet.mockRejectedValue(new OrganizationNotFoundError());
+
+    const result = (await handler(
+      createMockEvent({ OrganizationId: ORG_ID, Emails: ['user@example.com'] }),
+      {} as any,
+      () => {},
+    )) as APIGatewayProxyResult;
+
+    expect(result.statusCode).toBe(404);
+    expect(JSON.parse(result.body)).toMatchObject({ ErrorCode: 'EG-203' });
+  });
+
+  it('publishes one SNS message per email and returns success', async () => {
+    mockValidateSysAdmin.mockReturnValue(true);
+    mockOrgGet.mockResolvedValue({ OrganizationId: ORG_ID });
+    mockSnsPublish.mockResolvedValue({});
+
+    const emails = ['a@example.com', 'b@example.com'];
+    const result = (await handler(
+      createMockEvent({ OrganizationId: ORG_ID, Emails: emails }),
+      {} as any,
+      () => {},
+    )) as APIGatewayProxyResult;
+
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toEqual({ Status: 'success' });
+    expect(mockSnsPublish).toHaveBeenCalledTimes(emails.length);
+  });
+});

--- a/packages/shared-lib/src/app/constants/errorMessages.ts
+++ b/packages/shared-lib/src/app/constants/errorMessages.ts
@@ -4,6 +4,7 @@ export const ERROR_CODES: ErrorMessages = {
   'EG-101': 'Not Found',
   'EG-102': 'Required field is missing or Invalid request',
   'EG-103': 'Unauthorized access',
+  'EG-104': 'Workflow access denied',
   'EG-110': 'Expired organization access',
   'EG-201': 'Organization already exists',
   'EG-202': 'Organization deletion failed',
@@ -28,11 +29,15 @@ export const ERROR_CODES: ErrorMessages = {
   'EG-314': 'Laboratory Bucket not found',
   'EG-315': 'Laboratory does not have AWS HealthOmics enabled',
   'EG-316': 'Laboratory does not have Seqera Cloud / NextFlow Tower enabled',
+  'EG-322': 'Laboratory run deletion failed',
+  'EG-323': 'Laboratory run not found',
   'EG-401': 'User already exists',
   'EG-402': 'User deletion failed',
   'EG-403': 'User not found',
   'EG-404': 'User name already taken',
   'EG-405': 'User not permitted access without first granted access to the Organization',
+  'EG-503': 'Workflow not found in AWS HealthOmics',
+  'EG-600': 'Seqera Cloud API error',
 };
 
 /**

--- a/packages/shared-lib/src/app/types/easy-genomics/errors.ts
+++ b/packages/shared-lib/src/app/types/easy-genomics/errors.ts
@@ -2,6 +2,7 @@ export type ErrorCodeKeys =
   | 'EG-101'
   | 'EG-102'
   | 'EG-103'
+  | 'EG-104'
   | 'EG-110'
   | 'EG-201'
   | 'EG-202'
@@ -26,11 +27,15 @@ export type ErrorCodeKeys =
   | 'EG-314'
   | 'EG-315'
   | 'EG-316'
+  | 'EG-322'
+  | 'EG-323'
   | 'EG-401'
   | 'EG-402'
   | 'EG-403'
   | 'EG-404'
-  | 'EG-405';
+  | 'EG-405'
+  | 'EG-503'
+  | 'EG-600';
 
 export type ErrorMessages = {
   [key in ErrorCodeKeys]: string;

--- a/packages/shared-lib/src/app/utils/common.ts
+++ b/packages/shared-lib/src/app/utils/common.ts
@@ -57,6 +57,8 @@ export function buildErrorResponse(
   if (isHttpErrorShape(error)) {
     errorCode = error.errorCode;
     statusCode = error.statusCode;
+  } else {
+    console.error('Unexpected error:', error);
   }
 
   const body = JSON.stringify({

--- a/packages/shared-lib/test/app/utils/common.test.ts
+++ b/packages/shared-lib/test/app/utils/common.test.ts
@@ -1,0 +1,66 @@
+import { APIGatewayProxyWithCognitoAuthorizerEvent } from 'aws-lambda';
+import { buildErrorResponse, buildResponse } from '../../../src/app/utils/common';
+import { NotFoundError, InvalidRequestError } from '../../../src/app/utils/HttpError';
+
+const createMockEvent = (): APIGatewayProxyWithCognitoAuthorizerEvent => ({
+  body: null,
+  isBase64Encoded: false,
+  httpMethod: 'GET',
+  path: '/test',
+  headers: {},
+  requestContext: { authorizer: { claims: {} } } as any,
+  resource: '',
+  queryStringParameters: null,
+  multiValueQueryStringParameters: null,
+  pathParameters: null,
+  stageVariables: null,
+  multiValueHeaders: {},
+});
+
+describe('buildErrorResponse', () => {
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('returns correct statusCode and ErrorCode for an HttpError without logging', () => {
+    const result = buildErrorResponse(new NotFoundError(), createMockEvent());
+
+    expect(result.statusCode).toBe(404);
+    expect(JSON.parse(result.body)).toMatchObject({ ErrorCode: 'EG-101' });
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns correct statusCode and ErrorCode for an InvalidRequestError without logging', () => {
+    const result = buildErrorResponse(new InvalidRequestError(), createMockEvent());
+
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body)).toMatchObject({ ErrorCode: 'EG-102' });
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 with EG-100 and calls console.error for a plain Error', () => {
+    const err = new Error('boom');
+    const result = buildErrorResponse(err, createMockEvent());
+
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body)).toMatchObject({ ErrorCode: 'EG-100' });
+    expect(consoleSpy).toHaveBeenCalledWith('Unexpected error:', err);
+  });
+});
+
+describe('buildResponse', () => {
+  it('returns the given statusCode, body, and CORS headers', () => {
+    const body = JSON.stringify({ ok: true });
+    const result = buildResponse(200, body, createMockEvent());
+
+    expect(result.statusCode).toBe(200);
+    expect(result.body).toBe(body);
+    expect(result.headers).toMatchObject({ 'Access-Control-Allow-Origin': '*' });
+  });
+});


### PR DESCRIPTION
## Description

Improves error handling consistency and visibility across backend Lambda controllers and shared utilities on the `feat/egv-136-new-error-handling-backend` branch.

- **`list-buckets.lambda.ts`**: Replaced bare `catch` block (returned unstructured string) with `buildErrorResponse(err, event)` so errors are properly typed and logged.
- **`create-bulk-user-invitation-requests.lambda.ts`**, **`organization-service.ts`**, **`laboratory-service.ts`**, **`user-service.ts`**: Replaced `throw new Error('Invalid request')` with `throw new InvalidRequestError()` so Zod validation failures return EG-102 instead of unclassified EG-100.
- **`process-post-authentication.lambda.ts`**: Fixed handler type (was `Handler` / `APIGatewayProxyWithCognitoAuthorizerEvent`, now `PostAuthenticationTriggerHandler` / `PostAuthenticationTriggerEvent`); removed `@ts-ignore`; added intent comment explaining why the audit log error is swallowed.
- **`shared-lib/src/app/utils/common.ts`**: Added `console.error('Unexpected error:', error)` for non-`HttpError` exceptions so unexpected errors surface in CloudWatch.
- **`shared-lib/src/app/types/easy-genomics/errors.ts`** + **`errorMessages.ts`**: Added 5 missing error codes (`EG-104`, `EG-322`, `EG-323`, `EG-503`, `EG-600`) that were referenced in `HttpError.ts` but absent from the `ErrorCodeKeys` union and `ERROR_CODES` map — would have caused TypeScript compile errors.

> **Note:** `logSafeEvent` (PII-redacting event logger) is intentionally excluded from this PR — it touches 90+ controllers and will be delivered separately in `feat/egv-136-safe-event-logging`.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build configuration change
- [ ] Documentation
- [ ] Other

## How Has This Been Tested?

Added 4 new test files covering all changed paths (15 tests total, all passing):

| File | Tests |
|---|---|
| `back-end/test/.../list-buckets.lambda.test.ts` | S3 throws → EG-100; Buckets null → EG-100; tag filtering; CDK/Amplify exclusion; cross-region exclusion |
| `back-end/test/.../create-bulk-user-invitation-requests.lambda.test.ts` | Invalid body → EG-102; unauthorized → EG-103; org not found → EG-203; happy path → 200 |
| `back-end/test/.../process-post-authentication.lambda.test.ts` | Audit log succeeds → event returned; audit log fails → error swallowed, auth not blocked |
| `shared-lib/test/.../common.test.ts` | `HttpError` → correct status/code; plain `Error` → EG-100 + `console.error`; `buildResponse` → 200 + CORS |

```bash
cd packages/back-end && pnpm test -- --testPathPattern="list-buckets.lambda.test"
cd packages/back-end && pnpm test -- --testPathPattern="create-bulk-user-invitation-requests.lambda.test"
cd packages/back-end && pnpm test -- --testPathPattern="process-post-authentication.lambda.test"
cd packages/shared-lib && pnpm test -- --testPathPattern="common.test"
