### PR TITLE
feat: run workflows from data collections

### DIFF
--- a/packages/front-end/src/app/components/EGDataCollectionsPage.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsPage.vue
@@ -154,22 +154,6 @@
         (!!lab.value?.NextFlowTowerEnabled && !!lab.value?.HasNextFlowTowerAccessToken)),
   );
 
-  const tagsOnSelectionForRunModal = computed(() =>
-    tagsOnSelection.value.map((row) => ({
-      ...row,
-      name: tagById(row.tagId)?.Name ?? row.tagId,
-      kind: tagById(row.tagId)?.Kind,
-    })),
-  );
-
-  const neverAnalyzedCountOnSelection = computed(
-    () => selectedKeys.value.filter((key) => runCountForFileKey(key) === 0).length,
-  );
-
-  const previouslyAnalyzedCountOnSelection = computed(
-    () => selectedKeys.value.filter((key) => runCountForFileKey(key) > 0).length,
-  );
-
   function openRunWorkflowModal(): void {
     showRunWorkflowModal.value = true;
   }
@@ -467,6 +451,23 @@
 
   /** Tag ids that appear on at least one selected file (for Remove column list). */
   const removableTagIds = computed(() => tagsOnSelection.value.map((t) => t.tagId));
+
+  /** Comma-separated unique batch names for the run-workflow modal (sorted). */
+  const runModalAcrossBatchesSummary = computed(() => changeBatchCurrentlyInLine.value);
+
+  /** Comma-separated unique standard/permanent tag names on the selection (sorted). */
+  const runModalTagsPresentSummary = computed(() => {
+    const names = tagsOnSelection.value.map((row) => tagById(row.tagId)?.Name ?? row.tagId);
+    if (!names.length) return '—';
+    return names.join(', ');
+  });
+
+  const runModalPreviouslyAnalyzedSummary = computed(() => {
+    const total = selectedKeys.value.length;
+    if (!total) return '—';
+    const analyzed = selectedKeys.value.filter((key) => runCountForFileKey(key) > 0).length;
+    return `${analyzed} of ${total}`;
+  });
 
   async function loadTags(): Promise<void> {
     uiStore.setRequestPending('dataCollectionsTags');
@@ -1562,12 +1563,10 @@
       :lab-id="labId"
       :lab="lab"
       :selected-keys="selectedKeys"
-      :tags-on-selection="tagsOnSelectionForRunModal"
-      :batch-names-summary="changeBatchCurrentlyInLine"
-      :never-analyzed-count="neverAnalyzedCountOnSelection"
-      :previously-analyzed-count="previouslyAnalyzedCountOnSelection"
+      :across-batches-summary="runModalAcrossBatchesSummary"
+      :tags-present-summary="runModalTagsPresentSummary"
+      :previously-analyzed-summary="runModalPreviouslyAnalyzedSummary"
       :listing-truncated="listingTruncated"
-      :tag-by-id="tagById"
     />
 
     <UModal

--- a/packages/front-end/src/app/components/EGDataCollectionsPage.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsPage.vue
@@ -144,6 +144,35 @@
   const bulkPanelBusy = computed(() => uiStore.isRequestPending('dataCollectionsMutate'));
 
   const hasSelection = computed(() => selectedKeys.value.length > 0);
+
+  const showRunWorkflowModal = ref(false);
+
+  const canRunWorkflow = computed(
+    () =>
+      !!lab.value?.S3Bucket &&
+      (!!lab.value?.AwsHealthOmicsEnabled ||
+        (!!lab.value?.NextFlowTowerEnabled && !!lab.value?.HasNextFlowTowerAccessToken)),
+  );
+
+  const tagsOnSelectionForRunModal = computed(() =>
+    tagsOnSelection.value.map((row) => ({
+      ...row,
+      name: tagById(row.tagId)?.Name ?? row.tagId,
+      kind: tagById(row.tagId)?.Kind,
+    })),
+  );
+
+  const neverAnalyzedCountOnSelection = computed(
+    () => selectedKeys.value.filter((key) => runCountForFileKey(key) === 0).length,
+  );
+
+  const previouslyAnalyzedCountOnSelection = computed(
+    () => selectedKeys.value.filter((key) => runCountForFileKey(key) > 0).length,
+  );
+
+  function openRunWorkflowModal(): void {
+    showRunWorkflowModal.value = true;
+  }
   const bulkPanelOpen = computed(() => bulkPanelMode.value !== 'closed');
 
   function tagById(id: string): LaboratoryDataTag | undefined {
@@ -1375,6 +1404,14 @@
               <UButton size="sm" variant="outline" :disabled="bulkPanelBusy" @click="openChangeBatchModal">
                 Change Batch
               </UButton>
+              <UButton
+                size="sm"
+                icon="i-heroicons-play"
+                :disabled="bulkPanelBusy || !canRunWorkflow"
+                @click="openRunWorkflowModal"
+              >
+                Run workflow
+              </UButton>
             </div>
           </div>
         </div>
@@ -1519,6 +1556,19 @@
         </div>
       </div>
     </div>
+
+    <EGRunFromCollectionsModal
+      v-model="showRunWorkflowModal"
+      :lab-id="labId"
+      :lab="lab"
+      :selected-keys="selectedKeys"
+      :tags-on-selection="tagsOnSelectionForRunModal"
+      :batch-names-summary="changeBatchCurrentlyInLine"
+      :never-analyzed-count="neverAnalyzedCountOnSelection"
+      :previously-analyzed-count="previouslyAnalyzedCountOnSelection"
+      :listing-truncated="listingTruncated"
+      :tag-by-id="tagById"
+    />
 
     <UModal
       v-model="showChangeBatchModal"

--- a/packages/front-end/src/app/components/EGRunFormUploadData.vue
+++ b/packages/front-end/src/app/components/EGRunFormUploadData.vue
@@ -12,7 +12,11 @@
     UploadedFileInfo,
     UploadedFilePairInfo,
   } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/upload/s3-file-upload-sample-sheet';
-  import { extractS3KeysFromCsv, validateSampleSheetFile } from '@FE/utils/sample-sheet-utils';
+  import {
+    buildSampleSheetFileName,
+    extractS3KeysFromCsv,
+    validateSampleSheetFile,
+  } from '@FE/utils/sample-sheet-utils';
   import { useToastStore } from '@FE/stores';
   import { useNetwork } from '@vueuse/core';
   import { RunType } from '@easy-genomics/shared-lib/src/app/types/base-entity';
@@ -112,6 +116,18 @@
   );
 
   const hasSampleSheetUrl = computed<boolean>(() => !!wipRun.value.sampleSheetS3Url);
