### PR TITLE
feat: data tagging ui cleanup

### DIFF
--- a/packages/front-end/src/app/components/EGDataCollectionsExplorer.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsExplorer.vue
@@ -7,10 +7,13 @@
     LaboratoryDataTag,
     LaboratoryRunUsageSummary,
   } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/data-collections';
+  import { formatFileSize } from '@FE/utils/file-size';
 
   const props = defineProps<{
     /** Used to deep-link from the analysis history tooltip to a laboratory run detail page. */
     labId: string;
+    /** When set, path tooltips use `s3://bucket/key` instead of the raw key only. */
+    s3Bucket?: string;
     labRoot: string;
     visibleFiles: { Key: string; Size?: number; LastModified?: string }[];
     keyToTagIds: Record<string, string[]>;
@@ -46,6 +49,8 @@
     selectAllDisplayed: [];
     clearSelection: [];
     clearFilter: [chipId: string];
+    /** Fired when a file-card drag ends (including cancel) so parents can clear drop-target UI. */
+    fileKeysDragEnd: [];
     removeTagFromFile: [payload: { key: string; tagId: string }];
     /** Tooltip emits this when the user clicks the check button on a run row. */
     selectRunFiles: [payload: { runId: string; inputFileKeys: string[] }];
@@ -97,6 +102,13 @@
   function fileName(key: string): string {
     const parts = key.split('/').filter(Boolean);
     return parts[parts.length - 1] || key;
+  }
+
+  /** Full object location for hover tooltips (truncated paths in the grid). */
+  function s3ObjectTooltip(key: string): string {
+    const b = props.s3Bucket?.trim();
+    if (b) return `s3://${b}/${key}`;
+    return key;
   }
 
   /** Folder path under the lab root (for flat recursive listings). */
@@ -157,6 +169,18 @@
 
   const BATCH_HEADER_DOT_NOT_ANALYZED = '#EF9F27';
   const BATCH_HEADER_DOT_ANALYZED = '#2DB48F';
+
+  /**
+   * Nuxt UI v2 tooltip theme defaults: `max-w-xs`, fixed `h-6`, and `truncate` on the content box
+   * (see `node_modules/@nuxt/ui/dist/runtime/ui.config/overlays/tooltip.js`). That clips long S3
+   * URIs; widen the popper and allow wrapped multi-line text with vertical scroll if needed.
+   */
+  const s3PathTooltipUi = {
+    /** Default `inline-flex` keeps min-content width — long filenames overflow the card grid cell. */
+    wrapper: 'relative block w-full min-w-0 max-w-full',
+    width: 'max-w-[min(92vw,52rem)]',
+    base: '[@media(pointer:coarse)]:hidden min-h-0 h-auto max-h-[min(80vh,32rem)] overflow-y-auto overflow-x-hidden px-2.5 py-2 text-xs font-normal whitespace-normal break-all text-left relative',
+  };
 
   function batchSectionHeaderParts(sec: {
     batchId: string | null;
@@ -316,6 +340,10 @@
     e.dataTransfer?.setData('text/plain', 'keys');
   }
 
+  function onFileCardDragEnd(): void {
+    emit('fileKeysDragEnd');
+  }
+
   function onPillDragStart(e: DragEvent, tagId: string, key: string): void {
     e.stopPropagation();
     dragTagId = tagId;
@@ -344,7 +372,7 @@
 </script>
 
 <template>
-  <div class="flex min-w-0 flex-1 flex-col">
+  <div class="flex min-h-0 min-w-0 flex-1 flex-col">
     <div class="border-border-muted flex flex-wrap items-center gap-3 border-b px-4 py-3">
       <UInput
         :model-value="search"
@@ -417,7 +445,7 @@
       listing limit.
     </div>
 
-    <div ref="scrollEl" class="relative flex-1 overflow-auto p-2" @mousedown="onScrollHostMouseDown">
+    <div ref="scrollEl" class="relative min-h-0 flex-1 overflow-auto p-2" @mousedown="onScrollHostMouseDown">
       <div
         v-if="loading"
         class="absolute inset-0 z-20 flex min-h-[14rem] flex-col items-center justify-center gap-3 bg-white/90 p-6 backdrop-blur-[1px]"
@@ -475,13 +503,14 @@
             data-file-card
             :data-key="f.Key"
             draggable="true"
-            class="border-border-muted relative cursor-pointer rounded-xl border bg-white p-3 shadow-sm transition"
+            class="border-border-muted relative min-w-0 cursor-pointer rounded-xl border bg-white p-3 shadow-sm transition"
             :class="{
               'bg-primary-muted ring-primary ring-2': selectedKeys.includes(f.Key),
               'z-[80]': analysisPopoverOpenKey === f.Key,
             }"
             @click="emit('toggleKey', f.Key)"
             @dragstart="onCardDragStart($event, f.Key)"
+            @dragend="onFileCardDragEnd"
             @dragover="onCardDragOver"
             @dragleave="onCardDragLeave"
             @drop="onCardDrop($event)"
@@ -502,11 +531,20 @@
                 @update:open="onAnalysisPopoverOpen(f.Key, $event)"
               />
             </div>
-            <div class="mt-7 pr-8 text-sm font-medium leading-snug">{{ fileName(f.Key) }}</div>
-            <div v-if="folderPathUnderLab(f.Key)" class="text-muted mt-0.5 truncate text-[11px]">
-              {{ folderPathUnderLab(f.Key) }}
-            </div>
-            <div class="text-muted mt-1 text-xs">{{ f.Size != null ? `${f.Size} bytes` : '' }}</div>
+            <UTooltip :open-delay="500" :ui="s3PathTooltipUi">
+              <template #text>
+                {{ s3ObjectTooltip(f.Key) }}
+              </template>
+              <div class="w-full min-w-0 pr-8">
+                <div class="mt-7 line-clamp-2 w-full min-w-0 break-all text-sm font-medium leading-snug">
+                  {{ fileName(f.Key) }}
+                </div>
+                <div v-if="folderPathUnderLab(f.Key)" class="text-muted mt-0.5 truncate text-[11px]">
+                  {{ folderPathUnderLab(f.Key) }}
+                </div>
+              </div>
+            </UTooltip>
+            <div class="text-muted mt-1 text-xs">{{ formatFileSize(f.Size) }}</div>
             <div class="mt-2 flex min-h-[1.25rem] flex-wrap gap-1">
               <template v-if="standardTagIdsForFileKey(f.Key).length">
                 <span
@@ -601,6 +639,7 @@
                 }"
                 @click="emit('toggleKey', f.Key)"
                 @dragstart="onCardDragStart($event, f.Key)"
+                @dragend="onFileCardDragEnd"
                 @dragover="onCardDragOver"
                 @dragleave="onCardDragLeave"
                 @drop="onCardDrop($event)"
@@ -612,10 +651,17 @@
                   />
                 </td>
                 <td class="max-w-[14rem] px-3 py-2 align-middle">
-                  <div class="font-medium text-gray-900">{{ fileName(f.Key) }}</div>
-                  <div v-if="folderPathUnderLab(f.Key)" class="text-muted truncate text-xs">
-                    {{ folderPathUnderLab(f.Key) }}
-                  </div>
+                  <UTooltip :open-delay="500" :ui="s3PathTooltipUi">
+                    <template #text>
+                      {{ s3ObjectTooltip(f.Key) }}
+                    </template>
+                    <div class="min-w-0">
+                      <div class="font-medium text-gray-900">{{ fileName(f.Key) }}</div>
+                      <div v-if="folderPathUnderLab(f.Key)" class="text-muted truncate text-xs">
+                        {{ folderPathUnderLab(f.Key) }}
+                      </div>
+                    </div>
+                  </UTooltip>
                 </td>
                 <td class="text-muted px-3 py-2 align-middle">{{ batchDisplayName(f.Key) }}</td>
                 <td class="px-3 py-2 align-middle">

--- a/packages/front-end/src/app/components/EGDataCollectionsExplorer.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsExplorer.vue
@@ -7,10 +7,13 @@
     LaboratoryDataTag,
     LaboratoryRunUsageSummary,
   } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/data-collections';
+  import { formatFileSize } from '@FE/utils/file-size';
 
   const props = defineProps<{
     /** Used to deep-link from the analysis history tooltip to a laboratory run detail page. */
     labId: string;
+    /** When set, path tooltips use `s3://bucket/key` instead of the raw key only. */
+    s3Bucket?: string;
     labRoot: string;
     visibleFiles: { Key: string; Size?: number; LastModified?: string }[];
     keyToTagIds: Record<string, string[]>;
@@ -52,6 +55,8 @@
     selectAllDisplayed: [];
     clearSelection: [];
     clearFilter: [chipId: string];
+    /** Fired when a file-card drag ends (including cancel) so parents can clear drop-target UI. */
+    fileKeysDragEnd: [];
     removeTagFromFile: [payload: { key: string; tagId: string }];
     /** Tooltip emits this when the user clicks the check button on a run row. */
     selectRunFiles: [payload: { runId: string; inputFileKeys: string[] }];
@@ -138,6 +143,13 @@
     return months <= 1 ? 'in ~1 month' : `in ~${months} months`;
   }
 
