### PR TITLE
feat: data collections file type filter

### DIFF
--- a/packages/front-end/src/app/components/EGDataCollectionsExplorer.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsExplorer.vue
@@ -7,6 +7,7 @@
     LaboratoryDataTag,
     LaboratoryRunUsageSummary,
   } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/data-collections';
+  import type { DataCollectionFileTypeFilter, HiddenFileTypeBreakdownRow } from '@FE/utils/data-collections-file-type';
   import { formatFileSize } from '@FE/utils/file-size';
 
   const props = defineProps<{
@@ -46,10 +47,15 @@
     listingTruncated?: boolean;
     /** Active filter chips (scope + tags); each chip can be dismissed independently in the explorer header. */
     filterChips?: { chipId: string; label: string }[];
+    fileTypeFilter: DataCollectionFileTypeFilter;
+    fileTypeCounts: { fastq: number; fasta: number; other: number };
+    hiddenByFileTypeCount: number;
+    hiddenByFileTypeBreakdown: HiddenFileTypeBreakdownRow[];
   }>();
 
   const emit = defineEmits<{
     'update:search': [v: string];
+    'update:fileTypeFilter': [value: DataCollectionFileTypeFilter];
     'update:selectedKeys': [keys: string[]];
     toggleKey: [key: string];
     selectAllDisplayed: [];
@@ -65,6 +71,14 @@
 
   /** Cards grid vs tabular explorer layout. */
   const explorerView = ref<'cards' | 'table'>('cards');
+
+  const fileTypeFilterOpen = ref(false);
+
+  function onOpenFileTypeFilterFromHiddenChip(): void {
+    nextTick(() => {
+      fileTypeFilterOpen.value = true;
+    });
+  }
 
   const scrollEl = ref<HTMLElement | null>(null);
   const lassoActive = ref(false);
@@ -381,7 +395,7 @@
 
 <template>
   <div class="flex min-h-0 min-w-0 flex-1 flex-col">
-    <div class="border-border-muted flex flex-wrap items-center gap-3 border-b px-4 py-3">
+    <motion.div class="border-border-muted flex flex-wrap items-center gap-3 border-b px-4 py-3">
       <UInput
         :model-value="search"
         placeholder="Search file names…"
@@ -409,12 +423,26 @@
           @click="explorerView = 'table'"
         />
       </div>
-    </div>
+      <div class="ml-auto shrink-0">
+        <EGDataCollectionsFileTypeFilter
+          v-model:open="fileTypeFilterOpen"
+          :model-value="fileTypeFilter"
+          :counts="fileTypeCounts"
+          @update:model-value="emit('update:fileTypeFilter', $event)"
+        />
+      </div>
+    </motion.div>
     <div class="border-border-muted flex flex-wrap items-center gap-2 border-b bg-gray-50 px-4 py-2">
       <span class="text-xs font-semibold leading-snug text-gray-900">
         {{ visibleFiles.length }} {{ visibleSampleNoun }}
       </span>
-      <div class="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+      <motion.div class="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+        <EGDataCollectionsHiddenFileTypesPopover
+          v-if="hiddenByFileTypeCount > 0"
+          :hidden-count="hiddenByFileTypeCount"
+          :breakdown="hiddenByFileTypeBreakdown"
+          @open-file-type-filter="onOpenFileTypeFilterFromHiddenChip"
+        />
         <div
           v-for="chip in filterChipsResolved"
           :key="chip.chipId"
@@ -431,7 +459,7 @@
             @click="emit('clearFilter', chip.chipId)"
           />
         </div>
-      </div>
+      </motion.div>
       <div class="ml-auto flex shrink-0">
         <UButton v-if="selectedKeys.length" size="xs" variant="ghost" @click="emit('clearSelection')">
           Deselect all ({{ selectedKeys.length }})

--- a/packages/front-end/src/app/components/EGDataCollectionsFileTypeFilter.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsFileTypeFilter.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+  import type { DataCollectionFileTypeFilter } from '@FE/utils/data-collections-file-type';
+  import { fileTypeFilterTriggerLabel } from '@FE/utils/data-collections-file-type';
+
+  const props = defineProps<{
+    modelValue: DataCollectionFileTypeFilter;
+    counts: { fastq: number; fasta: number; other: number };
+  }>();
+
+  const emit = defineEmits<{
+    'update:modelValue': [value: DataCollectionFileTypeFilter];
+  }>();
+
+  const filterOpen = defineModel<boolean>('open', { default: false });
+
+  const triggerLabel = computed(() => fileTypeFilterTriggerLabel(props.modelValue));
+
+  const isFilterActive = computed(() => !(props.modelValue.fastq && props.modelValue.fasta && props.modelValue.other));
+
+  function setKind(kind: keyof DataCollectionFileTypeFilter, enabled: boolean): void {
+    emit('update:modelValue', { ...props.modelValue, [kind]: enabled });
+  }
+
+  const rows = [
+    {
+      kind: 'fastq' as const,
+      title: 'FASTQ',
+      description: 'Raw sequencing reads (.fastq.gz)',
+    },
+    {
+      kind: 'fasta' as const,
+      title: 'FASTA',
+      description: 'Reference genomes and assemblies (.fasta, .fa)',
+    },
+    {
+      kind: 'other' as const,
+      title: 'Workflow outputs & other',
+      description: 'Logs, CSV reports, HTML summaries, archives. Rarely used as inputs.',
+      separated: true,
+    },
+  ];
+</script>
+
+<template>
+  <UPopover v-model:open="filterOpen" :popper="{ placement: 'bottom-end' }">
+    <UButton
+      size="sm"
+      variant="outline"
+      color="gray"
+      trailing-icon="i-heroicons-chevron-down"
+      :class="{ 'ring-primary/30 ring-1': isFilterActive }"
+      :aria-expanded="filterOpen"
+      aria-haspopup="listbox"
+    >
+      {{ triggerLabel }}
+    </UButton>
+
+    <template #panel>
+      <div class="w-[min(17.5rem,calc(100vw-2rem))] py-1" role="listbox" aria-label="File type filter">
+        <template v-for="row in rows" :key="row.kind">
+          <div v-if="row.separated" class="mx-3 my-2 border-t border-gray-200" />
+          <div
+            class="flex items-start justify-evenly gap-2 px-3 py-2.5 hover:bg-gray-50"
+            role="option"
+            :aria-selected="modelValue[row.kind]"
+          >
+            <UCheckbox
+              class="mt-0.5 shrink-0"
+              :model-value="modelValue[row.kind]"
+              @update:model-value="setKind(row.kind, $event)"
+            />
+            <div class="min-w-0 max-w-[11rem] flex-1">
+              <div class="text-sm font-medium text-gray-900">{{ row.title }}</div>
+              <div class="text-muted text-xs leading-snug">{{ row.description }}</div>
+            </div>
+            <UBadge
+              size="xs"
+              class="bg-primary-muted text-primary-dark mt-0.5 shrink-0 rounded-xl border-0 font-serif tabular-nums ring-0"
+            >
+              {{ counts[row.kind] }}
+            </UBadge>
+          </div>
+        </template>
+
+        <div class="mt-1 border-t border-gray-200 px-3 py-2.5">
+          <p class="text-muted text-xs leading-relaxed">
+            FASTQ are the raw sequencing reads most workflows expect. FASTA includes reference genomes and assembled
+            outputs — needed for downstream workflows like phylogenetic comparison.
+          </p>
+        </div>
+      </div>
+    </template>
+  </UPopover>
+</template>

--- a/packages/front-end/src/app/components/EGDataCollectionsHiddenFileTypesPopover.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsHiddenFileTypesPopover.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+  import type { HiddenFileTypeBreakdownRow } from '@FE/utils/data-collections-file-type';
+
+  const props = defineProps<{
+    hiddenCount: number;
+    breakdown: HiddenFileTypeBreakdownRow[];
+  }>();
+
+  const emit = defineEmits<{
+    openFileTypeFilter: [];
+  }>();
+
+  const popoverOpen = ref(false);
+
+  function onOpenFileTypeFilterClick(): void {
+    popoverOpen.value = false;
+    emit('openFileTypeFilter');
+  }
+
+  const chipLabel = computed(() => {
+    const n = props.hiddenCount;
+    return n === 1 ? '1 hidden by file type' : `${n} hidden by file type`;
+  });
+
+  const headerLabel = computed(() => {
+    const n = props.hiddenCount;
+    const noun = n === 1 ? 'sample' : 'samples';
+    return `${n} ${noun} hidden by file type filter`;
+  });
+</script>
+
+<template>
+  <UPopover v-model:open="popoverOpen" :popper="{ placement: 'bottom-start' }">
+    <button
+      type="button"
+      class="text-muted inline-flex max-w-full items-center gap-1 rounded-full border border-gray-200 bg-white py-0.5 pl-2 pr-2.5 text-xs font-medium hover:bg-gray-100"
+      :aria-expanded="popoverOpen"
+      aria-haspopup="dialog"
+    >
+      <UIcon name="i-heroicons-eye" class="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+      <span class="truncate">{{ chipLabel }}</span>
+    </button>
+
+    <template #panel>
+      <div class="w-[min(17.5rem,calc(100vw-2rem))]">
+        <div class="border-b border-gray-200 px-3 py-3">
+          <h3 class="max-w-[14rem] text-sm font-semibold leading-snug text-gray-900">{{ headerLabel }}</h3>
+          <p class="text-muted mt-1.5 max-w-[14rem] text-xs leading-relaxed">
+            These samples don't contain any of the file types you've selected.
+            <button
+              type="button"
+              class="text-primary inline font-medium hover:underline"
+              @click="onOpenFileTypeFilterClick"
+            >
+              Use the filter to broaden the scope.
+            </button>
+          </p>
+        </div>
+
+        <ul class="max-h-56 overflow-y-auto py-2">
+          <li
+            v-for="row in breakdown"
+            :key="row.label"
+            class="flex items-center justify-between gap-3 px-3 py-1.5 text-sm"
+          >
+            <span class="min-w-0 truncate font-mono text-xs text-gray-800">{{ row.label }}</span>
+            <UBadge
+              size="xs"
+              class="shrink-0 rounded-xl border-0 bg-gray-100 font-serif tabular-nums text-gray-700 ring-0"
+            >
+              {{ row.count }}
+            </UBadge>
+          </li>
+        </ul>
+      </div>
+    </template>
+  </UPopover>
+</template>

--- a/packages/front-end/src/app/components/EGDataCollectionsPage.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsPage.vue
@@ -6,6 +6,13 @@
   } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/data-collections';
   import { useLabsStore, useToastStore, useUiStore } from '@FE/stores';
   import { isExpiringSoon } from '@FE/utils/data-collections-filters';