+
+  /** Files were selected on Data Collections; sample sheet was generated without browser upload. */
+  const isFromDataCollections = computed<boolean>(() => {
+    const hasPreSeededSheet = !!wipRun.value.sampleSheetS3Url;
+    const hasInputKeys = (wipRun.value.inputFileKeys?.length ?? 0) > 0;
+    const noUploadedFiles = !wipRun.value.files?.length;
+    return hasPreSeededSheet && hasInputKeys && noUploadedFiles;
+  });
+
+  const dataCollectionsFileBasenames = computed<string[]>(() =>
+    (wipRun.value.inputFileKeys ?? []).map((key) => key.split('/').pop() || key).sort((a, b) => a.localeCompare(b)),
+  );
 
   const haveUnmatchedFiles = computed<boolean>(() =>
     filePairs.value.some((filePair) => !filePair.r1File || !filePair.r2File),
@@ -619,9 +635,7 @@
   async function getSampleSheetCsv(uploadedFilePairs: UploadedFilePairInfo[]): Promise<SampleSheetResponse> {
     if (!wipRun.value.transactionId) throw new Error('no transaction id on wip run');
 
-    const sampleSheetName: string = wipRun.value.runName
-      ? `samplesheet-${wipRun.value.runName}.csv`
-      : 'samplesheet.csv';
+    const sampleSheetName: string = buildSampleSheetFileName(wipRun.value.runName);
 
     const request: SampleSheetRequest = {
       SampleSheetName: sampleSheetName,
@@ -955,165 +969,185 @@
   <EGCard>
     <EGText tag="small" class="mb-4">Step 02</EGText>
     <EGText tag="h4" class="mb-4">Upload Data</EGText>
-    <p class="text-muted mt-1 text-xs font-normal tracking-tight">
-      Any similar files with the suffix _R1 or _R2 will be combined as paired-end data samples. Max file size is 5GB.
-      <button
-        type="button"
-        class="text-primary ml-1 underline hover:opacity-80"
-        @click="showAdvancedOptions = !showAdvancedOptions"
-      >
-        {{ showAdvancedOptions ? 'Collapse advanced options' : 'View advanced options' }}
-      </button>
-    </p>
 
-    <div v-if="showAdvancedOptions" class="mt-4">
-      <UDivider />
-      <label class="text-body mb-1 mt-4 block text-sm font-medium">Sample ID split pattern</label>
-      <UInput v-model="sampleIdSplitPattern" class="w-64" />
-      <p class="text-muted mb-4 mt-1 text-xs">
-        Enter the character or pattern that appears after the Sample ID in your file names (e.g. _S, _L001, etc.).
+    <template v-if="isFromDataCollections">
+      <p class="text-muted mb-4 text-sm">
+        {{ dataCollectionsFileBasenames.length }} file(s) from Data Collections are included in this run. A sample sheet
+        has already been generated.
       </p>
-    </div>
+      <div class="mb-4 max-h-48 overflow-y-auto rounded-lg border border-gray-100 bg-gray-50 px-3 py-2">
+        <ul class="space-y-1 text-sm">
+          <li v-for="name in dataCollectionsFileBasenames" :key="name" class="truncate font-mono text-xs">
+            {{ name }}
+          </li>
+        </ul>
+      </div>
+      <UDivider class="py-4" />
+    </template>
 
-    <UDivider class="py-4" />
-    <div
-      class="py-4"
-      @drop.prevent="handleDroppedFiles"
-      :class="{ 'pointer-events-none opacity-50': !isDropzoneEnabled }"
-    >
+    <template v-else>
+      <p class="text-muted mt-1 text-xs font-normal tracking-tight">
+        Any similar files with the suffix _R1 or _R2 will be combined as paired-end data samples. Max file size is 5GB.
+        <button
+          type="button"
+          class="text-primary ml-1 underline hover:opacity-80"
+          @click="showAdvancedOptions = !showAdvancedOptions"
+        >
+          {{ showAdvancedOptions ? 'Collapse advanced options' : 'View advanced options' }}
+        </button>
+      </p>
+
+      <div v-if="showAdvancedOptions" class="mt-4">
+        <UDivider />
+        <label class="text-body mb-1 mt-4 block text-sm font-medium">Sample ID split pattern</label>
+        <UInput v-model="sampleIdSplitPattern" class="w-64" />
+        <p class="text-muted mb-4 mt-1 text-xs">
+          Enter the character or pattern that appears after the Sample ID in your file names (e.g. _S, _L001, etc.).
+        </p>
+      </div>
+
+      <UDivider class="py-4" />
       <div
-        id="dropzone"
-        @dragenter.prevent="setDropzoneActive(true)"
-        @dragleave.prevent="setDropzoneActive(false)"
-        @dragover.prevent
-        @drop.prevent="setDropzoneActive(false)"
+        class="py-4"
+        @drop.prevent="handleDroppedFiles"
+        :class="{ 'pointer-events-none opacity-50': !isDropzoneEnabled }"
       >
         <div
-          :class="
-            cn(
-              'ring-primary-500 text-body flex w-full items-center justify-center rounded-lg py-8 ring-2 ring-offset-1 transition-colors duration-200',
-              {
-                'bg-alert-success-muted ring-alert-success font-semibold ring-offset-2': isDropzoneActive,
-              },
-            )
-          "
+          id="dropzone"
+          @dragenter.prevent="setDropzoneActive(true)"
+          @dragleave.prevent="setDropzoneActive(false)"
+          @dragover.prevent
+          @drop.prevent="setDropzoneActive(false)"
         >
-          <div class="flex items-center justify-center">
-            <div>
-              <span :class="cn('visible', { 'invisible': isDropzoneActive })">Drag and&nbsp;</span>
-              <span v-if="isDropzoneActive">Drop</span>
-              <span v-else>drop</span>
-              your files
-              <span :class="cn('visible', { 'invisible': isDropzoneActive })">here or</span>
-            </div>
-            <input
-              accept=".gz,.fastq"
-              ref="chooseFilesButton"
-              type="file"
-              id="dropzoneFiles"
-              @change="handleFileInputChange"
-              hidden
-              multiple
-            />
-            <EGButton
-              :disabled="!isDropzoneEnabled"
-              :class="cn('visible ml-4', { 'invisible': isDropzoneActive })"
-              @click="chooseFiles"
-              label="Choose Files"
-              size="sm"
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <!-- Hidden CSV file input for custom sample sheet -->
-    <input ref="sampleSheetFileInput" type="file" accept=".csv" hidden @change="handleSampleSheetFileChange" />
-
-    <div class="files-list mb-6" v-if="filesForTable.length > 0">
-      <div class="files-list-header text-body mb-4 border-b border-[#d9d9d9]">
-        <div class="file-cell sample-id flex w-[30%] min-w-[240px]">Sample ID</div>
-        <div class="file-cell flex w-[60%] min-w-[320px]">Sample File</div>
-        <div class="file-cell flex w-[10%] min-w-[70px]"></div>
-      </div>
-      <div class="files-list-body">
-        <div
-          v-for="(row, index) in filesForTable"
-          :key="row.fileName"
-          class="file-row"
-          :style="{
-            background: row.error
-              ? '#FFF2F0'
-              : row.progress === 100
-                ? '#E2FBE8'
-                : row.progress !== undefined && row.progress > 0
-                  ? `linear-gradient(to right, #E2FBE8 ${row.progress}%, transparent ${Math.min(row.progress + 10, 100)}%), #f7f7f7`
-                  : '#f7f7f7',
-          }"
-        >
-          <div class="file-cell sample-id text-body flex w-[30%] min-w-[240px] items-center">
-            <div v-if="!row.error" class="truncate">{{ row.sampleId }}</div>
-            <div v-else class="text-alert-danger-dark mr-1 truncate font-medium">(Upload Failed)</div>
-          </div>
           <div
-            class="file-cell flex w-[60%] min-w-[320px] items-center"
-            :style="{ color: row.progress === 100 && !row.error ? '#306239' : 'inherit' }"
+            :class="
+              cn(
+                'ring-primary-500 text-body flex w-full items-center justify-center rounded-lg py-8 ring-2 ring-offset-1 transition-colors duration-200',
+                {
+                  'bg-alert-success-muted ring-alert-success font-semibold ring-offset-2': isDropzoneActive,
+                },
+              )
+            "
           >
-            <template v-if="row.error">
-              <UIcon name="i-heroicons-exclamation-triangle" class="text-alert-danger-dark mr-2" size="20" />
-            </template>
-            <div class="truncate">{{ row.fileName }}</div>
-          </div>
-
-          <div class="file-cell flex w-[10%] min-w-[70px] items-center justify-end gap-4">
-            <!-- retry button -->
-            <button
-              v-if="row.error"
-              class="flex items-center"
-              :class="[canRetryUpload(row) ? 'text-gray-900 hover:text-gray-700' : 'cursor-not-allowed text-gray-400']"
-              @click="retryUpload(row)"
-              :disabled="!isOnline || !canRetryUpload(row)"
-            >
-              <UIcon name="i-heroicons-arrow-path" size="20" />
-            </button>
-
-            <!-- complete check -->
-            <UIcon
-              v-if="!row.error && row.progress === 100"
-              size="20"
-              name="i-heroicons-check"
-              class="text-alert-success-text"
-            />
-
-            <!-- cancel upload button -->
-            <button
-              v-if="!row.error && row.progress && row.progress < 100"
-              class="flex items-center text-gray-500 hover:text-gray-700"
-              @click="cancelUpload(row.fileName)"
-            >
-              <UIcon name="i-heroicons-x-mark" size="20" />
-            </button>
-
-            <!-- delete button -->
-            <button
-              class="flex items-center"
-              :disabled="!isOnline || uploadStatus === 'uploading'"
-              :class="[
-                isOnline && uploadStatus !== 'uploading'
-                  ? 'text-alert-danger hover:text-alert-danger-dark'
-                  : 'cursor-not-allowed text-gray-400',
-              ]"
-              @click="removeFile(row)"
-            >
-              <UIcon name="i-heroicons-trash" size="20" />
-            </button>
+            <div class="flex items-center justify-center">
+              <div>
+                <span :class="cn('visible', { 'invisible': isDropzoneActive })">Drag and&nbsp;</span>
+                <span v-if="isDropzoneActive">Drop</span>
+                <span v-else>drop</span>
+                your files
+                <span :class="cn('visible', { 'invisible': isDropzoneActive })">here or</span>
+              </div>
+              <input
+                accept=".gz,.fastq"
+                ref="chooseFilesButton"
+                type="file"
+                id="dropzoneFiles"
+                @change="handleFileInputChange"
+                hidden
+                multiple
+              />
+              <EGButton
+                :disabled="!isDropzoneEnabled"
+                :class="cn('visible ml-4', { 'invisible': isDropzoneActive })"
+                @click="chooseFiles"
+                label="Choose Files"
+                size="sm"
+              />
+            </div>
           </div>
         </div>
       </div>
-    </div>
+
+      <!-- Hidden CSV file input for custom sample sheet -->
+      <input ref="sampleSheetFileInput" type="file" accept=".csv" hidden @change="handleSampleSheetFileChange" />
+
+      <div class="files-list mb-6" v-if="filesForTable.length > 0">
+        <div class="files-list-header text-body mb-4 border-b border-[#d9d9d9]">
+          <div class="file-cell sample-id flex w-[30%] min-w-[240px]">Sample ID</div>
+          <div class="file-cell flex w-[60%] min-w-[320px]">Sample File</div>
+          <div class="file-cell flex w-[10%] min-w-[70px]"></div>
+        </div>
+        <div class="files-list-body">
+          <div
+            v-for="(row, index) in filesForTable"
+            :key="row.fileName"
+            class="file-row"
+            :style="{
+              background: row.error
+                ? '#FFF2F0'
+                : row.progress === 100
+                  ? '#E2FBE8'
+                  : row.progress !== undefined && row.progress > 0
+                    ? `linear-gradient(to right, #E2FBE8 ${row.progress}%, transparent ${Math.min(row.progress + 10, 100)}%), #f7f7f7`
+                    : '#f7f7f7',
+            }"
+          >
+            <div class="file-cell sample-id text-body flex w-[30%] min-w-[240px] items-center">
+              <div v-if="!row.error" class="truncate">{{ row.sampleId }}</div>
+              <div v-else class="text-alert-danger-dark mr-1 truncate font-medium">(Upload Failed)</div>
+            </div>
+            <div
+              class="file-cell flex w-[60%] min-w-[320px] items-center"
+              :style="{ color: row.progress === 100 && !row.error ? '#306239' : 'inherit' }"
+            >
+              <template v-if="row.error">
+                <UIcon name="i-heroicons-exclamation-triangle" class="text-alert-danger-dark mr-2" size="20" />
+              </template>
+              <div class="truncate">{{ row.fileName }}</div>
+            </div>
+
+            <div class="file-cell flex w-[10%] min-w-[70px] items-center justify-end gap-4">
+              <!-- retry button -->
+              <button
+                v-if="row.error"
+                class="flex items-center"
+                :class="[
+                  canRetryUpload(row) ? 'text-gray-900 hover:text-gray-700' : 'cursor-not-allowed text-gray-400',
+                ]"
+                @click="retryUpload(row)"
+                :disabled="!isOnline || !canRetryUpload(row)"
+              >
+                <UIcon name="i-heroicons-arrow-path" size="20" />
+              </button>
+
+              <!-- complete check -->
+              <UIcon
+                v-if="!row.error && row.progress === 100"
+                size="20"
+                name="i-heroicons-check"
+                class="text-alert-success-text"
+              />
+
+              <!-- cancel upload button -->
+              <button
+                v-if="!row.error && row.progress && row.progress < 100"
+                class="flex items-center text-gray-500 hover:text-gray-700"
+                @click="cancelUpload(row.fileName)"
+              >
+                <UIcon name="i-heroicons-x-mark" size="20" />
+              </button>
+
+              <!-- delete button -->
+              <button
+                class="flex items-center"
+                :disabled="!isOnline || uploadStatus === 'uploading'"
+                :class="[
+                  isOnline && uploadStatus !== 'uploading'
+                    ? 'text-alert-danger hover:text-alert-danger-dark'
+                    : 'cursor-not-allowed text-gray-400',
+                ]"
+                @click="removeFile(row)"
+              >
+                <UIcon name="i-heroicons-trash" size="20" />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </template>
 
     <div