+  /** Full object location for hover tooltips (truncated paths in the grid). */
+  function s3ObjectTooltip(key: string): string {
+    const b = props.s3Bucket?.trim();
+    if (b) return `s3://${b}/${key}`;
+    return key;
+  }
+
   /** Folder path under the lab root (for flat recursive listings). */
   function folderPathUnderLab(key: string): string {
     const root = props.labRoot;
@@ -196,6 +208,18 @@
 
   const BATCH_HEADER_DOT_NOT_ANALYZED = '#EF9F27';
   const BATCH_HEADER_DOT_ANALYZED = '#2DB48F';
+
+  /**
+   * Nuxt UI v2 tooltip theme defaults: `max-w-xs`, fixed `h-6`, and `truncate` on the content box
+   * (see `node_modules/@nuxt/ui/dist/runtime/ui.config/overlays/tooltip.js`). That clips long S3
+   * URIs; widen the popper and allow wrapped multi-line text with vertical scroll if needed.
+   */
+  const s3PathTooltipUi = {
+    /** Default `inline-flex` keeps min-content width — long filenames overflow the card grid cell. */
+    wrapper: 'relative block w-full min-w-0 max-w-full',
+    width: 'max-w-[min(92vw,52rem)]',
+    base: '[@media(pointer:coarse)]:hidden min-h-0 h-auto max-h-[min(80vh,32rem)] overflow-y-auto overflow-x-hidden px-2.5 py-2 text-xs font-normal whitespace-normal break-all text-left relative',
+  };
 
   function batchSectionHeaderParts(sec: {
     batchId: string | null;
@@ -355,6 +379,10 @@
     e.dataTransfer?.setData('text/plain', 'keys');
   }
 
+  function onFileCardDragEnd(): void {
+    emit('fileKeysDragEnd');
+  }
+
   function onPillDragStart(e: DragEvent, tagId: string, key: string): void {
     e.stopPropagation();
     dragTagId = tagId;
@@ -383,7 +411,7 @@
 </script>
 
 <template>
-  <div class="flex min-w-0 flex-1 flex-col">
+  <div class="flex min-h-0 min-w-0 flex-1 flex-col">
     <div class="border-border-muted flex flex-wrap items-center gap-3 border-b px-4 py-3">
       <UInput
         :model-value="search"
@@ -456,7 +484,7 @@
       listing limit.
     </div>
 
-    <div ref="scrollEl" class="relative flex-1 overflow-auto p-2" @mousedown="onScrollHostMouseDown">
+    <div ref="scrollEl" class="relative min-h-0 flex-1 overflow-auto p-2" @mousedown="onScrollHostMouseDown">
       <div
         v-if="loading"
         class="absolute inset-0 z-20 flex min-h-[14rem] flex-col items-center justify-center gap-3 bg-white/90 p-6 backdrop-blur-[1px]"
@@ -514,13 +542,14 @@
             data-file-card
             :data-key="f.Key"
             draggable="true"
-            class="border-border-muted relative cursor-pointer rounded-xl border bg-white p-3 shadow-sm transition"
+            class="border-border-muted relative min-w-0 cursor-pointer rounded-xl border bg-white p-3 shadow-sm transition"
             :class="{
               'bg-primary-muted ring-primary ring-2': selectedKeys.includes(f.Key),
               'z-[80]': analysisPopoverOpenKey === f.Key,
             }"
             @click="emit('toggleKey', f.Key)"
             @dragstart="onCardDragStart($event, f.Key)"
+            @dragend="onFileCardDragEnd"
             @dragover="onCardDragOver"
             @dragleave="onCardDragLeave"
             @drop="onCardDrop($event)"
@@ -548,11 +577,20 @@
                 @update:open="onAnalysisPopoverOpen(f.Key, $event)"
               />
             </div>
-            <div class="mt-7 pr-8 text-sm font-medium leading-snug">{{ fileName(f.Key) }}</div>
-            <div v-if="folderPathUnderLab(f.Key)" class="text-muted mt-0.5 truncate text-[11px]">
-              {{ folderPathUnderLab(f.Key) }}
-            </div>
-            <div class="text-muted mt-1 text-xs">{{ f.Size != null ? `${f.Size} bytes` : '' }}</div>
+            <UTooltip :open-delay="500" :ui="s3PathTooltipUi">
+              <template #text>
+                {{ s3ObjectTooltip(f.Key) }}
+              </template>
+              <div class="w-full min-w-0 pr-8">
+                <div class="mt-7 line-clamp-2 w-full min-w-0 break-all text-sm font-medium leading-snug">
+                  {{ fileName(f.Key) }}
+                </div>
+                <div v-if="folderPathUnderLab(f.Key)" class="text-muted mt-0.5 truncate text-[11px]">
+                  {{ folderPathUnderLab(f.Key) }}
+                </div>
+              </div>
+            </UTooltip>
+            <div class="text-muted mt-1 text-xs">{{ formatFileSize(f.Size) }}</div>
             <div class="mt-2 flex min-h-[1.25rem] flex-wrap gap-1">
               <template v-if="standardTagIdsForFileKey(f.Key).length">
                 <span
@@ -647,6 +685,7 @@
                 }"
                 @click="emit('toggleKey', f.Key)"
                 @dragstart="onCardDragStart($event, f.Key)"
+                @dragend="onFileCardDragEnd"
                 @dragover="onCardDragOver"
                 @dragleave="onCardDragLeave"
                 @drop="onCardDrop($event)"
@@ -658,19 +697,26 @@
                   />
                 </td>
                 <td class="max-w-[14rem] px-3 py-2 align-middle">
-                  <div class="flex items-center gap-1.5">
-                    <UIcon
-                      v-if="isFilePermanent(f.Key)"
-                      name="i-heroicons-lock-closed"
-                      class="h-3.5 w-3.5 shrink-0 text-red-600"
-                      title="This file is protected from auto-deletion when run retention expires."
-                      aria-label="Protected from auto-deletion"
-                    />
-                    <span class="truncate font-medium text-gray-900">{{ fileName(f.Key) }}</span>
-                  </div>
-                  <div v-if="folderPathUnderLab(f.Key)" class="text-muted truncate text-xs">
-                    {{ folderPathUnderLab(f.Key) }}
-                  </div>
+                  <UTooltip :open-delay="500" :ui="s3PathTooltipUi">
+                    <template #text>
+                      {{ s3ObjectTooltip(f.Key) }}
+                    </template>
+                    <div class="min-w-0">
+                      <div class="flex items-center gap-1.5">
+                        <UIcon
+                          v-if="isFilePermanent(f.Key)"
+                          name="i-heroicons-lock-closed"
+                          class="h-3.5 w-3.5 shrink-0 text-red-600"
+                          title="This file is protected from auto-deletion when run retention expires."
+                          aria-label="Protected from auto-deletion"
+                        />
+                        <span class="truncate font-medium text-gray-900">{{ fileName(f.Key) }}</span>
+                      </div>
+                      <div v-if="folderPathUnderLab(f.Key)" class="text-muted truncate text-xs">
+                        {{ folderPathUnderLab(f.Key) }}
+                      </div>
+                    </div>
+                  </UTooltip>
                 </td>
                 <td class="text-muted px-3 py-2 align-middle">{{ batchDisplayName(f.Key) }}</td>
                 <td class="px-3 py-2 align-middle">

--- a/packages/front-end/src/app/components/EGDataCollectionsExplorer.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsExplorer.vue
@@ -51,7 +51,6 @@
     clearFilter: [chipId: string];
     /** Fired when a file-card drag ends (including cancel) so parents can clear drop-target UI. */
     fileKeysDragEnd: [];
-    removeTagFromFile: [payload: { key: string; tagId: string }];
     /** Tooltip emits this when the user clicks the check button on a run row. */
     selectRunFiles: [payload: { runId: string; inputFileKeys: string[] }];
   }>();
@@ -72,8 +71,6 @@
   });
   let lx0 = 0;
   let ly0 = 0;
-  let dragTagId: string | null = null;
-  let dragSourceKey: string | null = null;
 
   /** While a file’s analysis popover is open, that card/row is stacked above siblings so other files’ dots do not show through the panel. */
   const analysisPopoverOpenKey = ref<string | null>(null);
@@ -333,8 +330,6 @@
   });
 
   function onCardDragStart(e: DragEvent, key: string): void {
-    dragTagId = null;
-    dragSourceKey = null;
     const keys = props.selectedKeys.includes(key) ? [...props.selectedKeys] : [key];
     e.dataTransfer?.setData('application/x-eg-keys', JSON.stringify(keys));
     e.dataTransfer?.setData('text/plain', 'keys');
@@ -342,32 +337,6 @@
 
   function onFileCardDragEnd(): void {
     emit('fileKeysDragEnd');
-  }
-
-  function onPillDragStart(e: DragEvent, tagId: string, key: string): void {
-    e.stopPropagation();
-    dragTagId = tagId;
-    dragSourceKey = key;
-    e.dataTransfer?.setData('text/plain', 'tag');
-  }
-
-  function onCardDragOver(e: DragEvent): void {
-    if (!dragTagId) return;
-    e.preventDefault();
-    (e.currentTarget as HTMLElement).classList.add('outline', 'outline-2', 'outline-red-400');
-  }
-
-  function onCardDragLeave(e: DragEvent): void {
-    (e.currentTarget as HTMLElement).classList.remove('outline', 'outline-2', 'outline-red-400');
-  }
-
-  function onCardDrop(e: DragEvent): void {
-    (e.currentTarget as HTMLElement).classList.remove('outline', 'outline-2', 'outline-red-400');
-    if (!dragTagId || !dragSourceKey) return;
-    e.preventDefault();
-    emit('removeTagFromFile', { key: dragSourceKey, tagId: dragTagId });
-    dragTagId = null;
-    dragSourceKey = null;
   }
 </script>
 
@@ -511,9 +480,6 @@
             @click="emit('toggleKey', f.Key)"
             @dragstart="onCardDragStart($event, f.Key)"
             @dragend="onFileCardDragEnd"
-            @dragover="onCardDragOver"
-            @dragleave="onCardDragLeave"
-            @drop="onCardDrop($event)"
           >
             <div class="absolute right-2 top-2" @mousedown.stop @click.stop>
               <UCheckbox :model-value="selectedKeys.includes(f.Key)" @update:model-value="emit('toggleKey', f.Key)" />
@@ -550,13 +516,11 @@
                 <span
                   v-for="tid in standardTagIdsForFileKey(f.Key)"
                   :key="tid"
-                  class="inline-flex cursor-grab items-center rounded-full px-2 py-0.5 text-[10px] font-medium"
-                  draggable="true"
+                  class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium"
                   :style="{
                     background: tagById(tid)?.ColorHex || '#e2e2e8',
                     color: pillTextColor(tagById(tid)?.ColorHex || '#e2e2e8'),
                   }"
-                  @dragstart="onPillDragStart($event, tid, f.Key)"
                   @click.stop
                 >
                   {{ tagById(tid)?.Name || tid }}
@@ -573,7 +537,9 @@
           <thead>
             <tr class="border-border-muted bg-gray-50/90 text-xs uppercase tracking-wide text-gray-600">
               <th class="border-border-muted w-10 border-b px-3 py-2.5" scope="col" />
-              <th class="border-border-muted border-b px-3 py-2.5 font-semibold" scope="col">Sample ID</th>
+              <th class="border-border-muted min-w-0 max-w-[14rem] border-b px-3 py-2.5 font-semibold" scope="col">
+                Sample ID
+              </th>
               <th class="border-border-muted border-b px-3 py-2.5 font-semibold" scope="col">Batch</th>
               <th class="border-border-muted border-b px-3 py-2.5 font-semibold" scope="col">Status</th>
               <th class="border-border-muted border-b px-3 py-2.5 font-semibold" scope="col">Tags</th>
@@ -640,9 +606,6 @@
                 @click="emit('toggleKey', f.Key)"
                 @dragstart="onCardDragStart($event, f.Key)"
                 @dragend="onFileCardDragEnd"
-                @dragover="onCardDragOver"
-                @dragleave="onCardDragLeave"
-                @drop="onCardDrop($event)"
               >
                 <td class="px-3 py-2 align-middle" @mousedown.stop @click.stop>
                   <UCheckbox
@@ -650,13 +613,13 @@
                     @update:model-value="emit('toggleKey', f.Key)"
                   />
                 </td>
-                <td class="max-w-[14rem] px-3 py-2 align-middle">
+                <td class="min-w-0 max-w-[14rem] overflow-hidden px-3 py-2 align-middle">
                   <UTooltip :open-delay="500" :ui="s3PathTooltipUi">
                     <template #text>
                       {{ s3ObjectTooltip(f.Key) }}
                     </template>
                     <div class="min-w-0">
-                      <div class="font-medium text-gray-900">{{ fileName(f.Key) }}</div>
+                      <div class="truncate font-medium text-gray-900">{{ fileName(f.Key) }}</div>
                       <div v-if="folderPathUnderLab(f.Key)" class="text-muted truncate text-xs">
                         {{ folderPathUnderLab(f.Key) }}
                       </div>
@@ -685,13 +648,11 @@
                       <span
                         v-for="tid in standardTagIdsForFileKey(f.Key)"
                         :key="tid"
-                        class="inline-flex cursor-grab items-center rounded-full px-2 py-0.5 text-[10px] font-medium"
-                        draggable="true"
+                        class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium"
                         :style="{
                           background: tagById(tid)?.ColorHex || '#e2e2e8',
                           color: pillTextColor(tagById(tid)?.ColorHex || '#e2e2e8'),
                         }"
-                        @dragstart="onPillDragStart($event, tid, f.Key)"
                         @click.stop
                       >
                         {{ tagById(tid)?.Name || tid }}

--- a/packages/front-end/src/app/components/EGDataCollectionsExplorer.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsExplorer.vue
@@ -57,7 +57,6 @@
     clearFilter: [chipId: string];
     /** Fired when a file-card drag ends (including cancel) so parents can clear drop-target UI. */
     fileKeysDragEnd: [];
-    removeTagFromFile: [payload: { key: string; tagId: string }];
     /** Tooltip emits this when the user clicks the check button on a run row. */
     selectRunFiles: [payload: { runId: string; inputFileKeys: string[] }];
   }>();
@@ -78,8 +77,6 @@
   });
   let lx0 = 0;
   let ly0 = 0;
-  let dragTagId: string | null = null;
-  let dragSourceKey: string | null = null;
 
   /** While a file’s analysis popover is open, that card/row is stacked above siblings so other files’ dots do not show through the panel. */
   const analysisPopoverOpenKey = ref<string | null>(null);