+  import {
+    dataCollectionFileKind,
+    enabledFileTypeKinds,
+    fileMatchesFileTypeFilter,
+    groupHiddenFilesByTypeLabel,
+    type DataCollectionFileTypeFilter,
+  } from '@FE/utils/data-collections-file-type';
 
   const props = defineProps<{
     labId: string;
@@ -109,6 +116,13 @@
   const tagsSectionExpanded = ref(true);
   const workflowsSectionExpanded = ref(true);
   const search = ref('');
+
+  /** File-type filter: default FASTQ only (see plan). */
+  const fileTypeFilterEnabled = ref<DataCollectionFileTypeFilter>({
+    fastq: true,
+    fasta: false,
+    other: false,
+  });
 
   const KEYS_CHUNK = 100;
 
@@ -519,7 +533,7 @@
     });
   }
 
-  const visibleFiles = computed(() => {
+  const filesBeforeFileTypeFilter = computed(() => {
     let list = filesMatchingSearch.value;
     const sf = scopeFilter.value;
     switch (sf.kind) {
@@ -556,6 +570,32 @@
       );
     }
     return list;
+  });
+
+  const enabledFileTypes = computed(() => enabledFileTypeKinds(fileTypeFilterEnabled.value));
+
+  const visibleFiles = computed(() => {
+    const kinds = enabledFileTypes.value;
+    return filesBeforeFileTypeFilter.value.filter((f) => fileMatchesFileTypeFilter(f.Key, kinds));
+  });
+
+  const fileTypeCounts = computed(() => {
+    const counts = { fastq: 0, fasta: 0, other: 0 };
+    for (const f of filesMatchingSearch.value) {
+      counts[dataCollectionFileKind(f.Key)] += 1;
+    }
+    return counts;
+  });
+
+  const hiddenByFileTypeCount = computed(() => {
+    const before = filesBeforeFileTypeFilter.value.length;
+    return before - visibleFiles.value.length;
+  });
+
+  const hiddenByFileTypeBreakdown = computed(() => {
+    const kinds = enabledFileTypes.value;
+    const hidden = filesBeforeFileTypeFilter.value.filter((f) => !fileMatchesFileTypeFilter(f.Key, kinds));
+    return groupHiddenFilesByTypeLabel(hidden);
   });
 
   /** Count for "All samples" chip — all loaded files matching search (same universe as no filter). */
@@ -1302,7 +1342,12 @@
             :listing-file-count="files.length"
             :listing-truncated="listingTruncated"
             :filter-chips="explorerFilterChips"
+            :file-type-filter="fileTypeFilterEnabled"
+            :file-type-counts="fileTypeCounts"
+            :hidden-by-file-type-count="hiddenByFileTypeCount"
+            :hidden-by-file-type-breakdown="hiddenByFileTypeBreakdown"
             @update:search="search = $event"
+            @update:file-type-filter="fileTypeFilterEnabled = $event"
             @update:selected-keys="selectedKeys = $event"
             @toggle-key="toggleKey"
             @select-all-displayed="selectAllDisplayed"

--- a/packages/front-end/src/app/utils/data-collections-file-type.ts
+++ b/packages/front-end/src/app/utils/data-collections-file-type.ts
@@ -1,0 +1,104 @@
+/**
+ * File-kind helpers for the Data Collections explorer file-type filter.
+ * Classification drives the three checkbox filter rows; extension labels drive
+ * the "hidden by file type" popout breakdown.
+ */
+
+export type DataCollectionFileKind = 'fastq' | 'fasta' | 'other';
+
+export type DataCollectionFileTypeFilter = {
+  fastq: boolean;
+  fasta: boolean;
+  other: boolean;
+};
+
+export type HiddenFileTypeBreakdownRow = {
+  label: string;
+  count: number;
+};
+
+const NO_EXTENSION_LABEL = '(no extension)';
+
+/** Multi-part extensions checked before single-dot suffixes on the basename. */
+const HIDDEN_MULTI_SUFFIXES = ['.fastq.gz', '.fq.gz'] as const;
+
+/** Hidden popout list: these labels appear first, in this order; all others follow A–Z. */
+const HIDDEN_BREAKDOWN_PRIORITY_LABELS = ['.fastq.gz', '.fasta', '.fa'] as const;
+
+function hiddenBreakdownLabelSortRank(label: string): number {
+  const idx = (HIDDEN_BREAKDOWN_PRIORITY_LABELS as readonly string[]).indexOf(label);
+  return idx >= 0 ? idx : HIDDEN_BREAKDOWN_PRIORITY_LABELS.length;
+}
+
+function basenameFromS3Key(s3Key: string): string {
+  const parts = s3Key.split('/').filter(Boolean);
+  return parts[parts.length - 1] || s3Key;
+}
+
+/**
+ * Coarse kind used by the FASTQ / FASTA / Other filter checkboxes.
+ */
+export function dataCollectionFileKind(s3Key: string): DataCollectionFileKind {
+  const name = basenameFromS3Key(s3Key).toLowerCase();
+  if (name.endsWith('.fastq.gz') || name.endsWith('.fq.gz') || name.endsWith('.fastq') || name.endsWith('.fq')) {
+    return 'fastq';
+  }
+  if (name.endsWith('.fasta') || name.endsWith('.fa')) {
+    return 'fasta';
+  }
+  return 'other';
+}
+
+export function enabledFileTypeKinds(filter: DataCollectionFileTypeFilter): Set<DataCollectionFileKind> {
+  const kinds = new Set<DataCollectionFileKind>();
+  if (filter.fastq) kinds.add('fastq');
+  if (filter.fasta) kinds.add('fasta');
+  if (filter.other) kinds.add('other');
+  return kinds;
+}
+
+/** OR semantics: file is visible when its kind is among the enabled set. */
+export function fileMatchesFileTypeFilter(s3Key: string, enabledKinds: Set<DataCollectionFileKind>): boolean {
+  if (enabledKinds.size === 0) return false;
+  return enabledKinds.has(dataCollectionFileKind(s3Key));
+}
+
+/**
+ * Extension-centric label for the hidden-files popout (not the three filter bucket names).
+ */
+export function dataCollectionHiddenTypeLabel(s3Key: string): string {
+  const name = basenameFromS3Key(s3Key).toLowerCase();
+  for (const suffix of HIDDEN_MULTI_SUFFIXES) {
+    if (name.endsWith(suffix)) return suffix;
+  }
+  const dot = name.lastIndexOf('.');
+  if (dot <= 0) return NO_EXTENSION_LABEL;
+  return name.slice(dot);
+}
+
+export function groupHiddenFilesByTypeLabel(files: readonly { Key: string }[]): HiddenFileTypeBreakdownRow[] {
+  const counts = new Map<string, number>();
+  for (const f of files) {
+    const label = dataCollectionHiddenTypeLabel(f.Key);
+    counts.set(label, (counts.get(label) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([label, count]) => ({ label, count }))
+    .sort((a, b) => {
+      const rankDiff = hiddenBreakdownLabelSortRank(a.label) - hiddenBreakdownLabelSortRank(b.label);
+      if (rankDiff !== 0) return rankDiff;
+      return a.label.localeCompare(b.label);
+    });
+}
+
+export function fileTypeFilterTriggerLabel(filter: DataCollectionFileTypeFilter): string {
+  const enabled: string[] = [];
+  if (filter.fastq) enabled.push('FASTQ');
+  if (filter.fasta) enabled.push('FASTA');
+  if (filter.other) enabled.push('Workflow outputs & other');
+  if (enabled.length === 0) return 'No file types';
+  if (enabled.length === 3) return 'All file types';
+  if (enabled.length === 1) return enabled[0]!;
+  if (enabled.length === 2) return enabled.join(', ');
+  return 'All file types';
+}

--- a/packages/front-end/test/app/utils/data-collections-file-type.test.ts
+++ b/packages/front-end/test/app/utils/data-collections-file-type.test.ts
@@ -1,0 +1,80 @@
+import {
+  dataCollectionFileKind,
+  dataCollectionHiddenTypeLabel,
+  fileMatchesFileTypeFilter,
+  groupHiddenFilesByTypeLabel,
+} from '../../../src/app/utils/data-collections-file-type';
+
+describe('dataCollectionFileKind', () => {
+  it('classifies FASTQ extensions', () => {
+    expect(dataCollectionFileKind('org/lab/read1.fastq.gz')).toBe('fastq');
+    expect(dataCollectionFileKind('org/lab/read2.fq.gz')).toBe('fastq');
+    expect(dataCollectionFileKind('org/lab/read3.fastq')).toBe('fastq');
+    expect(dataCollectionFileKind('org/lab/read4.fq')).toBe('fastq');
+  });
+
+  it('classifies FASTA extensions (.fasta before .fa)', () => {
+    expect(dataCollectionFileKind('org/lab/ref.fasta')).toBe('fasta');
+    expect(dataCollectionFileKind('org/lab/ref.fa')).toBe('fasta');
+    expect(dataCollectionFileKind('org/lab/ref.FASTA')).toBe('fasta');
+  });
+
+  it('classifies other extensions', () => {
+    expect(dataCollectionFileKind('org/lab/report.csv')).toBe('other');
+    expect(dataCollectionFileKind('org/lab/summary.html')).toBe('other');
+    expect(dataCollectionFileKind('org/lab/README')).toBe('other');
+  });
+
+  it('does not treat .fastq as .fa', () => {
+    expect(dataCollectionFileKind('org/lab/sample.fastq')).toBe('fastq');
+  });
+});
+
+describe('fileMatchesFileTypeFilter', () => {
+  it('matches OR semantics across enabled kinds', () => {
+    const enabled = new Set(['fastq', 'fasta'] as const);
+    expect(fileMatchesFileTypeFilter('a.fastq.gz', enabled)).toBe(true);
+    expect(fileMatchesFileTypeFilter('b.fasta', enabled)).toBe(true);
+    expect(fileMatchesFileTypeFilter('c.csv', enabled)).toBe(false);
+  });
+
+  it('returns false when no kinds are enabled', () => {
+    expect(fileMatchesFileTypeFilter('a.fastq.gz', new Set())).toBe(false);
+  });
+});
+
+describe('dataCollectionHiddenTypeLabel', () => {
+  it('uses multi-part suffixes when present', () => {
+    expect(dataCollectionHiddenTypeLabel('org/lab/read.fastq.gz')).toBe('.fastq.gz');
+    expect(dataCollectionHiddenTypeLabel('org/lab/read.fq.gz')).toBe('.fq.gz');
+  });
+
+  it('uses single extension otherwise', () => {
+    expect(dataCollectionHiddenTypeLabel('org/lab/ref.fasta')).toBe('.fasta');
+    expect(dataCollectionHiddenTypeLabel('org/lab/report.csv')).toBe('.csv');
+  });
+
+  it('returns fallback for extensionless basenames', () => {
+    expect(dataCollectionHiddenTypeLabel('org/lab/README')).toBe('(no extension)');
+  });
+});
+
+describe('groupHiddenFilesByTypeLabel', () => {
+  it('pins .fastq.gz, .fasta, and .fa to the top; other labels alphabetical below', () => {
+    const rows = groupHiddenFilesByTypeLabel([
+      { Key: 'a.csv' },
+      { Key: 'b.csv' },
+      { Key: 'c.fasta' },
+      { Key: 'd.html' },
+      { Key: 'e.fa' },
+      { Key: 'f.fastq.gz' },
+    ]);
+    expect(rows.map((r) => r.label)).toEqual(['.fastq.gz', '.fasta', '.fa', '.csv', '.html']);
+    expect(rows.find((r) => r.label === '.csv')?.count).toBe(2);
+  });
+
+  it('omits missing priority labels and still sorts the rest', () => {
+    const rows = groupHiddenFilesByTypeLabel([{ Key: 'a.zip' }, { Key: 'b.csv' }]);
+    expect(rows.map((r) => r.label)).toEqual(['.csv', '.zip']);
+  });
+});


### PR DESCRIPTION
## Add file type filter and hidden-files insight to Data Collections explorer

## Type of Change*
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
Adds a file-type filter to the Data Collections explorer so users can narrow the S3 file grid to the kinds of inputs they care about, with clear feedback when files are excluded.

### File type filter (header, top right)
- New dropdown in the explorer header (right of search / view toggle) with three non-exclusive checkbox options:
  - **FASTQ** — raw sequencing reads (`.fastq.gz`, plus `.fq.gz`, `.fastq`, `.fq`)
  - **FASTA** — reference genomes and assemblies (`.fasta`, `.fa`)
  - **Workflow outputs & other** — everything else (logs, CSV, HTML, archives, etc.)
- **Default:** only FASTQ is selected on load.
- **OR semantics:** a file is shown if its classified kind matches any checked option.
- **None selected:** grid is empty, trigger label reads **"No file types"**, and the existing "no files match filters" empty state is shown.
- Per-option count badges reflect the search-scoped listing (same universe as left-rail counts).
- Footer note explains FASTQ vs FASTA usage.

### Filtering pipeline
- `EGDataCollectionsPage` applies file-type filtering after search, scope, and tag filters via `filesBeforeFileTypeFilter` → `visibleFiles`.
- Classification and helpers live in `data-collections-file-type.ts` (testable, no Vue dependency).

### "Hidden by file type" chip and popover
- When file-type filtering hides files, a separate chip appears in the gray filter row (not a dismissible scope/tag chip): eye icon + **"N hidden by file type"**.
- Clicking opens a popover with:
  - Header: **"N sample(s) hidden by file type filter"**
  - Subheader with a link: **"Use the filter to broaden the scope"** — closes the popover and opens the file-type dropdown.
  - A dynamic breakdown of hidden extensions (e.g. `.fastq.gz`, `.fasta`, `.csv`), **not** the three filter bucket names.
- Breakdown sort: `.fastq.gz`, `.fasta`, `.fa` pinned to the top (in that order when present); all other extensions A–Z below.

### New / updated files
| File | Purpose |
|------|---------|
| `packages/front-end/src/app/utils/data-collections-file-type.ts` | Classification, filter match, hidden label grouping, trigger label |
| `packages/front-end/test/app/utils/data-collections-file-type.test.ts` | Unit tests |
| `packages/front-end/src/app/components/EGDataCollectionsFileTypeFilter.vue` | Filter dropdown UI |
| `packages/front-end/src/app/components/EGDataCollectionsHiddenFileTypesPopover.vue` | Hidden chip + popover UI |
| `packages/front-end/src/app/components/EGDataCollectionsPage.vue` | State, counts, pipeline wiring |
| `packages/front-end/src/app/components/EGDataCollectionsExplorer.vue` | Header placement, props/events |

## Testing*
- [x] `pnpm exec jest test/app/utils/data-collections-file-type.test.ts` — classification, OR filter semantics, hidden label extraction, breakdown sort order.
- [ ] Manual — Data Collections tab in a lab with mixed file types:
  - Default shows FASTQ only; counts and grid match.
  - Toggle FASTA / Other; grid updates with OR behavior.
  - Uncheck all types → empty grid, "No file types" trigger, hidden chip lists all excluded files.
  - Hidden chip popover: priority sort, extension breakdown, link opens file-type filter.
  - Hidden chip respects search + left-rail scope/tag filters.
  - Scope/tag chips still dismiss independently.

## Impact
- **Behaviour:** Users see a FASTQ-first view by default; non-FASTQ files remain in the listing but are hidden until enabled.
- **Performance:** Filtering is client-side on the already-loaded listing; no new API calls.
- **Dependencies:** None.
- **Scope:** Front-end only; no backend or S3 listing changes.

## Additional Information
- Extension matching for FASTQ includes `.fq` / `.fq.gz` for common naming variants; UI copy emphasizes `.fastq.gz`.
- `.fasta` is checked before `.fa` when classifying so `ref.fasta` is not treated as `.fa` only.
- File-type filter open state is coordinated in the explorer via `v-model:open` so the hidden popover can open the dropdown programmatically.

## Checklist*
- [ ] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [ ] Code adheres to the coding and style guidelines of the project.
- [ ] Code has been commented in particularly hard-to-understand areas.