-      v-if="filesProblemAlertMessage"
+      v-if="!isFromDataCollections && filesProblemAlertMessage"
       class="bg-alert-danger-muted text-alert-danger my-10 flex items-center gap-2 rounded-lg p-6"
     >
       <UIcon class="text-2xl" name="i-heroicons-exclamation-triangle" />
@@ -1132,7 +1166,7 @@
       :display-label="true"
     />
 
-    <div class="flex items-center justify-between pt-4">
+    <div v-if="!isFromDataCollections" class="flex items-center justify-between pt-4">
       <EGButton
         variant="secondary"
         label="Upload Sample Sheet"

--- a/packages/front-end/src/app/components/EGRunFromCollectionsModal.vue
+++ b/packages/front-end/src/app/components/EGRunFromCollectionsModal.vue
@@ -1,0 +1,375 @@
+<script setup lang="ts">
+  import { z } from 'zod';
+  import { v4 as uuidv4 } from 'uuid';
+  import type { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
+  import type { LaboratoryDataTag } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/data-collections';
+  import { RunType } from '@easy-genomics/shared-lib/src/app/types/base-entity';
+  import {
+    useLabsStore,
+    useOmicsWorkflowsStore,
+    useRunStore,
+    useSeqeraPipelinesStore,
+    useToastStore,
+    useUiStore,
+    useUserStore,
+  } from '@FE/stores';
+  import { buildUploadedFilePairsFromKeys } from '@FE/utils/data-collections-to-sample-sheet';
+  import { buildSampleSheetFileName } from '@FE/utils/sample-sheet-utils';
+
+  export type RunFromCollectionsTagRow = { tagId: string; count: number; name: string; kind?: string };
+
+  export type WorkflowPickerOption = {
+    key: string;
+    id: string;
+    label: string;
+    platform: RunType;
+    description?: string;
+  };
+
+  const props = defineProps<{
+    modelValue: boolean;
+    labId: string;
+    lab: Laboratory | null;
+    selectedKeys: string[];
+    tagsOnSelection: RunFromCollectionsTagRow[];
+    batchNamesSummary: string;
+    neverAnalyzedCount: number;
+    previouslyAnalyzedCount: number;
+    listingTruncated: boolean;
+    tagById: (tagId: string) => LaboratoryDataTag | undefined;
+  }>();
+
+  const emit = defineEmits<{
+    'update:modelValue': [value: boolean];
+  }>();
+
+  const { $api } = useNuxtApp();
+  const runStore = useRunStore();
+  const omicsWorkflowsStore = useOmicsWorkflowsStore();
+  const seqeraPipelinesStore = useSeqeraPipelinesStore();
+  const userStore = useUserStore();
+  const toast = useToastStore();
+  const uiStore = useUiStore();
+
+  const runName = ref('');
+  const selectedWorkflowKey = ref<string | undefined>(undefined);
+  const isContinuing = ref(false);
+  const loadError = ref<string | null>(null);
+
+  const MAX_RUN_NAME_LENGTH_OMICS = 124;
+  const MAX_RUN_NAME_LENGTH_SEQERA = 50;
+
+  const omicsAvailable = computed(() => !!props.lab?.AwsHealthOmicsEnabled);
+  const seqeraAvailable = computed(() => !!props.lab?.NextFlowTowerEnabled && !!props.lab?.HasNextFlowTowerAccessToken);
+  const anyPlatformAvailable = computed(() => omicsAvailable.value || seqeraAvailable.value);
+
+  const workflowOptions = computed<WorkflowPickerOption[]>(() => {
+    const options: WorkflowPickerOption[] = [];
+    if (omicsAvailable.value) {
+      for (const w of omicsWorkflowsStore.workflowsForLab(props.labId)) {
+        if (!w.id) continue;
+        options.push({
+          key: `AWS HealthOmics:${w.id}`,
+          id: w.id,
+          label: w.name || w.id,
+          platform: 'AWS HealthOmics',
+          description: w.description,
+        });
+      }
+    }
+    if (seqeraAvailable.value) {
+      for (const p of seqeraPipelinesStore.pipelinesForLab(props.labId)) {
+        if (p.pipelineId == null) continue;
+        options.push({
+          key: `Seqera Cloud:${p.pipelineId}`,
+          id: String(p.pipelineId),
+          label: p.name || String(p.pipelineId),
+          platform: 'Seqera Cloud',
+          description: p.description,
+        });
+      }
+    }
+    return options.sort((a, b) => {
+      if (a.platform !== b.platform) return a.platform.localeCompare(b.platform);
+      return a.label.localeCompare(b.label);
+    });
+  });
+
+  const selectedWorkflow = computed(() => workflowOptions.value.find((o) => o.key === selectedWorkflowKey.value));
+
+  const isOmicsSelected = computed(() => selectedWorkflow.value?.platform === 'AWS HealthOmics');
+
+  const runNameError = computed(() => {
+    const name = runName.value;
+    if (!name.trim()) return 'Run name is required.';
+    if (isOmicsSelected.value) {
+      const schema = z
+        .string()
+        .min(1)
+        .max(MAX_RUN_NAME_LENGTH_OMICS)
+        .refine((v) => !v.startsWith(' '), 'Run name cannot start with a space');
+      const r = schema.safeParse(name);
+      return r.success ? null : (r.error.errors[0]?.message ?? 'Invalid run name');
+    }
+    const schema = z.string().trim().min(1).max(MAX_RUN_NAME_LENGTH_SEQERA);
+    const r = schema.safeParse(name);
+    return r.success ? null : (r.error.errors[0]?.message ?? 'Invalid run name');
+  });
+
+  const canContinue = computed(
+    () =>
+      !!selectedWorkflow.value &&
+      !runNameError.value &&
+      !isContinuing.value &&
+      !loadError.value &&
+      props.selectedKeys.length > 0 &&
+      anyPlatformAvailable.value,
+  );
+
+  watch(
+    () => props.modelValue,
+    async (open) => {
+      if (!open) return;
+      runName.value = '';
+      selectedWorkflowKey.value = undefined;
+      loadError.value = null;
+      isContinuing.value = false;
+      await loadWorkflowLists();
+    },
+  );
+
+  async function loadWorkflowLists(): Promise<void> {
+    loadError.value = null;
+    uiStore.setRequestPending('runFromCollectionsWorkflows');
+    try {
+      const tasks: Promise<void>[] = [];
+      if (omicsAvailable.value) {
+        tasks.push(omicsWorkflowsStore.loadWorkflowsForLab(props.labId));
+      }
+      if (seqeraAvailable.value) {
+        tasks.push(seqeraPipelinesStore.loadPipelinesForLab(props.labId));
+      }
+      await Promise.all(tasks);
+      if (!workflowOptions.value.length) {
+        loadError.value = 'No workflows or pipelines are available for this laboratory.';
+      }
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      loadError.value = `Failed to load workflows: ${msg}`;
+    } finally {
+      uiStore.setRequestComplete('runFromCollectionsWorkflows');
+    }
+  }
+
+  function close(): void {
+    emit('update:modelValue', false);
+  }
+
+  async function continueToRunSetup(): Promise<void> {
+    const workflow = selectedWorkflow.value;
+    if (!workflow || runNameError.value || !props.lab?.S3Bucket) return;
+
+    isContinuing.value = true;
+    const tempId = uuidv4();
+    const sampleIdSplitPattern = userStore.currentUserDetails.sampleIdSplitPattern ?? null;
+
+    try {
+      const pairing = buildUploadedFilePairsFromKeys(
+        props.selectedKeys,
+        props.lab.S3Bucket,
+        undefined,
+        sampleIdSplitPattern,
+      );
+      if (!pairing.ok) {
+        toast.error(pairing.message);
+        return;
+      }
+
+      const sampleSheetName = buildSampleSheetFileName(runName.value);
+
+      const sampleSheetResponse = await $api.uploads.getSampleSheetCsv(
+        {
+          SampleSheetName: sampleSheetName,
+          LaboratoryId: props.labId,
+          TransactionId: tempId,
+          Platform: workflow.platform,
+          UploadedFilePairs: pairing.pairs,
+        },
+        true,
+      );
+
+      const { S3Url, Bucket, Path } = sampleSheetResponse.SampleSheetInfo;
+
+      const wipSeed = {
+        transactionId: tempId,
+        runName: runName.value.trim(),
+        sampleSheetS3Url: S3Url,
+        s3Bucket: Bucket,
+        s3Path: Path,
+        inputFileKeys: [...props.selectedKeys],
+        paramsRequired: [] as string[],
+      };
+      const paramSeed = {
+        input: S3Url,
+        outdir: `s3://${Bucket}/${Path}/results`,
+      };
+
+      if (workflow.platform === 'AWS HealthOmics') {
+        runStore.updateWipOmicsRun(tempId, wipSeed);
+        runStore.updateWipOmicsRunParams(tempId, paramSeed);
+        const url = `/labs/${props.labId}/run-workflow/${workflow.id}?omicsRunTempId=${tempId}&from=data-collections`;
+        window.open(url, '_blank', 'noopener,noreferrer');
+      } else {
+        runStore.updateWipSeqeraRun(tempId, wipSeed);
+        runStore.updateWipSeqeraRunParams(tempId, paramSeed);
+        const url = `/labs/${props.labId}/run-pipeline/${workflow.id}?seqeraRunTempId=${tempId}&from=data-collections`;
+        window.open(url, '_blank', 'noopener,noreferrer');
+      }
+
+      close();
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      toast.error(`Could not prepare run: ${msg}`);
+    } finally {
+      isContinuing.value = false;
+    }
+  }
+</script>
+
+<template>
+  <UModal
+    :model-value="modelValue"
+    :ui="{
+      overlay: {
+        base: 'fixed inset-0 transition-opacity backdrop-blur-[5px]',
+        background: 'bg-gray-800/30',
+      },
+      rounded: 'rounded-3xl',
+      width: 'sm:max-w-lg',
+    }"
+    @update:model-value="emit('update:modelValue', $event)"
+  >
+    <UCard
+      :ui="{
+        base: 'p-8',
+        rounded: 'rounded-3xl',
+        header: { padding: '' },
+      }"
+    >
+      <template #header>
+        <div class="flex flex-col gap-1">
+          <h3 class="text-lg font-semibold text-gray-900">Run workflow</h3>
+          <p class="text-muted text-sm">
+            Choose a workflow or pipeline and continue to run setup with your selected files.
+          </p>
+        </div>
+      </template>
+
+      <div v-if="!anyPlatformAvailable" class="text-muted text-sm">
+        This laboratory does not have AWS HealthOmics or Seqera Cloud enabled. Configure a platform in lab settings to
+        run workflows.
+      </div>
+
+      <div v-else class="space-y-4">
+        <div
+          v-if="listingTruncated"
+          class="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900"
+        >
+          The file listing may be incomplete. Confirm your selection includes all intended samples.
+        </div>
+
+        <div class="rounded-lg border border-gray-100 bg-gray-50 px-4 py-3">
+          <dl class="space-y-2 text-sm">
+            <div class="flex justify-between gap-4">
+              <dt class="text-muted shrink-0">Selected files</dt>
+              <dd class="font-medium tabular-nums">{{ selectedKeys.length }}</dd>
+            </div>
+            <div class="flex items-start justify-between gap-4">
+              <dt class="text-muted shrink-0 pt-0.5">Batch(es)</dt>
+              <dd class="min-w-0 flex-1 break-words text-right font-medium leading-snug">{{ batchNamesSummary }}</dd>
+            </div>
+            <div class="flex justify-between gap-4">
+              <dt class="text-muted shrink-0">Never analyzed</dt>
+              <dd class="font-medium tabular-nums">{{ neverAnalyzedCount }}</dd>
+            </div>
+            <div class="flex justify-between gap-4">
+              <dt class="text-muted shrink-0">Previously analyzed</dt>
+              <dd class="font-medium tabular-nums">{{ previouslyAnalyzedCount }}</dd>
+            </div>
+          </dl>
+        </div>
+
+        <div v-if="tagsOnSelection.length">
+          <p class="text-muted mb-2 text-xs font-semibold uppercase tracking-wide">Tags on selection</p>
+          <ul class="max-h-28 space-y-1 overflow-y-auto text-sm">
+            <li
+              v-for="row in tagsOnSelection"
+              :key="row.tagId"
+              class="flex items-center justify-between gap-2 rounded border border-gray-100 bg-white px-2 py-1"
+            >
+              <span class="flex min-w-0 items-center gap-2">
+                <span
+                  class="inline-block h-2 w-2 shrink-0 rounded-full"
+                  :style="{ background: tagById(row.tagId)?.ColorHex || '#ccc' }"
+                />
+                <span class="truncate">{{ row.name }}</span>
+              </span>
+              <span class="text-muted shrink-0 text-xs tabular-nums">{{ row.count }}/{{ selectedKeys.length }}</span>
+            </li>
+          </ul>
+        </div>
+
+        <div v-if="uiStore.isRequestPending('runFromCollectionsWorkflows')" class="flex justify-center py-6">
+          <UIcon name="i-heroicons-arrow-path" class="text-muted h-8 w-8 animate-spin" />
+        </div>
+
+        <p v-else-if="loadError" class="text-alert-danger-dark text-sm">{{ loadError }}</p>
+
+        <template v-else>
+          <div>
+            <label class="text-muted mb-1 block text-xs font-semibold uppercase tracking-wide">
+              Workflow / pipeline
+            </label>
+            <USelectMenu
+              v-model="selectedWorkflowKey"
+              :options="workflowOptions"
+              option-attribute="label"
+              value-attribute="key"
+              placeholder="Select workflow or pipeline"
+              size="sm"
+              class="w-full"
+              :disabled="isContinuing"
+            />
+            <p v-if="!workflowOptions.length" class="text-muted mt-1 text-xs">No workflows or pipelines found.</p>
+          </div>
+
+          <div>
+            <label class="text-muted mb-1 block text-xs font-semibold uppercase tracking-wide">Run name</label>
+            <UInput
+              v-model="runName"
+              placeholder="e.g. Nov-2024-panel-run"
+              size="sm"
+              class="w-full"
+              :disabled="isContinuing"
+            />
+            <p v-if="runNameError && runName.length" class="text-alert-danger-dark mt-1 text-xs">{{ runNameError }}</p>
+            <p v-else class="text-muted mt-1 text-xs">
+              {{
+                isOmicsSelected
+                  ? 'AWS HealthOmics run names can include symbols and numbers, but cannot start with a space.'
+                  : 'Alphanumeric characters, hyphens, and underscores; first character must be a letter.'
+              }}
+            </p>
+          </div>
+        </template>
+      </div>
+
+      <div class="mt-8 flex flex-wrap justify-end gap-2 border-t border-gray-100 pt-4">
+        <UButton size="sm" variant="ghost" :disabled="isContinuing" @click="close">Cancel</UButton>
+        <UButton size="sm" :loading="isContinuing" :disabled="!canContinue" @click="continueToRunSetup">
+          Continue to run setup
+        </UButton>
+      </div>
+    </UCard>
+  </UModal>
+</template>