@@ -372,8 +369,6 @@
   });
 
   function onCardDragStart(e: DragEvent, key: string): void {
-    dragTagId = null;
-    dragSourceKey = null;
     const keys = props.selectedKeys.includes(key) ? [...props.selectedKeys] : [key];
     e.dataTransfer?.setData('application/x-eg-keys', JSON.stringify(keys));
     e.dataTransfer?.setData('text/plain', 'keys');
@@ -381,32 +376,6 @@
 
   function onFileCardDragEnd(): void {
     emit('fileKeysDragEnd');
-  }
-
-  function onPillDragStart(e: DragEvent, tagId: string, key: string): void {
-    e.stopPropagation();
-    dragTagId = tagId;
-    dragSourceKey = key;
-    e.dataTransfer?.setData('text/plain', 'tag');
-  }
-
-  function onCardDragOver(e: DragEvent): void {
-    if (!dragTagId) return;
-    e.preventDefault();
-    (e.currentTarget as HTMLElement).classList.add('outline', 'outline-2', 'outline-red-400');
-  }
-
-  function onCardDragLeave(e: DragEvent): void {
-    (e.currentTarget as HTMLElement).classList.remove('outline', 'outline-2', 'outline-red-400');
-  }
-
-  function onCardDrop(e: DragEvent): void {
-    (e.currentTarget as HTMLElement).classList.remove('outline', 'outline-2', 'outline-red-400');
-    if (!dragTagId || !dragSourceKey) return;
-    e.preventDefault();
-    emit('removeTagFromFile', { key: dragSourceKey, tagId: dragTagId });
-    dragTagId = null;
-    dragSourceKey = null;
   }
 </script>
 
@@ -550,9 +519,6 @@
             @click="emit('toggleKey', f.Key)"
             @dragstart="onCardDragStart($event, f.Key)"
             @dragend="onFileCardDragEnd"
-            @dragover="onCardDragOver"
-            @dragleave="onCardDragLeave"
-            @drop="onCardDrop($event)"
           >
             <div class="absolute right-2 top-2 flex items-center gap-1.5" @mousedown.stop @click.stop>
               <UIcon
@@ -596,13 +562,11 @@
                 <span
                   v-for="tid in standardTagIdsForFileKey(f.Key)"
                   :key="tid"
-                  class="inline-flex cursor-grab items-center rounded-full px-2 py-0.5 text-[10px] font-medium"
-                  draggable="true"
+                  class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium"
                   :style="{
                     background: tagById(tid)?.ColorHex || '#e2e2e8',
                     color: pillTextColor(tagById(tid)?.ColorHex || '#e2e2e8'),
                   }"
-                  @dragstart="onPillDragStart($event, tid, f.Key)"
                   @click.stop
                 >
                   {{ tagById(tid)?.Name || tid }}
@@ -619,7 +583,9 @@
           <thead>
             <tr class="border-border-muted bg-gray-50/90 text-xs uppercase tracking-wide text-gray-600">
               <th class="border-border-muted w-10 border-b px-3 py-2.5" scope="col" />
-              <th class="border-border-muted border-b px-3 py-2.5 font-semibold" scope="col">Sample ID</th>
+              <th class="border-border-muted min-w-0 max-w-[14rem] border-b px-3 py-2.5 font-semibold" scope="col">
+                Sample ID
+              </th>
               <th class="border-border-muted border-b px-3 py-2.5 font-semibold" scope="col">Batch</th>
               <th class="border-border-muted border-b px-3 py-2.5 font-semibold" scope="col">Status</th>
               <th class="border-border-muted border-b px-3 py-2.5 font-semibold" scope="col">Tags</th>
@@ -686,9 +652,6 @@
                 @click="emit('toggleKey', f.Key)"
                 @dragstart="onCardDragStart($event, f.Key)"
                 @dragend="onFileCardDragEnd"
-                @dragover="onCardDragOver"
-                @dragleave="onCardDragLeave"
-                @drop="onCardDrop($event)"
               >
                 <td class="px-3 py-2 align-middle" @mousedown.stop @click.stop>
                   <UCheckbox
@@ -696,13 +659,13 @@
                     @update:model-value="emit('toggleKey', f.Key)"
                   />
                 </td>
-                <td class="max-w-[14rem] px-3 py-2 align-middle">
+                <td class="min-w-0 max-w-[14rem] overflow-hidden px-3 py-2 align-middle">
                   <UTooltip :open-delay="500" :ui="s3PathTooltipUi">
                     <template #text>
                       {{ s3ObjectTooltip(f.Key) }}
                     </template>
                     <div class="min-w-0">
-                      <div class="flex items-center gap-1.5">
+                      <div class="flex min-w-0 items-center gap-1.5">
                         <UIcon
                           v-if="isFilePermanent(f.Key)"
                           name="i-heroicons-lock-closed"
@@ -740,13 +703,11 @@
                       <span
                         v-for="tid in standardTagIdsForFileKey(f.Key)"
                         :key="tid"
-                        class="inline-flex cursor-grab items-center rounded-full px-2 py-0.5 text-[10px] font-medium"
-                        draggable="true"
+                        class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium"
                         :style="{
                           background: tagById(tid)?.ColorHex || '#e2e2e8',
                           color: pillTextColor(tagById(tid)?.ColorHex || '#e2e2e8'),
                         }"
-                        @dragstart="onPillDragStart($event, tid, f.Key)"
                         @click.stop
                       >
                         {{ tagById(tid)?.Name || tid }}

--- a/packages/front-end/src/app/components/EGDataCollectionsPage.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsPage.vue
@@ -469,6 +469,11 @@
     return out;
   });
 
+  /** Files with no standard tags, among search results (same universe as tag filter chips). */
+  const untaggedChipCount = computed(
+    () => filesMatchingSearch.value.filter((f) => !standardTagIdsForFileKey(f.Key).length).length,
+  );
+
   /** Explorer dismiss chips — ids must stay in sync with `clearExplorerFilter`. */
   const CHIP_SCOPE_NOT_ANALYZED = 'chip-scope-not-analyzed';
   const CHIP_TAG_UNTAGGED = 'chip-tag-untagged';
@@ -707,9 +712,14 @@
 
   async function applyTagToKeys(tagId: string, keys: string[]): Promise<void> {
     if (!lab.value?.S3Bucket || !keys.length) return;
+    const keysToTag = keys.filter((k) => !(keyToTagIds.value[k] ?? []).includes(tagId));
+    if (!keysToTag.length) {
+      toast.info(keys.length === 1 ? 'Tag already applied to that sample.' : 'Tag already applied to those samples.');
+      return;
+    }
     uiStore.setRequestPending('dataCollectionsMutate');
     try {
-      await addTagsToFilesInChunks(keys, [tagId], []);
+      await addTagsToFilesInChunks(keysToTag, [tagId], []);
       selectedKeys.value = [];
       await loadTags();
       await loadListing();
@@ -745,13 +755,33 @@
     }
   }
 
-  function onCardDragOverTag(e: DragEvent): void {
-    if (e.dataTransfer?.types.includes('application/x-eg-keys')) {
-      e.preventDefault();
-    }
+  /** While dragging files from the explorer onto a tag row, that tag id is highlighted. */
+  const tagDropHighlightId = ref<string | null>(null);
+
+  function dataTransferHasFileKeys(dt: DataTransfer | null): boolean {
+    if (!dt) return false;
+    return [...dt.types].includes('application/x-eg-keys');
+  }
+
+  function onTagRowDragOver(e: DragEvent, tagId: string): void {
+    if (!dataTransferHasFileKeys(e.dataTransfer)) return;
+    e.preventDefault();
+    tagDropHighlightId.value = tagId;
+  }
+
+  function onTagRowDragLeave(e: DragEvent, tagId: string): void {
+    const cur = e.currentTarget as HTMLElement;
+    const rel = e.relatedTarget as Node | null;
+    if (rel && cur.contains(rel)) return;
+    if (tagDropHighlightId.value === tagId) tagDropHighlightId.value = null;
+  }
+
+  function clearTagDropHighlight(): void {
+    tagDropHighlightId.value = null;
   }
 
   function onTagRowDrop(e: DragEvent, tagId: string): void {
+    clearTagDropHighlight();
     e.preventDefault();
     const raw = e.dataTransfer?.getData('application/x-eg-keys');
     if (!raw) return;
@@ -852,264 +882,284 @@
   <div v-if="!lab?.S3Bucket" class="text-muted rounded-lg border border-dashed p-8 text-center text-sm">
     This lab has no S3 bucket configured. Set a bucket in Lab Settings to use Data Collections.
   </div>
-  <div
-    v-else
-    class="flex min-h-[480px] min-w-0 flex-col gap-0 overflow-hidden rounded-xl border border-gray-200 bg-white"
-  >
-    <div class="flex min-h-0 min-w-0 flex-1 overflow-hidden">
-      <div class="border-border-muted flex w-[280px] shrink-0 flex-col overflow-y-auto border-r bg-gray-50">
-        <div class="border-border-muted border-b p-2">
-          <button
-            type="button"
-            class="hover:bg-primary-muted flex w-full items-center justify-between gap-2 rounded-lg px-2 py-2 text-left text-sm"
-            :class="{ 'bg-primary-muted font-medium': isScopeAllActive() }"
-            @click="onAllSamplesScopeClick"
-          >
-            <span>All samples</span>
-            <UBadge
-              size="xs"
-              class="bg-primary-muted text-primary-dark shrink-0 rounded-xl border-0 font-serif tabular-nums ring-0"
-            >
-              {{ allSamplesChipCount }}
-            </UBadge>
-          </button>
-          <button
-            type="button"
-            class="hover:bg-primary-muted flex w-full items-center justify-between gap-2 rounded-lg px-2 py-2 text-left text-sm"
-            :class="{ 'bg-primary-muted font-medium': isNotAnalyzedScopeActive() }"
-            @click="onNotYetAnalyzedScopeClick"
-          >
-            <span>Not yet analyzed</span>
-            <UBadge
-              size="xs"
-              class="bg-primary-muted text-primary-dark shrink-0 rounded-xl border-0 font-serif tabular-nums ring-0"
-            >
-              {{ notAnalyzedChipCount }}
-            </UBadge>
-          </button>
-        </div>
-
-        <div class="border-border-muted border-b p-2">
-          <button
-            type="button"
-            class="text-muted hover:bg-primary-muted mb-1 flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left text-xs font-medium uppercase tracking-wide"
-            :aria-expanded="workflowsSectionExpanded"
-            @click="workflowsSectionExpanded = !workflowsSectionExpanded"
-          >
-            <UIcon
-              :name="workflowsSectionExpanded ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'"
-              class="h-4 w-4 shrink-0"
-              aria-hidden="true"
-            />
-            <span>Workflows</span>
-          </button>
-          <div v-show="workflowsSectionExpanded">
-            <p v-if="!workflowTemplates.length" class="text-muted mt-2 px-2 text-xs italic">
-              No workflows have been run on these files yet.
-            </p>
-
-            <div v-for="tmpl in visibleWorkflowTemplates" :key="tmpl.key" class="mt-1">
-              <div
-                class="hover:bg-primary-muted flex w-full cursor-pointer items-center gap-1 rounded-lg pr-2 text-left text-sm"
-                :class="{
-                  'bg-primary-muted font-medium': isWorkflowTemplateScopeActive(tmpl.key),
-                }"
+  <div v-else class="flex min-w-0 flex-col gap-0">
+    <div class="overflow-hidden rounded-xl border border-gray-200 bg-white">
+      <div class="flex h-[calc(100dvh-12rem)] min-h-0 flex-col overflow-hidden">
+        <div class="flex min-h-0 min-w-0 flex-1 overflow-hidden">
+          <div class="border-border-muted flex w-[280px] shrink-0 flex-col overflow-y-auto border-r bg-gray-50">
+            <div class="border-border-muted border-b p-2">
+              <button
+                type="button"
+                class="hover:bg-primary-muted flex w-full items-center justify-between gap-2 rounded-lg px-2 py-2 text-left text-sm"
+                :class="{ 'bg-primary-muted font-medium': isScopeAllActive() }"
+                @click="onAllSamplesScopeClick"
               >
-                <button
-                  v-if="tmpl.versions.length > 1"
-                  type="button"
-                  class="text-muted hover:text-primary flex h-7 w-7 shrink-0 items-center justify-center rounded"
-                  :aria-label="expandedWorkflowTemplates[tmpl.key] ? 'Collapse versions' : 'Expand versions'"
-                  @click.stop="toggleWorkflowTemplate(tmpl.key)"
+                <span>All samples</span>
+                <UBadge
+                  size="xs"
+                  class="bg-primary-muted text-primary-dark shrink-0 rounded-xl border-0 font-serif tabular-nums ring-0"
                 >
-                  <UIcon
-                    :name="
-                      expandedWorkflowTemplates[tmpl.key] ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'
-                    "
-                    class="h-4 w-4"
-                  />
-                </button>
-                <span v-else class="block h-7 w-7 shrink-0" />
-                <button
-                  type="button"
-                  class="flex min-w-0 flex-1 items-center justify-between gap-2 py-2 text-left"
-                  @click="onWorkflowTemplateScopeClick(tmpl.key)"
+                  {{ allSamplesChipCount }}
+                </UBadge>
+              </button>
+              <button
+                type="button"
+                class="hover:bg-primary-muted flex w-full items-center justify-between gap-2 rounded-lg px-2 py-2 text-left text-sm"
+                :class="{ 'bg-primary-muted font-medium': isNotAnalyzedScopeActive() }"
+                @click="onNotYetAnalyzedScopeClick"
+              >
+                <span>Not yet analyzed</span>
+                <UBadge
+                  size="xs"
+                  class="bg-primary-muted text-primary-dark shrink-0 rounded-xl border-0 font-serif tabular-nums ring-0"
                 >
-                  <span class="flex min-w-0 items-center gap-2">
-                    <span class="inline-block h-2.5 w-2.5 shrink-0 rounded-full" :style="{ background: tmpl.color }" />
-                    <span class="truncate">{{ tmpl.name }}</span>
-                  </span>
-                  <span class="text-muted shrink-0 text-xs">{{ tmpl.fileCount }}</span>
-                </button>
-              </div>
+                  {{ notAnalyzedChipCount }}
+                </UBadge>
+              </button>
+            </div>
 
-              <div v-if="expandedWorkflowTemplates[tmpl.key] && tmpl.versions.length > 1" class="ml-7 mt-0.5">
+            <div class="border-border-muted border-b p-2">
+              <button
+                type="button"
+                class="text-muted hover:bg-primary-muted mb-1 flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left text-xs font-medium uppercase tracking-wide"
+                :aria-expanded="workflowsSectionExpanded"
+                @click="workflowsSectionExpanded = !workflowsSectionExpanded"
+              >
+                <UIcon
+                  :name="workflowsSectionExpanded ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'"
+                  class="h-4 w-4 shrink-0"
+                  aria-hidden="true"
+                />
+                <span>Workflows</span>
+              </button>
+              <div v-show="workflowsSectionExpanded">
+                <p v-if="!workflowTemplates.length" class="text-muted mt-2 px-2 text-xs italic">
+                  No workflows have been run on these files yet.
+                </p>
+
+                <div v-for="tmpl in visibleWorkflowTemplates" :key="tmpl.key" class="mt-1">
+                  <div
+                    class="hover:bg-primary-muted flex w-full cursor-pointer items-center gap-1 rounded-lg pr-2 text-left text-sm"
+                    :class="{
+                      'bg-primary-muted font-medium': isWorkflowTemplateScopeActive(tmpl.key),
+                    }"
+                  >
+                    <button
+                      v-if="tmpl.versions.length > 1"
+                      type="button"
+                      class="text-muted hover:text-primary flex h-7 w-7 shrink-0 items-center justify-center rounded"
+                      :aria-label="expandedWorkflowTemplates[tmpl.key] ? 'Collapse versions' : 'Expand versions'"
+                      @click.stop="toggleWorkflowTemplate(tmpl.key)"
+                    >
+                      <UIcon
+                        :name="
+                          expandedWorkflowTemplates[tmpl.key] ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'
+                        "
+                        class="h-4 w-4"
+                      />
+                    </button>
+                    <span v-else class="block h-7 w-7 shrink-0" />
+                    <button
+                      type="button"
+                      class="flex min-w-0 flex-1 items-center justify-between gap-2 py-2 text-left"
+                      @click="onWorkflowTemplateScopeClick(tmpl.key)"
+                    >
+                      <span class="flex min-w-0 items-center gap-2">
+                        <span
+                          class="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
+                          :style="{ background: tmpl.color }"
+                        />
+                        <span class="truncate">{{ tmpl.name }}</span>
+                      </span>
+                      <span class="text-muted shrink-0 text-xs">{{ tmpl.fileCount }}</span>
+                    </button>
+                  </div>
+
+                  <div v-if="expandedWorkflowTemplates[tmpl.key] && tmpl.versions.length > 1" class="ml-7 mt-0.5">
+                    <button
+                      v-for="v in tmpl.versions"
+                      :key="v.tag.TagId"
+                      type="button"
+                      class="hover:bg-primary-muted flex w-full items-center justify-between gap-2 rounded-lg px-2 py-1.5 text-left text-xs"
+                      :class="{
+                        'bg-primary-muted font-medium': isWorkflowVersionScopeActive(v.tag.TagId),
+                      }"
+                      @click="onWorkflowVersionScopeClick(v.tag.TagId)"
+                    >
+                      <span class="text-muted truncate">{{ v.label }}</span>
+                      <span class="text-muted shrink-0 tabular-nums">{{ v.tag.FileCount }}</span>
+                    </button>
+                  </div>
+                </div>
+
                 <button
-                  v-for="v in tmpl.versions"
-                  :key="v.tag.TagId"
+                  v-if="workflowTemplates.length > visibleWorkflowTemplates.length || showAllWorkflowTemplates"
+                  v-show="workflowTemplates.length > 6"
                   type="button"
-                  class="hover:bg-primary-muted flex w-full items-center justify-between gap-2 rounded-lg px-2 py-1.5 text-left text-xs"
-                  :class="{
-                    'bg-primary-muted font-medium': isWorkflowVersionScopeActive(v.tag.TagId),
-                  }"
-                  @click="onWorkflowVersionScopeClick(v.tag.TagId)"
+                  class="text-primary mt-2 px-2 text-xs font-medium hover:underline"
+                  @click="showAllWorkflowTemplates = !showAllWorkflowTemplates"
                 >
-                  <span class="text-muted truncate">{{ v.label }}</span>
-                  <span class="text-muted shrink-0 tabular-nums">{{ v.tag.FileCount }}</span>
+                  {{
+                    showAllWorkflowTemplates
+                      ? 'Show fewer'
+                      : `Show ${workflowTemplates.length - visibleWorkflowTemplates.length} more`
+                  }}
                 </button>
               </div>
             </div>
 
-            <button
-              v-if="workflowTemplates.length > visibleWorkflowTemplates.length || showAllWorkflowTemplates"
-              v-show="workflowTemplates.length > 6"
-              type="button"
-              class="text-primary mt-2 px-2 text-xs font-medium hover:underline"
-              @click="showAllWorkflowTemplates = !showAllWorkflowTemplates"
-            >
-              {{
-                showAllWorkflowTemplates
-                  ? 'Show fewer'
-                  : `Show ${workflowTemplates.length - visibleWorkflowTemplates.length} more`
-              }}
-            </button>
-          </div>
-        </div>
-
-        <div class="p-2">
-          <button
-            type="button"
-            class="text-muted hover:bg-primary-muted mb-1 flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left text-xs font-medium uppercase tracking-wide"
-            :aria-expanded="tagsSectionExpanded"
-            @click="tagsSectionExpanded = !tagsSectionExpanded"
-          >
-            <UIcon
-              :name="tagsSectionExpanded ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'"
-              class="h-4 w-4 shrink-0"
-              aria-hidden="true"
-            />
-            <span>Tags</span>
-          </button>
-          <div v-show="tagsSectionExpanded">
-            <button
-              type="button"
-              class="hover:bg-primary-muted flex w-full items-center justify-between rounded-lg px-2 py-2 text-left text-sm"
-              :class="{ 'bg-primary-muted font-medium': isUntaggedTagFilterActive() }"
-              @click="onUntaggedTagFilterClick"
-            >
-              <span>Untagged</span>
-            </button>
-            <button
-              v-for="t in standardTags"
-              :key="t.TagId"
-              class="hover:bg-primary-muted flex w-full cursor-pointer items-center justify-between gap-2 rounded-lg px-2 py-2 text-left text-sm"
-              :class="{ 'bg-primary-muted font-medium': isStandardTagFilterActive(t.TagId) }"
-              @click="onStandardTagFilterClick(t.TagId)"
-              @dragover.prevent="onCardDragOverTag"
-              @drop="onTagRowDrop($event, t.TagId)"
-            >
-              <span class="flex min-w-0 items-center gap-2">
-                <span class="inline-block h-2.5 w-2.5 shrink-0 rounded-full" :style="{ background: t.ColorHex }" />
-                <span class="truncate">{{ t.Name }}</span>
-              </span>
-              <UBadge
-                size="xs"
-                class="bg-primary-muted text-primary-dark shrink-0 rounded-xl border-0 font-serif tabular-nums ring-0"
-              >
-                {{ standardTagIdToChipCount[t.TagId] ?? 0 }}
-              </UBadge>
-            </button>
-
-            <div class="border-border-muted mt-2 border-t pt-2">
+            <div class="p-2">
               <button
-                v-if="!showLeftRailCreateTag"
                 type="button"
-                class="text-primary hover:text-primary-dark px-2 py-1.5 text-left text-xs font-medium hover:underline"
-                @click="showLeftRailCreateTag = true"
+                class="text-muted hover:bg-primary-muted mb-1 flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left text-xs font-medium uppercase tracking-wide"
+                :aria-expanded="tagsSectionExpanded"
+                @click="tagsSectionExpanded = !tagsSectionExpanded"
               >
-                + New Tag
+                <UIcon
+                  :name="tagsSectionExpanded ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'"
+                  class="h-4 w-4 shrink-0"
+                  aria-hidden="true"
+                />
+                <span>Tags</span>
               </button>