--- a/packages/front-end/src/app/components/EGRunFromCollectionsModal.vue
+++ b/packages/front-end/src/app/components/EGRunFromCollectionsModal.vue
@@ -2,10 +2,8 @@
   import { z } from 'zod';
   import { v4 as uuidv4 } from 'uuid';
   import type { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
-  import type { LaboratoryDataTag } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/data-collections';
   import { RunType } from '@easy-genomics/shared-lib/src/app/types/base-entity';
   import {
-    useLabsStore,
     useOmicsWorkflowsStore,
     useRunStore,
     useSeqeraPipelinesStore,
@@ -15,8 +13,6 @@
   } from '@FE/stores';
   import { buildUploadedFilePairsFromKeys } from '@FE/utils/data-collections-to-sample-sheet';
   import { buildSampleSheetFileName } from '@FE/utils/sample-sheet-utils';
-
-  export type RunFromCollectionsTagRow = { tagId: string; count: number; name: string; kind?: string };
 
   export type WorkflowPickerOption = {
     key: string;
@@ -31,12 +27,10 @@
     labId: string;
     lab: Laboratory | null;
     selectedKeys: string[];
-    tagsOnSelection: RunFromCollectionsTagRow[];
-    batchNamesSummary: string;
-    neverAnalyzedCount: number;
-    previouslyAnalyzedCount: number;
+    acrossBatchesSummary: string;
+    tagsPresentSummary: string;
+    previouslyAnalyzedSummary: string;
     listingTruncated: boolean;
-    tagById: (tagId: string) => LaboratoryDataTag | undefined;
   }>();
 
   const emit = defineEmits<{
@@ -281,42 +275,22 @@
         <div class="rounded-lg border border-gray-100 bg-gray-50 px-4 py-3">
           <dl class="space-y-2 text-sm">
             <div class="flex justify-between gap-4">
-              <dt class="text-muted shrink-0">Selected files</dt>
+              <dt class="text-muted shrink-0">Samples selected</dt>
               <dd class="font-medium tabular-nums">{{ selectedKeys.length }}</dd>
             </div>
             <div class="flex items-start justify-between gap-4">
-              <dt class="text-muted shrink-0 pt-0.5">Batch(es)</dt>
-              <dd class="min-w-0 flex-1 break-words text-right font-medium leading-snug">{{ batchNamesSummary }}</dd>
+              <dt class="text-muted shrink-0 pt-0.5">Across batches</dt>
+              <dd class="min-w-0 flex-1 break-words text-right font-medium leading-snug">{{ acrossBatchesSummary }}</dd>
             </div>
-            <div class="flex justify-between gap-4">
-              <dt class="text-muted shrink-0">Never analyzed</dt>
-              <dd class="font-medium tabular-nums">{{ neverAnalyzedCount }}</dd>
+            <div class="flex items-start justify-between gap-4">
+              <dt class="text-muted shrink-0 pt-0.5">Tags present</dt>
+              <dd class="min-w-0 flex-1 break-words text-right font-medium leading-snug">{{ tagsPresentSummary }}</dd>
             </div>
             <div class="flex justify-between gap-4">
               <dt class="text-muted shrink-0">Previously analyzed</dt>
-              <dd class="font-medium tabular-nums">{{ previouslyAnalyzedCount }}</dd>
+              <dd class="font-medium tabular-nums">{{ previouslyAnalyzedSummary }}</dd>
             </div>
           </dl>
-        </div>
-
-        <div v-if="tagsOnSelection.length">
-          <p class="text-muted mb-2 text-xs font-semibold uppercase tracking-wide">Tags on selection</p>
-          <ul class="max-h-28 space-y-1 overflow-y-auto text-sm">
-            <li
-              v-for="row in tagsOnSelection"
-              :key="row.tagId"
-              class="flex items-center justify-between gap-2 rounded border border-gray-100 bg-white px-2 py-1"
-            >
-              <span class="flex min-w-0 items-center gap-2">
-                <span
-                  class="inline-block h-2 w-2 shrink-0 rounded-full"
-                  :style="{ background: tagById(row.tagId)?.ColorHex || '#ccc' }"
-                />
-                <span class="truncate">{{ row.name }}</span>
-              </span>
-              <span class="text-muted shrink-0 text-xs tabular-nums">{{ row.count }}/{{ selectedKeys.length }}</span>
-            </li>
-          </ul>
         </div>
 
         <div v-if="uiStore.isRequestPending('runFromCollectionsWorkflows')" class="flex justify-center py-6">

--- a/packages/front-end/src/app/pages/labs/[labId]/run-pipeline/[pipelineId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/run-pipeline/[pipelineId].vue
@@ -173,6 +173,8 @@
       paramsRequired: paramsRequired,
     });
 
+    const existingWip = runStore.wipSeqeraRuns[seqeraRunTempId.value];
+
     // initialize params and save so that they can be easily reset
     initialParams.value = {
       ...schemaDefaults, // default values for all non-hidden fields
@@ -180,13 +182,32 @@
       input: '', // clear the default sample sheet github link that comes from the pipeline itself
     };
 
-    runStore.updateWipSeqeraRunParams(
-      seqeraRunTempId.value,
-      // make a copy of initialParams to ensure the original doesn't get changed
-      JSON.parse(JSON.stringify(initialParams.value)),
-    );
+    const paramsToApply = JSON.parse(JSON.stringify(initialParams.value));
+    if (existingWip?.sampleSheetS3Url && existingWip?.params?.input) {
+      paramsToApply.input = existingWip.params.input;
+      paramsToApply.outdir = existingWip.params.outdir;
+    }
+
+    runStore.updateWipSeqeraRunParams(seqeraRunTempId.value, paramsToApply);
+
+    applyDataCollectionsPrepopulation();
 
     uiStore.setRequestComplete('loadSeqeraPipeline');
+  }
+
+  /** When opened from Data Collections with a pre-built sample sheet, skip to parameter configuration. */
+  function applyDataCollectionsPrepopulation(): void {
+    if ($route.query.from !== 'data-collections') return;
+
+    const wip = runStore.wipSeqeraRuns[seqeraRunTempId.value];
+    if (!wip?.sampleSheetS3Url || !wip?.runName) return;
+
+    setStepEnabled('upload', true);
+    setStepEnabled('parameters', true);
+    const parametersIndex = steps.value.findIndex((step) => step.key === 'parameters');
+    if (parametersIndex >= 0) {
+      selectedStepIndex.value = parametersIndex;
+    }
   }
 
   function resetParams() {

--- a/packages/front-end/src/app/pages/labs/[labId]/run-workflow/[workflowId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/run-workflow/[workflowId].vue
@@ -178,7 +178,24 @@
     });
     runStore.updateWipOmicsRunParams(omicsRunTempId.value, workflowDefaultParams);
 