-              <div v-else class="rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
-                <div class="text-muted mb-2 text-xs font-semibold uppercase tracking-wide">Create Tag</div>
-                <div class="space-y-2">
-                  <div>
-                    <label class="text-muted mb-0.5 block text-xs font-medium">Tag name</label>
-                    <UInput v-model="leftRailNewTagName" placeholder="Tag name" size="sm" />
-                  </div>
-                  <div>
-                    <label class="text-muted mb-0.5 block text-xs font-medium">Tag color</label>
-                    <div class="flex flex-wrap gap-1">
-                      <button
-                        v-for="c in presetColors"
-                        :key="'left-rail-preset-' + c"
-                        type="button"
-                        class="h-7 w-7 rounded border-2"
-                        :class="leftRailNewTagColor === c ? 'border-primary' : 'border-transparent'"
-                        :style="{ background: c }"
-                        @click="leftRailNewTagColor = c"
-                      />
+              <div v-show="tagsSectionExpanded">
+                <button
+                  type="button"
+                  class="hover:bg-primary-muted flex w-full items-center justify-between gap-2 rounded-lg px-2 py-2 text-left text-sm"
+                  :class="{ 'bg-primary-muted font-medium': isUntaggedTagFilterActive() }"
+                  @click="onUntaggedTagFilterClick"
+                >
+                  <span>Untagged</span>
+                  <UBadge
+                    size="xs"
+                    class="bg-primary-muted text-primary-dark shrink-0 rounded-xl border-0 font-serif tabular-nums ring-0"
+                  >
+                    {{ untaggedChipCount }}
+                  </UBadge>
+                </button>
+                <button
+                  v-for="t in standardTags"
+                  :key="t.TagId"
+                  class="hover:bg-primary-muted flex w-full cursor-pointer items-center justify-between gap-2 rounded-lg px-2 py-2 text-left text-sm"
+                  :class="{
+                    'bg-primary-muted font-medium': isStandardTagFilterActive(t.TagId),
+                    'ring-primary ring-2 ring-inset': tagDropHighlightId === t.TagId,
+                  }"
+                  @click="onStandardTagFilterClick(t.TagId)"
+                  @dragover="onTagRowDragOver($event, t.TagId)"
+                  @dragleave="onTagRowDragLeave($event, t.TagId)"
+                  @drop="onTagRowDrop($event, t.TagId)"
+                >
+                  <span class="flex min-w-0 items-center gap-2">
+                    <span class="inline-block h-2.5 w-2.5 shrink-0 rounded-full" :style="{ background: t.ColorHex }" />
+                    <span class="truncate">{{ t.Name }}</span>
+                  </span>
+                  <UBadge
+                    size="xs"
+                    class="bg-primary-muted text-primary-dark shrink-0 rounded-xl border-0 font-serif tabular-nums ring-0"
+                  >
+                    {{ standardTagIdToChipCount[t.TagId] ?? 0 }}
+                  </UBadge>
+                </button>
+
+                <div class="border-border-muted mt-2 border-t pt-2">
+                  <button
+                    v-if="!showLeftRailCreateTag"
+                    type="button"
+                    class="text-primary hover:text-primary-dark px-2 py-1.5 text-left text-xs font-medium hover:underline"
+                    @click="showLeftRailCreateTag = true"
+                  >
+                    + New Tag
+                  </button>
+                  <div v-else class="rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
+                    <div class="text-muted mb-2 text-xs font-semibold uppercase tracking-wide">Create Tag</div>
+                    <div class="space-y-2">
+                      <div>
+                        <label class="text-muted mb-0.5 block text-xs font-medium">Tag name</label>
+                        <UInput v-model="leftRailNewTagName" placeholder="Tag name" size="sm" />
+                      </div>
+                      <div>
+                        <label class="text-muted mb-0.5 block text-xs font-medium">Tag color</label>
+                        <div class="flex flex-wrap gap-1">
+                          <button
+                            v-for="c in presetColors"
+                            :key="'left-rail-preset-' + c"
+                            type="button"
+                            class="h-7 w-7 rounded border-2"
+                            :class="leftRailNewTagColor === c ? 'border-primary' : 'border-transparent'"
+                            :style="{ background: c }"
+                            @click="leftRailNewTagColor = c"
+                          />
+                        </div>
+                        <UInput v-model="leftRailNewTagColor" placeholder="#RRGGBB" size="sm" class="mt-1.5" />
+                      </div>
+                      <div class="flex gap-2 pt-1">
+                        <UButton size="xs" variant="ghost" @click="cancelLeftRailCreateTag">Cancel</UButton>
+                        <UButton
+                          size="xs"
+                          :disabled="!leftRailNewTagName.trim()"
+                          :loading="loading"
+                          @click="createTagLeftRail"
+                        >
+                          Create
+                        </UButton>
+                      </div>
                     </div>
-                    <UInput v-model="leftRailNewTagColor" placeholder="#RRGGBB" size="sm" class="mt-1.5" />
-                  </div>
-                  <div class="flex gap-2 pt-1">
-                    <UButton size="xs" variant="ghost" @click="cancelLeftRailCreateTag">Cancel</UButton>
-                    <UButton
-                      size="xs"
-                      :disabled="!leftRailNewTagName.trim()"
-                      :loading="loading"
-                      @click="createTagLeftRail"
-                    >
-                      Create
-                    </UButton>
                   </div>
                 </div>
               </div>
             </div>
           </div>
+
+          <EGDataCollectionsExplorer
+            class="min-h-0 min-w-0 flex-1"
+            :lab-id="props.labId"
+            :lab-root="labRoot"
+            :s3-bucket="lab?.S3Bucket"
+            :visible-files="visibleFiles"
+            :key-to-tag-ids="keyToStandardTagIdsForExplorer"
+            :key-to-batch-tag-id="keyToBatchTagId"
+            :key-to-workflow-tag-ids="keyToWorkflowTagIdsEffective"
+            :key-to-run-usages="keyToRunUsages"
+            :batch-tags="batchTags"
+            :tags="tags"
+            :selected-keys="selectedKeys"
+            :loading="loading"
+            :search="search"
+            :listing-file-count="files.length"
+            :listing-truncated="listingTruncated"
+            :filter-chips="explorerFilterChips"
+            @update:search="search = $event"
+            @update:selected-keys="selectedKeys = $event"
+            @toggle-key="toggleKey"
+            @select-all-displayed="selectAllDisplayed"
+            @clear-selection="selectedKeys = []"
+            @clear-filter="clearExplorerFilter($event)"
+            @file-keys-drag-end="clearTagDropHighlight"
+            @remove-tag-from-file="removeTagFromFile($event.key, $event.tagId)"
+            @select-run-files="selectFilesForRun($event)"
+          />
         </div>
-      </div>
 
-      <EGDataCollectionsExplorer
-        class="min-h-0 min-w-0 flex-1"
-        :lab-id="props.labId"
-        :lab-root="labRoot"
-        :visible-files="visibleFiles"
-        :key-to-tag-ids="keyToStandardTagIdsForExplorer"
-        :key-to-batch-tag-id="keyToBatchTagId"
-        :key-to-workflow-tag-ids="keyToWorkflowTagIdsEffective"
-        :key-to-run-usages="keyToRunUsages"
-        :batch-tags="batchTags"
-        :tags="tags"
-        :selected-keys="selectedKeys"
-        :loading="loading"
-        :search="search"
-        :listing-file-count="files.length"
-        :listing-truncated="listingTruncated"
-        :filter-chips="explorerFilterChips"
-        @update:search="search = $event"
-        @update:selected-keys="selectedKeys = $event"
-        @toggle-key="toggleKey"
-        @select-all-displayed="selectAllDisplayed"
-        @clear-selection="selectedKeys = []"
-        @clear-filter="clearExplorerFilter($event)"
-        @remove-tag-from-file="removeTagFromFile($event.key, $event.tagId)"
-        @select-run-files="selectFilesForRun($event)"
-      />
-    </div>
-
-    <div class="border-border-muted shrink-0 border-t bg-gray-50">
-      <div class="flex flex-wrap items-center gap-2 px-4 py-2">
-        <span v-if="hasSelection" class="text-muted text-xs">{{ selectedKeys.length }} file(s) selected</span>
-        <span v-else class="text-muted text-xs">Select files in the grid to add or remove tags in bulk.</span>
-        <div v-if="hasSelection" class="ml-auto flex flex-wrap items-center gap-2">
-          <UIcon v-if="bulkPanelBusy" name="i-heroicons-arrow-path" class="text-muted h-5 w-5 shrink-0 animate-spin" />
-          <UButton size="sm" variant="soft" :disabled="bulkPanelBusy" @click="openAddBulkPanel">Add Tags</UButton>
-          <UButton size="sm" variant="outline" :disabled="bulkPanelBusy" @click="openRemoveBulkPanel">
-            Remove Tags
-          </UButton>
-          <UButton size="sm" variant="outline" :disabled="bulkPanelBusy" @click="openChangeBatchModal">
-            Change Batch
-          </UButton>
+        <div class="border-border-muted shrink-0 border-t bg-gray-50">
+          <div class="flex flex-wrap items-center gap-2 px-4 py-2">
+            <span v-if="hasSelection" class="text-muted text-xs">{{ selectedKeys.length }} file(s) selected</span>
+            <span v-else class="text-muted text-xs">Select files in the grid to add or remove tags in bulk.</span>
+            <div v-if="hasSelection" class="ml-auto flex flex-wrap items-center gap-2">
+              <UIcon
+                v-if="bulkPanelBusy"
+                name="i-heroicons-arrow-path"
+                class="text-muted h-5 w-5 shrink-0 animate-spin"
+              />
+              <UButton size="sm" variant="soft" :disabled="bulkPanelBusy" @click="openAddBulkPanel">Add Tags</UButton>
+              <UButton size="sm" variant="outline" :disabled="bulkPanelBusy" @click="openRemoveBulkPanel">
+                Remove Tags
+              </UButton>
+              <UButton size="sm" variant="outline" :disabled="bulkPanelBusy" @click="openChangeBatchModal">
+                Change Batch
+              </UButton>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/packages/front-end/src/app/components/EGDataCollectionsPage.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsPage.vue
@@ -607,6 +607,11 @@
     }
   });
 
+  /** Files with no standard tags, among search results (same universe as tag filter chips). */
+  const untaggedChipCount = computed(
+    () => filesMatchingSearch.value.filter((f) => !standardTagIdsForFileKey(f.Key).length).length,
+  );
+
   /** Explorer dismiss chips — ids must stay in sync with `clearExplorerFilter`. */
   const CHIP_SCOPE_NOT_ANALYZED = 'chip-scope-not-analyzed';
   const CHIP_SCOPE_EXPIRING_SOON = 'chip-scope-expiring-soon';
@@ -855,9 +860,14 @@
 
   async function applyTagToKeys(tagId: string, keys: string[]): Promise<void> {
     if (!lab.value?.S3Bucket || !keys.length) return;
+    const keysToTag = keys.filter((k) => !(keyToTagIds.value[k] ?? []).includes(tagId));
+    if (!keysToTag.length) {
+      toast.info(keys.length === 1 ? 'Tag already applied to that sample.' : 'Tag already applied to those samples.');
+      return;
+    }
     uiStore.setRequestPending('dataCollectionsMutate');
     try {
-      await addTagsToFilesInChunks(keys, [tagId], []);
+      await addTagsToFilesInChunks(keysToTag, [tagId], []);
       selectedKeys.value = [];
       await loadTags();
       await loadListing();
@@ -893,13 +903,33 @@
     }
   }
 
-  function onCardDragOverTag(e: DragEvent): void {
-    if (e.dataTransfer?.types.includes('application/x-eg-keys')) {
-      e.preventDefault();
-    }
+  /** While dragging files from the explorer onto a tag row, that tag id is highlighted. */
+  const tagDropHighlightId = ref<string | null>(null);
+
+  function dataTransferHasFileKeys(dt: DataTransfer | null): boolean {
+    if (!dt) return false;
+    return [...dt.types].includes('application/x-eg-keys');
+  }
+
+  function onTagRowDragOver(e: DragEvent, tagId: string): void {
+    if (!dataTransferHasFileKeys(e.dataTransfer)) return;
+    e.preventDefault();
+    tagDropHighlightId.value = tagId;
+  }
+
+  function onTagRowDragLeave(e: DragEvent, tagId: string): void {
+    const cur = e.currentTarget as HTMLElement;
+    const rel = e.relatedTarget as Node | null;
+    if (rel && cur.contains(rel)) return;
+    if (tagDropHighlightId.value === tagId) tagDropHighlightId.value = null;
+  }
+
+  function clearTagDropHighlight(): void {
+    tagDropHighlightId.value = null;
   }
 
   function onTagRowDrop(e: DragEvent, tagId: string): void {
+    clearTagDropHighlight();
     e.preventDefault();
     const raw = e.dataTransfer?.getData('application/x-eg-keys');
     if (!raw) return;
@@ -1000,311 +1030,331 @@
   <div v-if="!lab?.S3Bucket" class="text-muted rounded-lg border border-dashed p-8 text-center text-sm">
     This lab has no S3 bucket configured. Set a bucket in Lab Settings to use Data Collections.
   </div>
-  <div
-    v-else
-    class="flex min-h-[480px] min-w-0 flex-col gap-0 overflow-hidden rounded-xl border border-gray-200 bg-white"
-  >
-    <div class="flex min-h-0 min-w-0 flex-1 overflow-hidden">
-      <div class="border-border-muted flex w-[280px] shrink-0 flex-col overflow-y-auto border-r bg-gray-50">
-        <div class="border-border-muted border-b p-2">
-          <button
-            type="button"
-            class="hover:bg-primary-muted flex w-full items-center justify-between gap-2 rounded-lg px-2 py-2 text-left text-sm"
-            :class="{ 'bg-primary-muted font-medium': isScopeAllActive() }"
-            @click="onAllSamplesScopeClick"
-          >
-            <span>All samples</span>
-            <UBadge
-              size="xs"
-              class="bg-primary-muted text-primary-dark shrink-0 rounded-xl border-0 font-serif tabular-nums ring-0"
-            >
-              {{ allSamplesChipCount }}
-            </UBadge>
-          </button>
-          <button
-            type="button"
-            class="hover:bg-primary-muted flex w-full items-center justify-between gap-2 rounded-lg px-2 py-2 text-left text-sm"
-            :class="{ 'bg-primary-muted font-medium': isNotAnalyzedScopeActive() }"
-            @click="onNotYetAnalyzedScopeClick"
-          >
-            <span>Not yet analyzed</span>
-            <UBadge
-              size="xs"
-              class="bg-primary-muted text-primary-dark shrink-0 rounded-xl border-0 font-serif tabular-nums ring-0"
-            >
-              {{ notAnalyzedChipCount }}
-            </UBadge>
-          </button>
-          <button
-            type="button"
-            class="hover:bg-primary-muted flex w-full items-center justify-between gap-2 rounded-lg px-2 py-2 text-left text-sm"
-            :class="{ 'bg-primary-muted font-medium': isExpiringSoonScopeActive() }"
-            :title="`Files whose soonest run-retention ExpiresAt is within ${expiringSoonThresholdDays} days. Permanent files are excluded.`"
-            @click="onExpiringSoonScopeClick"
-          >
-            <span class="flex items-center gap-2">
-              <UIcon name="i-heroicons-clock" class="h-4 w-4 shrink-0 text-amber-600" aria-hidden="true" />
-              <span>Expiring soon</span>
-            </span>
-            <UBadge
-              size="xs"
-              class="bg-primary-muted text-primary-dark shrink-0 rounded-xl border-0 font-serif tabular-nums ring-0"
-            >
-              {{ expiringSoonChipCount }}
-            </UBadge>
-          </button>
-          <div
-            v-if="isExpiringSoonScopeActive()"
-            class="text-muted mt-1 flex items-center justify-between gap-2 rounded-lg px-2 py-1.5 text-xs"
-          >
-            <label :for="`expiring-soon-days-${props.labId}`">Days ahead</label>
-            <input
-              :id="`expiring-soon-days-${props.labId}`"
-              v-model.number="expiringSoonThresholdDays"
-              type="number"
-              :min="EXPIRING_SOON_MIN_DAYS"
-              :max="EXPIRING_SOON_MAX_DAYS"
-              step="1"
-              class="focus:border-primary w-16 rounded border border-gray-300 px-2 py-1 text-right text-xs tabular-nums focus:outline-none"
-              @click.stop
-            />
-          </div>
-        </div>
-
-        <div class="border-border-muted border-b p-2">
-          <button
-            type="button"
-            class="text-muted hover:bg-primary-muted mb-1 flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left text-xs font-medium uppercase tracking-wide"
-            :aria-expanded="workflowsSectionExpanded"
-            @click="workflowsSectionExpanded = !workflowsSectionExpanded"
-          >
-            <UIcon
-              :name="workflowsSectionExpanded ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'"
-              class="h-4 w-4 shrink-0"
-              aria-hidden="true"
-            />
-            <span>Workflows</span>
-          </button>
-          <div v-show="workflowsSectionExpanded">
-            <p v-if="!workflowTemplates.length" class="text-muted mt-2 px-2 text-xs italic">
-              No workflows have been run on these files yet.
-            </p>
-
-            <div v-for="tmpl in visibleWorkflowTemplates" :key="tmpl.key" class="mt-1">
-              <div
-                class="hover:bg-primary-muted flex w-full cursor-pointer items-center gap-1 rounded-lg pr-2 text-left text-sm"
-                :class="{
-                  'bg-primary-muted font-medium': isWorkflowTemplateScopeActive(tmpl.key),
-                }"
+  <div v-else class="flex min-w-0 flex-col gap-0">
+    <div class="overflow-hidden rounded-xl border border-gray-200 bg-white">
+      <div class="flex h-[calc(100dvh-12rem)] min-h-0 flex-col overflow-hidden">
+        <div class="flex min-h-0 min-w-0 flex-1 overflow-hidden">
+          <div class="border-border-muted flex w-[280px] shrink-0 flex-col overflow-y-auto border-r bg-gray-50">
+            <div class="border-border-muted border-b p-2">
+              <button
+                type="button"
+                class="hover:bg-primary-muted flex w-full items-center justify-between gap-2 rounded-lg px-2 py-2 text-left text-sm"
+                :class="{ 'bg-primary-muted font-medium': isScopeAllActive() }"
+                @click="onAllSamplesScopeClick"
               >
-                <button
-                  v-if="tmpl.versions.length > 1"
-                  type="button"
-                  class="text-muted hover:text-primary flex h-7 w-7 shrink-0 items-center justify-center rounded"
-                  :aria-label="expandedWorkflowTemplates[tmpl.key] ? 'Collapse versions' : 'Expand versions'"
-                  @click.stop="toggleWorkflowTemplate(tmpl.key)"
+                <span>All samples</span>
+                <UBadge
+                  size="xs"
+                  class="bg-primary-muted text-primary-dark shrink-0 rounded-xl border-0 font-serif tabular-nums ring-0"
                 >
-                  <UIcon
-                    :name="
-                      expandedWorkflowTemplates[tmpl.key] ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'
-                    "
-                    class="h-4 w-4"
-                  />
-                </button>
-                <span v-else class="block h-7 w-7 shrink-0" />
-                <button
-                  type="button"
-                  class="flex min-w-0 flex-1 items-center justify-between gap-2 py-2 text-left"
-                  @click="onWorkflowTemplateScopeClick(tmpl.key)"
+                  {{ allSamplesChipCount }}
+                </UBadge>
+              </button>
+              <button
+                type="button"
+                class="hover:bg-primary-muted flex w-full items-center justify-between gap-2 rounded-lg px-2 py-2 text-left text-sm"
+                :class="{ 'bg-primary-muted font-medium': isNotAnalyzedScopeActive() }"
+                @click="onNotYetAnalyzedScopeClick"
+              >
+                <span>Not yet analyzed</span>
+                <UBadge
+                  size="xs"
+                  class="bg-primary-muted text-primary-dark shrink-0 rounded-xl border-0 font-serif tabular-nums ring-0"
                 >
-                  <span class="flex min-w-0 items-center gap-2">
-                    <span class="inline-block h-2.5 w-2.5 shrink-0 rounded-full" :style="{ background: tmpl.color }" />
-                    <span class="truncate">{{ tmpl.name }}</span>
-                  </span>
-                  <span class="text-muted shrink-0 text-xs">{{ tmpl.fileCount }}</span>
-                </button>
+                  {{ notAnalyzedChipCount }}
+                </UBadge>
+              </button>
+              <button
+                type="button"
+                class="hover:bg-primary-muted flex w-full items-center justify-between gap-2 rounded-lg px-2 py-2 text-left text-sm"
+                :class="{ 'bg-primary-muted font-medium': isExpiringSoonScopeActive() }"
+                :title="`Files whose soonest run-retention ExpiresAt is within ${expiringSoonThresholdDays} days. Permanent files are excluded.`"
+                @click="onExpiringSoonScopeClick"
+              >
+                <span class="flex items-center gap-2">
+                  <UIcon name="i-heroicons-clock" class="h-4 w-4 shrink-0 text-amber-600" aria-hidden="true" />
+                  <span>Expiring soon</span>
+                </span>
+                <UBadge
+                  size="xs"
+                  class="bg-primary-muted text-primary-dark shrink-0 rounded-xl border-0 font-serif tabular-nums ring-0"
+                >
+                  {{ expiringSoonChipCount }}
+                </UBadge>
+              </button>
+              <div
+                v-if="isExpiringSoonScopeActive()"
+                class="text-muted mt-1 flex items-center justify-between gap-2 rounded-lg px-2 py-1.5 text-xs"
+              >
+                <label :for="`expiring-soon-days-${props.labId}`">Days ahead</label>
+                <input
+                  :id="`expiring-soon-days-${props.labId}`"
+                  v-model.number="expiringSoonThresholdDays"
+                  type="number"
+                  :min="EXPIRING_SOON_MIN_DAYS"
+                  :max="EXPIRING_SOON_MAX_DAYS"
+                  step="1"
+                  class="focus:border-primary w-16 rounded border border-gray-300 px-2 py-1 text-right text-xs tabular-nums focus:outline-none"
+                  @click.stop
+                />
               </div>
+            </div>
 
-              <div v-if="expandedWorkflowTemplates[tmpl.key] && tmpl.versions.length > 1" class="ml-7 mt-0.5">
+            <div class="border-border-muted border-b p-2">
+              <button
+                type="button"
+                class="text-muted hover:bg-primary-muted mb-1 flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left text-xs font-medium uppercase tracking-wide"
+                :aria-expanded="workflowsSectionExpanded"
+                @click="workflowsSectionExpanded = !workflowsSectionExpanded"
+              >
+                <UIcon
+                  :name="workflowsSectionExpanded ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'"
+                  class="h-4 w-4 shrink-0"
+                  aria-hidden="true"
+                />
+                <span>Workflows</span>
+              </button>
+              <div v-show="workflowsSectionExpanded">
+                <p v-if="!workflowTemplates.length" class="text-muted mt-2 px-2 text-xs italic">
+                  No workflows have been run on these files yet.
+                </p>
+
+                <div v-for="tmpl in visibleWorkflowTemplates" :key="tmpl.key" class="mt-1">
+                  <div
+                    class="hover:bg-primary-muted flex w-full cursor-pointer items-center gap-1 rounded-lg pr-2 text-left text-sm"
+                    :class="{
+                      'bg-primary-muted font-medium': isWorkflowTemplateScopeActive(tmpl.key),
+                    }"
+                  >
+                    <button
+                      v-if="tmpl.versions.length > 1"
+                      type="button"
+                      class="text-muted hover:text-primary flex h-7 w-7 shrink-0 items-center justify-center rounded"
+                      :aria-label="expandedWorkflowTemplates[tmpl.key] ? 'Collapse versions' : 'Expand versions'"
+                      @click.stop="toggleWorkflowTemplate(tmpl.key)"
+                    >
+                      <UIcon
+                        :name="
+                          expandedWorkflowTemplates[tmpl.key] ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'
+                        "
+                        class="h-4 w-4"
+                      />
+                    </button>
+                    <span v-else class="block h-7 w-7 shrink-0" />
+                    <button
+                      type="button"
+                      class="flex min-w-0 flex-1 items-center justify-between gap-2 py-2 text-left"
+                      @click="onWorkflowTemplateScopeClick(tmpl.key)"
+                    >
+                      <span class="flex min-w-0 items-center gap-2">
+                        <span
+                          class="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
+                          :style="{ background: tmpl.color }"
+                        />
+                        <span class="truncate">{{ tmpl.name }}</span>
+                      </span>
+                      <span class="text-muted shrink-0 text-xs">{{ tmpl.fileCount }}</span>
+                    </button>
+                  </div>
+
+                  <div v-if="expandedWorkflowTemplates[tmpl.key] && tmpl.versions.length > 1" class="ml-7 mt-0.5">
+                    <button
+                      v-for="v in tmpl.versions"
+                      :key="v.tag.TagId"
+                      type="button"
+                      class="hover:bg-primary-muted flex w-full items-center justify-between gap-2 rounded-lg px-2 py-1.5 text-left text-xs"
+                      :class="{
+                        'bg-primary-muted font-medium': isWorkflowVersionScopeActive(v.tag.TagId),
+                      }"
+                      @click="onWorkflowVersionScopeClick(v.tag.TagId)"
+                    >
+                      <span class="text-muted truncate">{{ v.label }}</span>
+                      <span class="text-muted shrink-0 tabular-nums">{{ v.tag.FileCount }}</span>
+                    </button>
+                  </div>
+                </div>
+
                 <button
-                  v-for="v in tmpl.versions"
-                  :key="v.tag.TagId"
+                  v-if="workflowTemplates.length > visibleWorkflowTemplates.length || showAllWorkflowTemplates"
+                  v-show="workflowTemplates.length > 6"
                   type="button"