+    applyDataCollectionsPrepopulation();
+
     uiStore.setRequestComplete('loadOmicsWorkflow');
+  }
+
+  /** When opened from Data Collections with a pre-built sample sheet, skip to parameter configuration. */
+  function applyDataCollectionsPrepopulation(): void {
+    if ($route.query.from !== 'data-collections') return;
+
+    const wip = runStore.wipOmicsRuns[omicsRunTempId.value];
+    if (!wip?.sampleSheetS3Url || !wip?.runName) return;
+
+    setStepEnabled('upload', true);
+    setStepEnabled('parameters', true);
+    const parametersIndex = steps.value.findIndex((step) => step.key === 'parameters');
+    if (parametersIndex >= 0) {
+      selectedStepIndex.value = parametersIndex;
+    }
   }
 
   function resetParams() {

--- a/packages/front-end/src/app/pages/labs/[labId]/run-workflow/[workflowId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/run-workflow/[workflowId].vue
@@ -176,7 +176,14 @@
       transactionId: omicsRunTempId.value,
       paramsRequired: paramsRequired,
     });
-    runStore.updateWipOmicsRunParams(omicsRunTempId.value, workflowDefaultParams);
+
+    const existingWip = runStore.wipOmicsRuns[omicsRunTempId.value];
+    const paramsToApply = { ...workflowDefaultParams };
+    if (existingWip?.sampleSheetS3Url && existingWip?.params?.input) {
+      paramsToApply.input = existingWip.params.input;
+      paramsToApply.outdir = existingWip.params.outdir;
+    }
+    runStore.updateWipOmicsRunParams(omicsRunTempId.value, paramsToApply);
 
     applyDataCollectionsPrepopulation();
 