-                  class="hover:bg-primary-muted flex w-full items-center justify-between gap-2 rounded-lg px-2 py-1.5 text-left text-xs"
-                  :class="{
-                    'bg-primary-muted font-medium': isWorkflowVersionScopeActive(v.tag.TagId),
-                  }"
-                  @click="onWorkflowVersionScopeClick(v.tag.TagId)"
+                  class="text-primary mt-2 px-2 text-xs font-medium hover:underline"
+                  @click="showAllWorkflowTemplates = !showAllWorkflowTemplates"
                 >
-                  <span class="text-muted truncate">{{ v.label }}</span>
-                  <span class="text-muted shrink-0 tabular-nums">{{ v.tag.FileCount }}</span>
+                  {{
+                    showAllWorkflowTemplates
+                      ? 'Show fewer'
+                      : `Show ${workflowTemplates.length - visibleWorkflowTemplates.length} more`
+                  }}
                 </button>
               </div>
             </div>
 
-            <button
-              v-if="workflowTemplates.length > visibleWorkflowTemplates.length || showAllWorkflowTemplates"
-              v-show="workflowTemplates.length > 6"
-              type="button"
-              class="text-primary mt-2 px-2 text-xs font-medium hover:underline"
-              @click="showAllWorkflowTemplates = !showAllWorkflowTemplates"
-            >
-              {{
-                showAllWorkflowTemplates
-                  ? 'Show fewer'
-                  : `Show ${workflowTemplates.length - visibleWorkflowTemplates.length} more`
-              }}
-            </button>
-          </div>
-        </div>
-
-        <div class="p-2">
-          <button
-            type="button"
-            class="text-muted hover:bg-primary-muted mb-1 flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left text-xs font-medium uppercase tracking-wide"
-            :aria-expanded="tagsSectionExpanded"
-            @click="tagsSectionExpanded = !tagsSectionExpanded"
-          >
-            <UIcon
-              :name="tagsSectionExpanded ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'"
-              class="h-4 w-4 shrink-0"
-              aria-hidden="true"
-            />
-            <span>Tags</span>
-          </button>
-          <div v-show="tagsSectionExpanded">
-            <button
-              type="button"
-              class="hover:bg-primary-muted flex w-full items-center justify-between rounded-lg px-2 py-2 text-left text-sm"
-              :class="{ 'bg-primary-muted font-medium': isUntaggedTagFilterActive() }"
-              @click="onUntaggedTagFilterClick"
-            >
-              <span>Untagged</span>
-            </button>
-            <button
-              v-for="t in leftRailTagFilterTags"
-              :key="t.TagId"
-              class="hover:bg-primary-muted flex w-full cursor-pointer items-center justify-between gap-2 rounded-lg px-2 py-2 text-left text-sm"
-              :class="{ 'bg-primary-muted font-medium': isStandardTagFilterActive(t.TagId) }"
-              @click="onStandardTagFilterClick(t.TagId)"
-              @dragover.prevent="onCardDragOverTag"
-              @drop="onTagRowDrop($event, t.TagId)"
-            >
-              <span class="flex min-w-0 flex-1 items-center gap-2">
-                <span class="inline-block h-2.5 w-2.5 shrink-0 rounded-full" :style="{ background: t.ColorHex }" />
-                <span class="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0.5">
-                  <span class="truncate">{{ t.Name }}</span>
-                  <span
-                    v-if="(t.Kind ?? 'standard') === 'permanent'"
-                    class="text-muted shrink-0 text-[10px] font-normal"
-                  >
-                    Protect from expiry
-                  </span>
-                </span>
-              </span>
-              <UBadge
-                size="xs"
-                class="bg-primary-muted text-primary-dark shrink-0 rounded-xl border-0 font-serif tabular-nums ring-0"
-              >
-                {{
-                  (t.Kind ?? 'standard') === 'permanent'
-                    ? permanentTaggedFileCountInSearch
-                    : (standardTagIdToChipCount[t.TagId] ?? 0)
-                }}
-              </UBadge>
-            </button>
-
-            <div class="border-border-muted mt-2 border-t pt-2">
+            <div class="p-2">
               <button
-                v-if="!showLeftRailCreateTag"
                 type="button"
-                class="text-primary hover:text-primary-dark px-2 py-1.5 text-left text-xs font-medium hover:underline"
-                @click="showLeftRailCreateTag = true"
+                class="text-muted hover:bg-primary-muted mb-1 flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left text-xs font-medium uppercase tracking-wide"
+                :aria-expanded="tagsSectionExpanded"
+                @click="tagsSectionExpanded = !tagsSectionExpanded"
               >
-                + New Tag
+                <UIcon
+                  :name="tagsSectionExpanded ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'"
+                  class="h-4 w-4 shrink-0"
+                  aria-hidden="true"
+                />
+                <span>Tags</span>
               </button>
-              <div v-else class="rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
-                <div class="text-muted mb-2 text-xs font-semibold uppercase tracking-wide">Create Tag</div>
-                <div class="space-y-2">
-                  <div>
-                    <label class="text-muted mb-0.5 block text-xs font-medium">Tag name</label>
-                    <UInput v-model="leftRailNewTagName" placeholder="Tag name" size="sm" />
-                  </div>
-                  <div>
-                    <label class="text-muted mb-0.5 block text-xs font-medium">Tag color</label>
-                    <div class="flex flex-wrap gap-1">
-                      <button
-                        v-for="c in presetColors"
-                        :key="'left-rail-preset-' + c"
-                        type="button"
-                        class="h-7 w-7 rounded border-2"
-                        :class="leftRailNewTagColor === c ? 'border-primary' : 'border-transparent'"
-                        :style="{ background: c }"
-                        @click="leftRailNewTagColor = c"
-                      />
+              <div v-show="tagsSectionExpanded">
+                <button
+                  type="button"
+                  class="hover:bg-primary-muted flex w-full items-center justify-between gap-2 rounded-lg px-2 py-2 text-left text-sm"
+                  :class="{ 'bg-primary-muted font-medium': isUntaggedTagFilterActive() }"
+                  @click="onUntaggedTagFilterClick"
+                >
+                  <span>Untagged</span>
+                  <UBadge
+                    size="xs"
+                    class="bg-primary-muted text-primary-dark shrink-0 rounded-xl border-0 font-serif tabular-nums ring-0"
+                  >
+                    {{ untaggedChipCount }}
+                  </UBadge>
+                </button>
+                <button
+                  v-for="t in leftRailTagFilterTags"
+                  :key="t.TagId"
+                  class="hover:bg-primary-muted flex w-full cursor-pointer items-center justify-between gap-2 rounded-lg px-2 py-2 text-left text-sm"
+                  :class="{
+                    'bg-primary-muted font-medium': isStandardTagFilterActive(t.TagId),
+                    'ring-primary ring-2 ring-inset': tagDropHighlightId === t.TagId,
+                  }"
+                  @click="onStandardTagFilterClick(t.TagId)"
+                  @dragover="onTagRowDragOver($event, t.TagId)"
+                  @dragleave="onTagRowDragLeave($event, t.TagId)"
+                  @drop="onTagRowDrop($event, t.TagId)"
+                >
+                  <span class="flex min-w-0 flex-1 items-center gap-2">
+                    <span class="inline-block h-2.5 w-2.5 shrink-0 rounded-full" :style="{ background: t.ColorHex }" />
+                    <span class="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0.5">
+                      <span class="truncate">{{ t.Name }}</span>
+                      <span
+                        v-if="(t.Kind ?? 'standard') === 'permanent'"
+                        class="text-muted shrink-0 text-[10px] font-normal"
+                      >
+                        Protect from expiry
+                      </span>
+                    </span>
+                  </span>
+                  <UBadge
+                    size="xs"
+                    class="bg-primary-muted text-primary-dark shrink-0 rounded-xl border-0 font-serif tabular-nums ring-0"
+                  >
+                    {{
+                      (t.Kind ?? 'standard') === 'permanent'
+                        ? permanentTaggedFileCountInSearch
+                        : (standardTagIdToChipCount[t.TagId] ?? 0)
+                    }}
+                  </UBadge>
+                </button>
+
+                <div class="border-border-muted mt-2 border-t pt-2">
+                  <button
+                    v-if="!showLeftRailCreateTag"
+                    type="button"
+                    class="text-primary hover:text-primary-dark px-2 py-1.5 text-left text-xs font-medium hover:underline"
+                    @click="showLeftRailCreateTag = true"
+                  >
+                    + New Tag
+                  </button>
+                  <div v-else class="rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
+                    <div class="text-muted mb-2 text-xs font-semibold uppercase tracking-wide">Create Tag</div>
+                    <div class="space-y-2">
+                      <div>
+                        <label class="text-muted mb-0.5 block text-xs font-medium">Tag name</label>
+                        <UInput v-model="leftRailNewTagName" placeholder="Tag name" size="sm" />
+                      </div>
+                      <div>
+                        <label class="text-muted mb-0.5 block text-xs font-medium">Tag color</label>
+                        <div class="flex flex-wrap gap-1">
+                          <button
+                            v-for="c in presetColors"
+                            :key="'left-rail-preset-' + c"
+                            type="button"
+                            class="h-7 w-7 rounded border-2"
+                            :class="leftRailNewTagColor === c ? 'border-primary' : 'border-transparent'"
+                            :style="{ background: c }"
+                            @click="leftRailNewTagColor = c"
+                          />
+                        </div>
+                        <UInput v-model="leftRailNewTagColor" placeholder="#RRGGBB" size="sm" class="mt-1.5" />
+                      </div>
+                      <div class="flex gap-2 pt-1">
+                        <UButton size="xs" variant="ghost" @click="cancelLeftRailCreateTag">Cancel</UButton>
+                        <UButton
+                          size="xs"
+                          :disabled="!leftRailNewTagName.trim()"
+                          :loading="loading"
+                          @click="createTagLeftRail"
+                        >
+                          Create
+                        </UButton>
+                      </div>
                     </div>
-                    <UInput v-model="leftRailNewTagColor" placeholder="#RRGGBB" size="sm" class="mt-1.5" />
-                  </div>
-                  <div class="flex gap-2 pt-1">
-                    <UButton size="xs" variant="ghost" @click="cancelLeftRailCreateTag">Cancel</UButton>
-                    <UButton
-                      size="xs"
-                      :disabled="!leftRailNewTagName.trim()"
-                      :loading="loading"
-                      @click="createTagLeftRail"
-                    >
-                      Create
-                    </UButton>
                   </div>
                 </div>
               </div>
             </div>
           </div>
+
+          <EGDataCollectionsExplorer
+            class="min-h-0 min-w-0 flex-1"
+            :lab-id="props.labId"
+            :lab-root="labRoot"
+            :s3-bucket="lab?.S3Bucket"
+            :visible-files="visibleFiles"
+            :key-to-tag-ids="keyToStandardTagIdsForExplorer"
+            :key-to-batch-tag-id="keyToBatchTagId"
+            :key-to-workflow-tag-ids="keyToWorkflowTagIdsEffective"
+            :key-to-run-usages="keyToRunUsages"
+            :key-to-is-permanent="keyToIsPermanent"
+            :batch-tags="batchTags"
+            :tags="tags"
+            :selected-keys="selectedKeys"
+            :loading="loading"
+            :search="search"
+            :listing-file-count="files.length"
+            :listing-truncated="listingTruncated"
+            :filter-chips="explorerFilterChips"
+            @update:search="search = $event"
+            @update:selected-keys="selectedKeys = $event"
+            @toggle-key="toggleKey"
+            @select-all-displayed="selectAllDisplayed"
+            @clear-selection="selectedKeys = []"
+            @clear-filter="clearExplorerFilter($event)"
+            @file-keys-drag-end="clearTagDropHighlight"
+            @remove-tag-from-file="removeTagFromFile($event.key, $event.tagId)"
+            @select-run-files="selectFilesForRun($event)"
+          />
         </div>
-      </div>
 
-      <EGDataCollectionsExplorer
-        class="min-h-0 min-w-0 flex-1"
-        :lab-id="props.labId"
-        :lab-root="labRoot"
-        :visible-files="visibleFiles"
-        :key-to-tag-ids="keyToStandardTagIdsForExplorer"
-        :key-to-batch-tag-id="keyToBatchTagId"
-        :key-to-workflow-tag-ids="keyToWorkflowTagIdsEffective"
-        :key-to-run-usages="keyToRunUsages"
-        :key-to-is-permanent="keyToIsPermanent"
-        :batch-tags="batchTags"
-        :tags="tags"
-        :selected-keys="selectedKeys"
-        :loading="loading"
-        :search="search"
-        :listing-file-count="files.length"
-        :listing-truncated="listingTruncated"
-        :filter-chips="explorerFilterChips"
-        @update:search="search = $event"
-        @update:selected-keys="selectedKeys = $event"
-        @toggle-key="toggleKey"
-        @select-all-displayed="selectAllDisplayed"
-        @clear-selection="selectedKeys = []"
-        @clear-filter="clearExplorerFilter($event)"
-        @remove-tag-from-file="removeTagFromFile($event.key, $event.tagId)"
-        @select-run-files="selectFilesForRun($event)"
-      />
-    </div>
-
-    <div class="border-border-muted shrink-0 border-t bg-gray-50">
-      <div class="flex flex-wrap items-center gap-2 px-4 py-2">
-        <span v-if="hasSelection" class="text-muted text-xs">{{ selectedKeys.length }} file(s) selected</span>
-        <span v-else class="text-muted text-xs">Select files in the grid to add or remove tags in bulk.</span>
-        <div v-if="hasSelection" class="ml-auto flex flex-wrap items-center gap-2">
-          <UIcon v-if="bulkPanelBusy" name="i-heroicons-arrow-path" class="text-muted h-5 w-5 shrink-0 animate-spin" />
-          <UButton size="sm" variant="soft" :disabled="bulkPanelBusy" @click="openAddBulkPanel">Add Tags</UButton>
-          <UButton size="sm" variant="outline" :disabled="bulkPanelBusy" @click="openRemoveBulkPanel">
-            Remove Tags
-          </UButton>
-          <UButton size="sm" variant="outline" :disabled="bulkPanelBusy" @click="openChangeBatchModal">
-            Change Batch
-          </UButton>
+        <div class="border-border-muted shrink-0 border-t bg-gray-50">
+          <div class="flex flex-wrap items-center gap-2 px-4 py-2">
+            <span v-if="hasSelection" class="text-muted text-xs">{{ selectedKeys.length }} file(s) selected</span>
+            <span v-else class="text-muted text-xs">Select files in the grid to add or remove tags in bulk.</span>
+            <div v-if="hasSelection" class="ml-auto flex flex-wrap items-center gap-2">
+              <UIcon
+                v-if="bulkPanelBusy"
+                name="i-heroicons-arrow-path"
+                class="text-muted h-5 w-5 shrink-0 animate-spin"
+              />
+              <UButton size="sm" variant="soft" :disabled="bulkPanelBusy" @click="openAddBulkPanel">Add Tags</UButton>
+              <UButton size="sm" variant="outline" :disabled="bulkPanelBusy" @click="openRemoveBulkPanel">
+                Remove Tags
+              </UButton>
+              <UButton size="sm" variant="outline" :disabled="bulkPanelBusy" @click="openChangeBatchModal">
+                Change Batch
+              </UButton>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/packages/front-end/src/app/components/EGDataCollectionsPage.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsPage.vue
@@ -881,28 +881,6 @@
     }
   }
 
-  async function removeTagFromFile(key: string, tagId: string): Promise<void> {
-    if (!lab.value?.S3Bucket) return;
-    uiStore.setRequestPending('dataCollectionsMutate');
-    try {
-      await $api.dataCollections.addTagsToFiles({
-        LaboratoryId: props.labId,
-        S3Bucket: lab.value.S3Bucket,
-        Keys: [key],
-        RemoveTagIds: [tagId],
-      });
-      await loadTags();
-      await loadListing();
-      await nextTick();
-      toast.success('Tag removed');
-    } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : String(e);
-      toast.error(`Remove failed: ${msg}`);
-    } finally {
-      uiStore.setRequestComplete('dataCollectionsMutate');
-    }
-  }
-
   /** While dragging files from the explorer onto a tag row, that tag id is highlighted. */
   const tagDropHighlightId = ref<string | null>(null);
 
@@ -1331,7 +1309,6 @@
             @clear-selection="selectedKeys = []"
             @clear-filter="clearExplorerFilter($event)"
             @file-keys-drag-end="clearTagDropHighlight"
-            @remove-tag-from-file="removeTagFromFile($event.key, $event.tagId)"
             @select-run-files="selectFilesForRun($event)"
           />
         </div>

--- a/packages/front-end/src/app/components/EGDataCollectionsPage.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsPage.vue
@@ -733,28 +733,6 @@
     }
   }
 
-  async function removeTagFromFile(key: string, tagId: string): Promise<void> {
-    if (!lab.value?.S3Bucket) return;
-    uiStore.setRequestPending('dataCollectionsMutate');
-    try {
-      await $api.dataCollections.addTagsToFiles({
-        LaboratoryId: props.labId,
-        S3Bucket: lab.value.S3Bucket,
-        Keys: [key],
-        RemoveTagIds: [tagId],
-      });
-      await loadTags();
-      await loadListing();
-      await nextTick();
-      toast.success('Tag removed');
-    } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : String(e);
-      toast.error(`Remove failed: ${msg}`);
-    } finally {
-      uiStore.setRequestComplete('dataCollectionsMutate');
-    }
-  }
-
   /** While dragging files from the explorer onto a tag row, that tag id is highlighted. */
   const tagDropHighlightId = ref<string | null>(null);
 
@@ -1136,7 +1114,6 @@
             @clear-selection="selectedKeys = []"
             @clear-filter="clearExplorerFilter($event)"
             @file-keys-drag-end="clearTagDropHighlight"
-            @remove-tag-from-file="removeTagFromFile($event.key, $event.tagId)"
             @select-run-files="selectFilesForRun($event)"
           />
         </div>

--- a/packages/front-end/src/app/components/EGFileAnalysisHistoryTooltip.vue
+++ b/packages/front-end/src/app/components/EGFileAnalysisHistoryTooltip.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
   /**
    * Hover-triggered analysis history panel for a single file in the data collections explorer.
-   * Card view: dot (+ count chip when N>1) only. Table view: dot + status text. Panel lists runs;
+   * Card view: dot (+ count chip when N>1) + trailing chevron. Table view: dot + status text. Panel lists runs;
    * left opens run detail; right zone selects input files for that run.
    */
   import { format } from 'date-fns';
@@ -17,7 +17,7 @@
     standardTagNames: string[];
     /** Per-run usage history, sorted newest first by `RunCreatedAt`. */
     runUsages: LaboratoryRunUsageSummary[];
-    /** Card = dot (+ count when N>1) only; table = dot + status label. */
+    /** Card = dot (+ count when N>1) + trailing chevron; table = dot + status label. */
     variant?: 'card' | 'table';
   }>();
 
@@ -114,7 +114,7 @@
     :ui="popoverUi"
     @update:open="emit('update:open', $event)"
   >
-    <!-- Card: circle (+ count when N>1); hover flush to card top-left (parent is absolute left-0 top-0 on card). -->
+    <!-- Card: circle (+ count when N>1) + trailing chevron; chevron hints hover reveals analysis history (parent is absolute left-0 top-0 on card). -->
     <span
       v-if="isCard"
       class="inline-flex cursor-default items-center gap-1 rounded-tl-xl pb-1.5 pl-2 pr-1.5 pt-2 transition-colors hover:bg-gray-100 focus:outline-none"
@@ -137,6 +137,7 @@
       >
         {{ runCount }}
       </span>
+      <UIcon name="i-heroicons-chevron-down" class="text-muted h-3 w-3 shrink-0" aria-hidden="true" />
     </span>
 
     <!-- Table: dot + status text, no chip outline -->

--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -135,7 +135,8 @@
       runs: 'View your pipeline runs',
       seqeraPipelines: 'View your Seqera pipelines',
       omicsWorkflows: 'View your HealthOmics workflows',
-      dataCollections: 'Tag and browse files in your lab S3 bucket',
+      dataCollections:
+        "All of your lab's sequencing data lives here. Tag samples by organism, run, or any other grouping that makes sense for your lab, then use those tags to select what goes into a workflow.",
       users: 'View your lab users',
       details: 'View your lab settings',
     };

--- a/packages/front-end/src/app/utils/file-size.ts
+++ b/packages/front-end/src/app/utils/file-size.ts
@@ -1,0 +1,12 @@
+/** Human-readable byte size (binary units), e.g. 1536 → "1.50 KB". */
+export function formatFileSize(value?: number | null): string {
+  if (value == null || value < 0) return '';
+  let v = value;
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let unitIndex = 0;
+  while (v >= 1024 && unitIndex < units.length - 1) {
+    v /= 1024;
+    unitIndex++;
+  }
+  return `${v.toFixed(unitIndex === 0 ? 0 : 2)} ${units[unitIndex]}`;
+}


### PR DESCRIPTION
## Data collections: fix tag drag behavior, improve tagging UX, and polish explorer layout

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
This branch cleans up the Data Collections tagging and file explorer experience (EGV-140).

**Tagging and drag-and-drop**
- Removed dragging **tag pills** onto file cards to remove tags. That interaction conflicted with normal file selection and produced incorrect drag/drop behavior; tag removal is no longer driven from pill drags on cards.
- File → tag assignment is unchanged in intent but more reliable: drags that carry `application/x-eg-keys` now use explicit `dragover` / `dragleave` handling, highlight the target tag row while dragging, and clear highlight on drop or when a file-card drag ends (`fileKeysDragEnd` from the explorer).
- Applying a tag to a selection now **skips files that already have that tag** and shows an informational toast instead of issuing redundant API work.

**Explorer and layout**
- Explorer uses **`formatFileSize`** for human-readable sizes (new `packages/front-end/src/app/utils/file-size.ts`).
- Optional **`s3Bucket`** prop shows full `s3://bucket/key` in hover tooltips; tooltip UI is widened and scrollable so long paths are not clipped by Nuxt UI defaults.
- Card grid: `min-h-0` / `min-w-0`, line-clamped filenames with `break-all`, and tooltip wrapping for overflow.
- Main collections shell uses a **viewport-based height** (`calc(100dvh - 12rem)`) so the split panel scrolls predictably.

**Other UX**
- **Untagged** filter shows a **count badge** (same search universe as other tag chips).
- Analysis history on file cards: **trailing chevron** to hint that hover opens history (`EGFileAnalysisHistoryTooltip.vue`).
- Lab view: **Data Collections** tab description updated to explain tagging and workflow selection (`EGLabView.vue`).

## Testing*
- [ ] Manually verified dragging selected file(s) onto a standard tag row applies the tag and clears row highlight.
- [ ] Manually verified drag cancel / drag end clears tag-row highlight without leaving a stuck ring.
- [ ] Manually verified dropping a tag onto files that already have it shows the “already applied” toast and does not error.
- [ ] Confirmed tag pills on cards/table no longer initiate pill drags that interfered with file drags.
- [ ] Hover tooltips show full S3 URI when bucket is configured; long paths wrap/scroll in the tooltip.
- [ ] File sizes display as KB/MB/etc. in grid and table views.
- [ ] Untagged chip count matches expectation for current search results.
- [ ] Automated test suite: *(not run in this session — please run your usual `pnpm` test/lint commands.)*

## Impact
- **Behavior change:** Users can no longer remove a tag by dragging a pill onto another file card; bulk “Remove Tags” in the footer remains the path for removal.
- **API:** Fewer redundant tag-add calls when re-applying an existing tag to the same files.
- **No new runtime dependencies**; small new front-end utility only.

## Additional Information
- Branch: `feat/egv-140-data-tagging-ui-cleanup`
- Commits vs `development`: `feat: data tagging ui cleanup`, `feat: remove tag dragging bug, improve analysis history ux`
- Related ticket: EGV-140 *(adjust if your tracker link differs)*

## Checklist*
- [ ] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [ ] Code adheres to the coding and style guidelines of the project.
- [ ] Code has been commented in particularly hard-to-understand areas.