--- a/packages/front-end/src/app/repository/modules/uploads.ts
+++ b/packages/front-end/src/app/repository/modules/uploads.ts
@@ -9,8 +9,9 @@ import {
 import HttpFactory from '@FE/repository/factory';
 
 class UploadsModule extends HttpFactory {
-  async getSampleSheetCsv(req: SampleSheetRequest): Promise<SampleSheetResponse> {
-    const res = await this.call<SampleSheetResponse>('POST', '/upload/create-file-upload-sample-sheet', req);
+  async getSampleSheetCsv(req: SampleSheetRequest, validate = false): Promise<SampleSheetResponse> {
+    const query = validate ? '?validate=true' : '';
+    const res = await this.call<SampleSheetResponse>('POST', `/upload/create-file-upload-sample-sheet${query}`, req);
 
     if (!res) {
       throw new Error('Failed to create file upload sample sheet');

--- a/packages/front-end/src/app/utils/data-collections-to-sample-sheet.ts
+++ b/packages/front-end/src/app/utils/data-collections-to-sample-sheet.ts
@@ -1,0 +1,134 @@
+import type {
+  UploadedFileInfo,
+  UploadedFilePairInfo,
+} from '@easy-genomics/shared-lib/src/app/types/easy-genomics/upload/s3-file-upload-sample-sheet';
+
+/** Placeholder region; sample-sheet generation validates objects by bucket/key on the server. */
+export const DEFAULT_S3_REGION = 'us-east-1';
+
+export function getFileNameWithoutExt(fileName: string): string {
+  return fileName.replace(/\.f(ast)?q.*$/i, '');
+}
+
+export function getReadDirection(fileName: string, sampleIdSplitPattern?: string | null): 'R1' | 'R2' | null {
+  const nameWithoutExt = getFileNameWithoutExt(fileName);
+
+  if (/_R1(?:_|$)/i.test(nameWithoutExt)) return 'R1';
+  if (/_R2(?:_|$)/i.test(nameWithoutExt)) return 'R2';
+
+  const pattern = sampleIdSplitPattern?.trim();
+  if (!pattern) return null;
+
+  const patternIndex = nameWithoutExt.indexOf(pattern);
+  if (patternIndex === -1) return null;
+
+  const suffixAfterPattern = nameWithoutExt.substring(patternIndex + pattern.length);
+  const readNumberMatch = suffixAfterPattern.match(/^([12])(?:_|$)/);
+  if (!readNumberMatch) return null;
+
+  return readNumberMatch[1] === '1' ? 'R1' : 'R2';
+}
+
+export function getSampleIdFromRFileName(fileName: string, sampleIdSplitPattern?: string | null): string | null {
+  const pattern = sampleIdSplitPattern?.trim();
+  if (pattern) {
+    const idx = fileName.indexOf(pattern);
+    return idx !== -1 ? fileName.substring(0, idx) || null : null;
+  }
+  return fileName.substring(0, fileName.lastIndexOf('_R')) || null;
+}
+
+function getSharedSampleIdFromPair(
+  r1Name?: string,
+  r2Name?: string,
+  sampleIdSplitPattern?: string | null,
+): string | null {
+  const r1SampleId = getSampleIdFromRFileName(r1Name || '', sampleIdSplitPattern);
+  const r2SampleId = getSampleIdFromRFileName(r2Name || '', sampleIdSplitPattern);
+  return r1SampleId || r2SampleId;
+}
+
+export type PairingValidationResult = { ok: true; pairs: UploadedFilePairInfo[] } | { ok: false; message: string };
+
+/**
+ * Build UploadedFilePairInfo from laboratory S3 object keys (same pairing rules as EGRunFormUploadData).
+ */
+export function buildUploadedFilePairsFromKeys(
+  keys: string[],
+  bucket: string,
+  region: string = DEFAULT_S3_REGION,
+  sampleIdSplitPattern?: string | null,
+): PairingValidationResult {
+  if (!keys.length) {
+    return { ok: false, message: 'No files selected.' };
+  }
+
+  const uploadedFilePairs: UploadedFilePairInfo[] = [];
+
+  for (const key of keys) {
+    const name = key.split('/').pop() || key;
+    const uploadFileInfo: UploadedFileInfo = { Bucket: bucket, Key: key, Region: region };
+
+    const sampleId = getSampleIdFromRFileName(name, sampleIdSplitPattern);
+    const readDirection = getReadDirection(name, sampleIdSplitPattern);
+    const fileName = getFileNameWithoutExt(name);
+
+    if (!sampleId || !readDirection) {
+      uploadedFilePairs.push({
+        SampleId: fileName,
+        R1: uploadFileInfo,
+      });
+      continue;
+    }
+
+    const existingFilePair = uploadedFilePairs.find(
+      (filePair) =>
+        getSharedSampleIdFromPair(
+          filePair.R1?.Key?.split('/').at(-1),
+          filePair.R2?.Key?.split('/').at(-1),
+          sampleIdSplitPattern,
+        ) === sampleId,
+    );
+
+    if (existingFilePair) {
+      if (readDirection === 'R1') {
+        existingFilePair.R1 = uploadFileInfo;
+      } else if (readDirection === 'R2') {
+        existingFilePair.R2 = uploadFileInfo;
+      }
+
+      if (!existingFilePair.R1 || !existingFilePair.R2) {
+        existingFilePair.SampleId = fileName;
+      } else {
+        existingFilePair.SampleId = sampleId;
+      }
+    } else {
+      uploadedFilePairs.push({
+        SampleId: fileName,
+        R1: readDirection === 'R1' ? uploadFileInfo : undefined,
+        R2: readDirection === 'R2' ? uploadFileInfo : undefined,
+      });
+    }
+  }
+
+  return validateUploadedFilePairs(uploadedFilePairs);
+}
+
+export function validateUploadedFilePairs(pairs: UploadedFilePairInfo[]): PairingValidationResult {
+  const areAllPairsComplete = pairs.every((pair) => pair.R1);
+  if (!areAllPairsComplete) {
+    return { ok: false, message: 'There is an R2 file with no matching R1 file.' };
+  }
+
+  const haveMatchedFiles = pairs.some((pair) => pair.R1 && pair.R2);
+  const haveUnmatchedFiles = pairs.some((pair) => !pair.R1 || !pair.R2);
+
+  if (haveMatchedFiles && haveUnmatchedFiles) {
+    return {
+      ok: false,
+      message: 'There is a mix of single files and pair files. Files must be all single files or all pair files.',
+    };
+  }
+
+  return { ok: true, pairs };
+}

--- a/packages/front-end/src/app/utils/sample-sheet-utils.ts
+++ b/packages/front-end/src/app/utils/sample-sheet-utils.ts
@@ -1,6 +1,28 @@
+/** Matches create-file-upload-sample-sheet Lambda validation (no spaces). */
+const SAMPLE_SHEET_NAME_PATTERN = /^[a-zA-Z0-9._:!@#$%^()-]+(\.csv)$/;
+
 export interface SampleSheetValidationResult {
   valid: boolean;
   error?: string;
+}
+
+/**
+ * Builds a sample sheet object key filename from a run name. Run names may contain spaces
+ * (e.g. AWS HealthOmics); the S3 sample sheet name must not.
+ */
+export function buildSampleSheetFileName(runName?: string | null): string {
+  const trimmed = runName?.trim() ?? '';
+  if (!trimmed) {
+    return 'samplesheet.csv';
+  }
+
+  const sanitized = trimmed
+    .replace(/[^a-zA-Z0-9._:!@#$%^()-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  const candidate = sanitized ? `samplesheet-${sanitized}.csv` : 'samplesheet.csv';
+  return SAMPLE_SHEET_NAME_PATTERN.test(candidate) ? candidate : 'samplesheet.csv';
 }
 
 /**


### PR DESCRIPTION
## Run workflows from Data Collections with prepopulated run setup

## Type of Change*
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
Adds a **Run workflow** action on the Data Collections page so users can start a HealthOmics workflow or Seqera pipeline run from files already in the lab S3 bucket, without re-uploading them in the run wizard.

### User flow
1. Select files in the Data Collections grid.
2. Click **Run workflow** (with play icon) in the bottom action tray.
3. In the modal, review selection summary (file count, batches, tags, prior analysis counts), choose a workflow/pipeline, and enter a run name.
4. Click **Continue to run setup** — the app pairs selected FASTQs, generates a sample sheet from existing S3 objects (`validate=true`), seeds the WIP run store, and opens the existing 4-step run wizard in a new tab.
5. The wizard lands on **Edit Parameters** with run name, sample sheet, `input`/`outdir`, and `inputFileKeys` already set; the upload step shows a read-only summary of Data Collections files instead of the dropzone.

### Key implementation details
- **`EGRunFromCollectionsModal.vue`** — platform-aware workflow/pipeline picker (Omics + Seqera when enabled), run name validation, sample sheet generation, WIP seeding, navigation with `from=data-collections` query param.
- **`data-collections-to-sample-sheet.ts`** — builds `UploadedFilePairs` from S3 keys using the same R1/R2 pairing rules as `EGRunFormUploadData`.
- **`buildSampleSheetFileName()`** in `sample-sheet-utils.ts` — sanitizes run names for sample sheet filenames (e.g. spaces → hyphens) to satisfy backend validation; also applied in the standard upload wizard.
- **`uploads.getSampleSheetCsv()`** — optional `validate` flag to pass `?validate=true` to the API.
- **`run-workflow` / `run-pipeline` pages** — preserve prepopulated WIP state on init; Seqera no longer clears `input`/`outdir` when arriving from Data Collections; auto-enable steps and jump to parameters when pre-seeded.
- **`EGRunFormUploadData.vue`** — read-only “from Data Collections” mode when sample sheet and `inputFileKeys` exist without uploaded browser files.

Direct launch from the modal was intentionally not implemented; workflow-specific required parameters still use the existing parameter and review steps.

## Screenshots

https://github.com/user-attachments/assets/e8c4368c-0c31-4204-af13-0c85f3f51b3d




## Testing*
Manual testing performed locally:

- [x] Select paired FASTQs on Data Collections → **Run workflow** → choose HealthOmics workflow → continue → wizard opens with run name prepopulated and lands on Edit Parameters.
- [x] Upload step shows read-only file list (no dropzone); can proceed to parameters and complete launch.
- [x] Run name with spaces (e.g. `From DC Page Test`) succeeds — sample sheet filename sanitized to `samplesheet-From-DC-Page-Test.csv`.
- [x] Seqera pipeline path when lab has Seqera enabled and PAT configured.
- [x] Button disabled when neither Omics nor Seqera is available for the lab.
- [x] Pairing validation errors surfaced in modal (e.g. invalid R1/R2 mix) without opening wizard tab.
- [x] `InputFileKeys` still recorded on laboratory run at launch (existing review behavior).

No new automated tests added in this change.

## Impact
- **Front-end only** for this feature; reuses existing `create-file-upload-sample-sheet` API with existing S3 objects (no backend changes required).
- **Behaviour:** New entry point for run creation; does not change existing workflow/pipeline launch paths from Dashboard or lab tabs.
- **Pinia WIP persistence:** Pre-seeded runs use a new `omicsRunTempId` / `seqeraRunTempId` per modal session (same pattern as other run starts).
- **Performance:** Modal performs one sample-sheet API call on continue; proportional to selection size via pairing validation only.

## Additional Information
- Labs need `S3Bucket` configured and at least one of `AwsHealthOmicsEnabled` or `NextFlowTowerEnabled` (+ Seqera access token) for the button to be enabled.
- Sample sheet is **generated on continue**, not required to exist beforehand; only the selected S3 objects must already be in the lab bucket.
- If the file listing is truncated (`listingTruncated`), the modal shows a warning to confirm the selection is complete.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [ ] Code has been commented in particularly hard-to-understand areas.