### PR TITLE
feat: limit scope of s3 fetch to input files

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/data-collections/request-laboratory-bucket-objects.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/data-collections/request-laboratory-bucket-objects.lambda.ts
@@ -16,8 +16,160 @@ import {
 const laboratoryService = new LaboratoryService();
 const s3Service = new S3Service();
 
+const DEFAULT_MAX_TOTAL_KEYS = 15_000;
+const DEFAULT_MAX_TRANSACTION_FOLDERS = 10_000;
+const LIST_CONCURRENCY = 15;
+
 function isFileObjectKey(key: string | undefined): boolean {
   return !!key && !key.endsWith('/');
+}
+
+function lastPathSegment(prefix: string): string {
+  const normalized = prefix.endsWith('/') ? prefix.slice(0, -1) : prefix;
+  const idx = normalized.lastIndexOf('/');
+  return idx >= 0 ? normalized.slice(idx + 1) : normalized;
+}
+
+/** Do not descend into workflow output/work dirs or Omics workflow-definition uploads. */
+function shouldSkipDescentPrefix(prefix: string): boolean {
+  const segment = lastPathSegment(prefix);
+  return segment === 'results' || segment === 'work' || segment === 'workflow-definitions';
+}
+
+async function listOneLevel(
+  bucket: string,
+  prefix: string,
+  pageSize: number,
+): Promise<{ contents: _Object[]; commonPrefixes: string[] }> {
+  const contents: _Object[] = [];
+  const commonPrefixes: string[] = [];
+  let continuationToken: string | undefined;
+  let isTruncated = true;
+
+  while (isTruncated) {
+    const response: ListObjectsV2CommandOutput = await s3Service.listBucketObjectsV2({
+      Bucket: bucket,
+      Prefix: prefix,
+      Delimiter: '/',
+      MaxKeys: pageSize,
+      ContinuationToken: continuationToken,
+    });
+
+    if (response.Contents) {
+      contents.push(...response.Contents);
+    }
+
+    if (response.CommonPrefixes) {
+      for (const cp of response.CommonPrefixes) {
+        if (cp.Prefix) {
+          commonPrefixes.push(cp.Prefix);
+        }
+      }
+    }
+
+    isTruncated = !!response.IsTruncated;
+    continuationToken = response.NextContinuationToken;
+  }
+
+  return { contents, commonPrefixes };
+}
+
+function appendFileObjects(target: _Object[], objects: _Object[], maxTotalKeys: number): boolean {
+  for (const obj of objects) {
+    if (!isFileObjectKey(obj.Key)) {
+      continue;
+    }
+    if (target.length >= maxTotalKeys) {
+      return true;
+    }
+    target.push(obj);
+  }
+  return target.length >= maxTotalKeys;
+}
+
+async function mapWithConcurrency<T, R>(items: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+  const results: R[] = [];
+  for (let i = 0; i < items.length; i += limit) {
+    const chunk = items.slice(i, i + limit);
+    results.push(...(await Promise.all(chunk.map(fn))));
+  }
+  return results;
+}
+
+type ListTransactionInputsOptions = {
+  bucket: string;
+  labPrefix: string;
+  pageSize: number;
+  maxTotalKeys: number;
+  maxTransactionFolders: number;
+};
+
+type ListTransactionInputsResult = {
+  contents: _Object[];
+  listingTruncated: boolean;
+};
+
+/**
+ * Lists input files for Data Collections by walking org/lab → platform → transaction
+ * with S3 delimiter "/", never descending into results/, work/, or workflow-definitions/.
+ */
+async function listTransactionInputs(options: ListTransactionInputsOptions): Promise<ListTransactionInputsResult> {
+  const { bucket, labPrefix, pageSize, maxTotalKeys, maxTransactionFolders } = options;
+  const allContents: _Object[] = [];
+  let listingTruncated = false;
+
+  const addLevel = (contents: _Object[]): boolean => {
+    if (appendFileObjects(allContents, contents, maxTotalKeys)) {
+      listingTruncated = true;
+      return true;
+    }
+    return false;
+  };
+
+  const labLevel = await listOneLevel(bucket, labPrefix, pageSize);
+  if (addLevel(labLevel.contents)) {
+    return { contents: allContents, listingTruncated: true };
+  }
+
+  const platformPrefixes = labLevel.commonPrefixes.filter((p) => !shouldSkipDescentPrefix(p));
+
+  const platformResults = await mapWithConcurrency(platformPrefixes, LIST_CONCURRENCY, async (platformPrefix) => {
+    const platformLevel = await listOneLevel(bucket, platformPrefix, pageSize);
+    const txnPrefixes = platformLevel.commonPrefixes.filter((p) => !shouldSkipDescentPrefix(p));
+    return { contents: platformLevel.contents, transactionPrefixes: txnPrefixes };
+  });
+
+  const transactionPrefixes: string[] = [];
+  for (const { contents, transactionPrefixes: txnPrefixes } of platformResults) {
+    if (addLevel(contents)) {
+      return { contents: allContents, listingTruncated: true };
+    }
+    transactionPrefixes.push(...txnPrefixes);
+  }
+
+  if (listingTruncated) {
+    return { contents: allContents, listingTruncated: true };
+  }
+
+  let transactionPrefixesToWalk = transactionPrefixes;
+  if (transactionPrefixes.length > maxTransactionFolders) {
+    listingTruncated = true;
+    transactionPrefixesToWalk = transactionPrefixes.slice(0, maxTransactionFolders);
+  }
+
+  await mapWithConcurrency(transactionPrefixesToWalk, LIST_CONCURRENCY, async (transactionPrefix) => {
+    if (listingTruncated) {
+      return;
+    }
+
+    const transactionLevel = await listOneLevel(bucket, transactionPrefix, pageSize);
+    // Inputs live at the transaction root; do not descend into results/, work/, etc.
+    if (addLevel(transactionLevel.contents)) {
+      listingTruncated = true;
+    }
+  });
+
+  return { contents: allContents, listingTruncated };
 }
 
 export const handler: Handler = async (
@@ -58,78 +210,16 @@ export const handler: Handler = async (
     }
 
     const pageSize = Math.min(body.MaxKeys ?? 1000, 1000);
-    const recursive = body.Recursive === true;
+    const maxTotalKeys = Math.min(body.MaxTotalKeys ?? DEFAULT_MAX_TOTAL_KEYS, 50000);
+    const maxTransactionFolders = Math.min(body.MaxTransactionFolders ?? DEFAULT_MAX_TRANSACTION_FOLDERS, 50000);
 
-    let allContents: _Object[] = [];
-    let allCommonPrefixes: { Prefix: string }[] = [];
-    let isTruncated = true;
-    let continuationToken: string | undefined = undefined;
-    let listingTruncated = false;
-
-    if (!recursive) {
-      while (isTruncated) {
-        const response: ListObjectsV2CommandOutput = await s3Service.listBucketObjectsV2({
-          Bucket: s3Bucket,
-          Prefix: normalizedPrefix,
-          Delimiter: '/',
-          MaxKeys: pageSize,
-          ContinuationToken: continuationToken,
-        });
-
-        if (response.Contents) {
-          allContents = allContents.concat(response.Contents);
-        }
-
-        if (response.CommonPrefixes) {
-          allCommonPrefixes = allCommonPrefixes.concat(response.CommonPrefixes);
-        }
-
-        isTruncated = !!response.IsTruncated;
-        continuationToken = response.NextContinuationToken;
-      }
-    } else {
-      const maxTotalKeys = Math.min(body.MaxTotalKeys ?? 15000, 50000);
-      isTruncated = true;
-      continuationToken = undefined;
-
-      while (isTruncated && allContents.length < maxTotalKeys) {
-        const remaining = maxTotalKeys - allContents.length;
-        const requestMax = Math.max(1, Math.min(pageSize, remaining));
-
-        const response: ListObjectsV2CommandOutput = await s3Service.listBucketObjectsV2({
-          Bucket: s3Bucket,
-          Prefix: normalizedPrefix,
-          MaxKeys: requestMax,
-          ContinuationToken: continuationToken,
-        });
-
-        for (const obj of response.Contents || []) {
-          if (!isFileObjectKey(obj.Key)) {
-            continue;
-          }
-          if (allContents.length >= maxTotalKeys) {
-            listingTruncated = true;
-            break;
-          }
-          allContents.push(obj);
-        }
-
-        const s3More = !!response.IsTruncated;
-        continuationToken = response.NextContinuationToken;
-        if (listingTruncated) {
-          isTruncated = false;
-          break;
-        }
-        isTruncated = s3More;
-        if (!s3More) {
-          break;
-        }
-        if (allContents.length >= maxTotalKeys) {
-          listingTruncated = true;
-          break;
-        }
-      }
-    }
+    const { contents: allContents, listingTruncated } = await listTransactionInputs({
+      bucket: s3Bucket,
+      labPrefix: normalizedPrefix,
+      pageSize,
+      maxTotalKeys,
+      maxTransactionFolders,
+    });
 
     return buildResponse(
       200,
@@ -142,11 +232,10 @@ export const handler: Handler = async (
           totalRetryDelay: 0,
         },
         Contents: allContents,
-        CommonPrefixes: allCommonPrefixes,
-        IsTruncated: recursive ? listingTruncated : false,
+        CommonPrefixes: [],
+        IsTruncated: listingTruncated,
         S3Bucket: s3Bucket,
         ResolvedPrefix: normalizedPrefix,
-        Recursive: recursive,
         ListingTruncated: listingTruncated,
         ReturnedKeyCount: allContents.length,
       }),

--- a/packages/back-end/src/app/controllers/easy-genomics/data-collections/request-laboratory-bucket-objects.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/data-collections/request-laboratory-bucket-objects.lambda.ts
@@ -1,11 +1,10 @@
-import { ListObjectsV2CommandOutput, _Object } from '@aws-sdk/client-s3';
 import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/lib/app/utils/common';
 import { InvalidRequestError, UnauthorizedAccessError } from '@easy-genomics/shared-lib/lib/app/utils/HttpError';
 import { RequestLaboratoryBucketObjectsSchema } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/data-collections/request-laboratory-bucket-objects';
 import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
 import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
+import { DataCollectionService } from '@BE/services/easy-genomics/data-collection-service';
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
-import { S3Service } from '@BE/services/s3-service';
 import {
   validateLaboratoryManagerAccess,
   validateLaboratoryTechnicianAccess,
@@ -14,163 +13,7 @@ import {
 } from '@BE/utils/auth-utils';
 
 const laboratoryService = new LaboratoryService();
-const s3Service = new S3Service();
-
-const DEFAULT_MAX_TOTAL_KEYS = 15_000;
-const DEFAULT_MAX_TRANSACTION_FOLDERS = 10_000;
-const LIST_CONCURRENCY = 15;
-
-function isFileObjectKey(key: string | undefined): boolean {
-  return !!key && !key.endsWith('/');
-}
-
-function lastPathSegment(prefix: string): string {
-  const normalized = prefix.endsWith('/') ? prefix.slice(0, -1) : prefix;
-  const idx = normalized.lastIndexOf('/');
-  return idx >= 0 ? normalized.slice(idx + 1) : normalized;
-}
-
-/** Do not descend into workflow output/work dirs or Omics workflow-definition uploads. */
-function shouldSkipDescentPrefix(prefix: string): boolean {
-  const segment = lastPathSegment(prefix);
-  return segment === 'results' || segment === 'work' || segment === 'workflow-definitions';
-}
-
-async function listOneLevel(
-  bucket: string,
-  prefix: string,
-  pageSize: number,
-): Promise<{ contents: _Object[]; commonPrefixes: string[] }> {
-  const contents: _Object[] = [];
-  const commonPrefixes: string[] = [];
-  let continuationToken: string | undefined;
-  let isTruncated = true;
-
-  while (isTruncated) {
-    const response: ListObjectsV2CommandOutput = await s3Service.listBucketObjectsV2({
-      Bucket: bucket,
-      Prefix: prefix,
-      Delimiter: '/',
-      MaxKeys: pageSize,
-      ContinuationToken: continuationToken,
-    });
-
-    if (response.Contents) {
-      contents.push(...response.Contents);
-    }
-
-    if (response.CommonPrefixes) {
-      for (const cp of response.CommonPrefixes) {
-        if (cp.Prefix) {
-          commonPrefixes.push(cp.Prefix);
-        }
-      }
-    }
-
-    isTruncated = !!response.IsTruncated;
-    continuationToken = response.NextContinuationToken;
-  }
-
-  return { contents, commonPrefixes };
-}
-
-function appendFileObjects(target: _Object[], objects: _Object[], maxTotalKeys: number): boolean {
-  for (const obj of objects) {
-    if (!isFileObjectKey(obj.Key)) {
-      continue;
-    }
-    if (target.length >= maxTotalKeys) {
-      return true;
-    }
-    target.push(obj);
-  }
-  return target.length >= maxTotalKeys;
-}
-
-async function mapWithConcurrency<T, R>(items: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
-  const results: R[] = [];
-  for (let i = 0; i < items.length; i += limit) {
-    const chunk = items.slice(i, i + limit);
-    results.push(...(await Promise.all(chunk.map(fn))));
-  }
-  return results;
-}
-
-type ListTransactionInputsOptions = {
-  bucket: string;
-  labPrefix: string;
-  pageSize: number;
-  maxTotalKeys: number;
-  maxTransactionFolders: number;
-};
-
-type ListTransactionInputsResult = {
-  contents: _Object[];
-  listingTruncated: boolean;
-};
-
-/**
- * Lists input files for Data Collections by walking org/lab → platform → transaction
- * with S3 delimiter "/", never descending into results/, work/, or workflow-definitions/.
- */
-async function listTransactionInputs(options: ListTransactionInputsOptions): Promise<ListTransactionInputsResult> {
-  const { bucket, labPrefix, pageSize, maxTotalKeys, maxTransactionFolders } = options;
-  const allContents: _Object[] = [];
-  let listingTruncated = false;
-
-  const addLevel = (contents: _Object[]): boolean => {
-    if (appendFileObjects(allContents, contents, maxTotalKeys)) {
-      listingTruncated = true;
-      return true;
-    }
-    return false;
-  };
-
-  const labLevel = await listOneLevel(bucket, labPrefix, pageSize);
-  if (addLevel(labLevel.contents)) {
-    return { contents: allContents, listingTruncated: true };
-  }
-
-  const platformPrefixes = labLevel.commonPrefixes.filter((p) => !shouldSkipDescentPrefix(p));
-
-  const platformResults = await mapWithConcurrency(platformPrefixes, LIST_CONCURRENCY, async (platformPrefix) => {
-    const platformLevel = await listOneLevel(bucket, platformPrefix, pageSize);
-    const txnPrefixes = platformLevel.commonPrefixes.filter((p) => !shouldSkipDescentPrefix(p));
-    return { contents: platformLevel.contents, transactionPrefixes: txnPrefixes };
-  });
-
-  const transactionPrefixes: string[] = [];
-  for (const { contents, transactionPrefixes: txnPrefixes } of platformResults) {
-    if (addLevel(contents)) {
-      return { contents: allContents, listingTruncated: true };
-    }
-    transactionPrefixes.push(...txnPrefixes);
-  }
-
-  if (listingTruncated) {
-    return { contents: allContents, listingTruncated: true };
-  }
-
-  let transactionPrefixesToWalk = transactionPrefixes;
-  if (transactionPrefixes.length > maxTransactionFolders) {
-    listingTruncated = true;
-    transactionPrefixesToWalk = transactionPrefixes.slice(0, maxTransactionFolders);
-  }
-
-  await mapWithConcurrency(transactionPrefixesToWalk, LIST_CONCURRENCY, async (transactionPrefix) => {
-    if (listingTruncated) {
-      return;
-    }
-
-    const transactionLevel = await listOneLevel(bucket, transactionPrefix, pageSize);
-    // Inputs live at the transaction root; do not descend into results/, work/, etc.
-    if (addLevel(transactionLevel.contents)) {
-      listingTruncated = true;
-    }
-  });
-
-  return { contents: allContents, listingTruncated };
-}
+const dataCollectionService = new DataCollectionService();
 
 export const handler: Handler = async (
   event: APIGatewayProxyWithCognitoAuthorizerEvent,
@@ -210,10 +53,10 @@ export const handler: Handler = async (
     }
 
     const pageSize = Math.min(body.MaxKeys ?? 1000, 1000);
-    const maxTotalKeys = Math.min(body.MaxTotalKeys ?? DEFAULT_MAX_TOTAL_KEYS, 50000);
-    const maxTransactionFolders = Math.min(body.MaxTransactionFolders ?? DEFAULT_MAX_TRANSACTION_FOLDERS, 50000);
+    const maxTotalKeys = Math.min(body.MaxTotalKeys ?? 15_000, 50000);
+    const maxTransactionFolders = Math.min(body.MaxTransactionFolders ?? 10_000, 50000);
 
-    const { contents: allContents, listingTruncated } = await listTransactionInputs({
+    const { contents: allContents, listingTruncated } = await dataCollectionService.listTransactionInputs({
       bucket: s3Bucket,
       labPrefix: normalizedPrefix,
       pageSize,

--- a/packages/back-end/src/app/services/easy-genomics/data-collection-service.ts
+++ b/packages/back-end/src/app/services/easy-genomics/data-collection-service.ts
@@ -1,0 +1,172 @@
+import { ListObjectsV2CommandOutput, _Object } from '@aws-sdk/client-s3';
+import { S3Service } from '../s3-service';
+
+const DEFAULT_MAX_TOTAL_KEYS = 15_000;
+const DEFAULT_MAX_TRANSACTION_FOLDERS = 10_000;
+const LIST_CONCURRENCY = 15;
+
+function isFileObjectKey(key: string | undefined): boolean {
+  return !!key && !key.endsWith('/');
+}
+
+function lastPathSegment(prefix: string): string {
+  const normalized = prefix.endsWith('/') ? prefix.slice(0, -1) : prefix;
+  const idx = normalized.lastIndexOf('/');
+  return idx >= 0 ? normalized.slice(idx + 1) : normalized;
+}
+
+/** Do not descend into workflow output/work dirs or Omics workflow-definition uploads. */
+function shouldSkipDescentPrefix(prefix: string): boolean {
+  const segment = lastPathSegment(prefix);
+  return segment === 'results' || segment === 'work' || segment === 'workflow-definitions';
+}
+
+function appendFileObjects(target: _Object[], objects: _Object[], maxTotalKeys: number): boolean {
+  for (const obj of objects) {
+    if (!isFileObjectKey(obj.Key)) {
+      continue;
+    }
+    if (target.length >= maxTotalKeys) {
+      return true;
+    }
+    target.push(obj);
+  }
+  return target.length >= maxTotalKeys;
+}
+
+async function mapWithConcurrency<T, R>(items: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+  const results: R[] = [];
+  for (let i = 0; i < items.length; i += limit) {
+    const chunk = items.slice(i, i + limit);
+    results.push(...(await Promise.all(chunk.map(fn))));
+  }
+  return results;
+}
+
+export type ListTransactionInputsOptions = {
+  bucket: string;
+  labPrefix: string;
+  pageSize: number;
+  maxTotalKeys?: number;
+  maxTransactionFolders?: number;
+};
+
+export type ListTransactionInputsResult = {
+  contents: _Object[];
+  listingTruncated: boolean;
+};
+
+export class DataCollectionService {
+  private readonly s3Service: S3Service;
+
+  public constructor(s3Service?: S3Service) {
+    this.s3Service = s3Service ?? new S3Service();
+  }
+
+  private async listOneLevel(
+    bucket: string,
+    prefix: string,
+    pageSize: number,
+  ): Promise<{ contents: _Object[]; commonPrefixes: string[] }> {
+    const contents: _Object[] = [];
+    const commonPrefixes: string[] = [];
+    let continuationToken: string | undefined;
+    let isTruncated = true;
+
+    while (isTruncated) {
+      const response: ListObjectsV2CommandOutput = await this.s3Service.listBucketObjectsV2({
+        Bucket: bucket,
+        Prefix: prefix,
+        Delimiter: '/',
+        MaxKeys: pageSize,
+        ContinuationToken: continuationToken,
+      });
+
+      if (response.Contents) {
+        contents.push(...response.Contents);
+      }
+
+      if (response.CommonPrefixes) {
+        for (const cp of response.CommonPrefixes) {
+          if (cp.Prefix) {
+            commonPrefixes.push(cp.Prefix);
+          }
+        }
+      }
+
+      isTruncated = !!response.IsTruncated;
+      continuationToken = response.NextContinuationToken;
+    }
+
+    return { contents, commonPrefixes };
+  }
+
+  /**
+   * Lists input files for Data Collections by walking org/lab → platform → transaction
+   * with S3 delimiter "/", never descending into results/, work/, or workflow-definitions/.
+   */
+  public async listTransactionInputs(options: ListTransactionInputsOptions): Promise<ListTransactionInputsResult> {
+    const {
+      bucket,
+      labPrefix,
+      pageSize,
+      maxTotalKeys = DEFAULT_MAX_TOTAL_KEYS,
+      maxTransactionFolders = DEFAULT_MAX_TRANSACTION_FOLDERS,
+    } = options;
+    const allContents: _Object[] = [];
+    let listingTruncated = false;
+
+    const addLevel = (contents: _Object[]): boolean => {
+      if (appendFileObjects(allContents, contents, maxTotalKeys)) {
+        listingTruncated = true;
+        return true;
+      }
+      return false;
+    };
+
+    const labLevel = await this.listOneLevel(bucket, labPrefix, pageSize);
+    if (addLevel(labLevel.contents)) {
+      return { contents: allContents, listingTruncated: true };
+    }
+
+    const platformPrefixes = labLevel.commonPrefixes.filter((p) => !shouldSkipDescentPrefix(p));
+
+    const platformResults = await mapWithConcurrency(platformPrefixes, LIST_CONCURRENCY, async (platformPrefix) => {
+      const platformLevel = await this.listOneLevel(bucket, platformPrefix, pageSize);
+      const txnPrefixes = platformLevel.commonPrefixes.filter((p) => !shouldSkipDescentPrefix(p));
+      return { contents: platformLevel.contents, transactionPrefixes: txnPrefixes };
+    });
+
+    const transactionPrefixes: string[] = [];
+    for (const { contents, transactionPrefixes: txnPrefixes } of platformResults) {
+      if (addLevel(contents)) {
+        return { contents: allContents, listingTruncated: true };
+      }
+      transactionPrefixes.push(...txnPrefixes);
+    }
+
+    if (listingTruncated) {
+      return { contents: allContents, listingTruncated: true };
+    }
+
+    let transactionPrefixesToWalk = transactionPrefixes;
+    if (transactionPrefixes.length > maxTransactionFolders) {
+      listingTruncated = true;
+      transactionPrefixesToWalk = transactionPrefixes.slice(0, maxTransactionFolders);
+    }
+
+    await mapWithConcurrency(transactionPrefixesToWalk, LIST_CONCURRENCY, async (transactionPrefix) => {
+      if (listingTruncated) {
+        return;
+      }
+
+      const transactionLevel = await this.listOneLevel(bucket, transactionPrefix, pageSize);
+      // Inputs live at the transaction root; do not descend into results/, work/, etc.
+      if (addLevel(transactionLevel.contents)) {
+        listingTruncated = true;
+      }
+    });
+
+    return { contents: allContents, listingTruncated };
+  }
+}

--- a/packages/back-end/test/app/controllers/easy-genomics/data-collections/request-laboratory-bucket-objects.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/data-collections/request-laboratory-bucket-objects.lambda.test.ts
@@ -1,0 +1,257 @@
+import { APIGatewayProxyWithCognitoAuthorizerEvent, Context } from 'aws-lambda';
+import { handler } from '../../../../../src/app/controllers/easy-genomics/data-collections/request-laboratory-bucket-objects.lambda';
+
+jest.mock('../../../../../src/app/services/easy-genomics/laboratory-service');
+jest.mock('../../../../../src/app/services/s3-service');
+jest.mock('../../../../../src/app/utils/auth-utils');
+
+import { LaboratoryService } from '../../../../../src/app/services/easy-genomics/laboratory-service';
+import { S3Service } from '../../../../../src/app/services/s3-service';
+import {
+  validateLaboratoryManagerAccess,
+  validateLaboratoryTechnicianAccess,
+  validateOrganizationAdminAccess,
+  validateSystemAdminAccess,
+} from '../../../../../src/app/utils/auth-utils';
+
+describe('request-laboratory-bucket-objects Lambda', () => {
+  let mockValidateSystemAdmin: jest.MockedFunction<typeof validateSystemAdminAccess>;
+  let mockValidateOrgAdmin: jest.MockedFunction<typeof validateOrganizationAdminAccess>;
+  let mockValidateLabManager: jest.MockedFunction<typeof validateLaboratoryManagerAccess>;
+  let mockValidateLabTechnician: jest.MockedFunction<typeof validateLaboratoryTechnicianAccess>;
+  let mockQueryByLaboratoryId: jest.Mock;
+  let mockListBucketObjectsV2: jest.Mock;
+
+  const labRoot = 'test-org-id/test-lab-id/';
+  const platformPrefix = `${labRoot}aws-healthomics/`;
+  const transactionPrefix = `${platformPrefix}txn-uuid-1/`;
+  const resultsPrefix = `${transactionPrefix}results/`;
+
+  const mockLaboratory = {
+    OrganizationId: 'test-org-id',
+    LaboratoryId: 'test-lab-id',
+    S3Bucket: 'test-bucket',
+  };
+
+  const createMockEvent = (body: Record<string, unknown>): APIGatewayProxyWithCognitoAuthorizerEvent => ({
+    body: JSON.stringify(body),
+    isBase64Encoded: false,
+    httpMethod: 'POST',
+    path: '/data-collections/request-laboratory-bucket-objects',
+    headers: {},
+    requestContext: {
+      requestId: 'request-id',
+      extendedRequestId: 'extended-request-id',
+      authorizer: { claims: { email: 'test@example.com' } },
+    } as any,
+    resource: '',
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    pathParameters: null,
+    stageVariables: null,
+    multiValueHeaders: {},
+  });
+
+  const createMockContext = (): Context => ({
+    functionName: 'request-laboratory-bucket-objects',
+    functionVersion: '$LATEST',
+    invokedFunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:request-laboratory-bucket-objects',
+    memoryLimitInMB: '128',
+    awsRequestId: 'test-request-id',
+    logGroupName: '/aws/lambda/request-laboratory-bucket-objects',
+    logStreamName: '2026/03/17/[$LATEST]test',
+    identity: undefined,
+    clientContext: undefined,
+    callbackWaitsForEmptyEventLoop: true,
+    getRemainingTimeInMillis: () => 30000,
+    done: jest.fn(),
+    fail: jest.fn(),
+    succeed: jest.fn(),
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockValidateSystemAdmin = validateSystemAdminAccess as jest.MockedFunction<typeof validateSystemAdminAccess>;
+    mockValidateOrgAdmin = validateOrganizationAdminAccess as jest.MockedFunction<
+      typeof validateOrganizationAdminAccess
+    >;
+    mockValidateLabManager = validateLaboratoryManagerAccess as jest.MockedFunction<
+      typeof validateLaboratoryManagerAccess
+    >;
+    mockValidateLabTechnician = validateLaboratoryTechnicianAccess as jest.MockedFunction<
+      typeof validateLaboratoryTechnicianAccess
+    >;
+
+    mockValidateSystemAdmin.mockReturnValue(false);
+    mockValidateOrgAdmin.mockReturnValue(false);
+    mockValidateLabManager.mockReturnValue(false);
+    mockValidateLabTechnician.mockReturnValue(false);
+
+    const mockLaboratoryServiceInstance = LaboratoryService as jest.MockedClass<typeof LaboratoryService>;
+    mockQueryByLaboratoryId = jest.fn();
+    mockLaboratoryServiceInstance.prototype.queryByLaboratoryId = mockQueryByLaboratoryId;
+
+    const mockS3ServiceInstance = S3Service as jest.MockedClass<typeof S3Service>;
+    mockListBucketObjectsV2 = jest.fn();
+    mockS3ServiceInstance.prototype.listBucketObjectsV2 = mockListBucketObjectsV2;
+  });
+
+  it('returns transaction-root input files and never lists objects under results/', async () => {
+    mockValidateOrgAdmin.mockReturnValue(true);
+    mockQueryByLaboratoryId.mockResolvedValue(mockLaboratory);
+
+    mockListBucketObjectsV2.mockImplementation(async (params: { Prefix?: string }) => {
+      const prefix = params.Prefix ?? '';
+      if (prefix === labRoot) {
+        return {
+          Contents: [],
+          CommonPrefixes: [{ Prefix: platformPrefix }],
+          IsTruncated: false,
+        };
+      }
+      if (prefix === platformPrefix) {
+        return {
+          Contents: [],
+          CommonPrefixes: [{ Prefix: transactionPrefix }],
+          IsTruncated: false,
+        };
+      }
+      if (prefix === transactionPrefix) {
+        return {
+          Contents: [
+            {
+              Key: `${transactionPrefix}sample_R1.fastq.gz`,
+              Size: 100,
+              LastModified: new Date('2026-01-01'),
+              ETag: '"abc"',
+              StorageClass: 'STANDARD',
+            },
+          ],
+          CommonPrefixes: [{ Prefix: resultsPrefix }],
+          IsTruncated: false,
+        };
+      }
+      if (prefix === resultsPrefix) {
+        throw new Error('Should not list under results/');
+      }
+      throw new Error(`Unexpected prefix: ${prefix}`);
+    });
+
+    const response = await handler(createMockEvent({ LaboratoryId: 'test-lab-id' }), createMockContext(), jest.fn());
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    const keys = (body.Contents || []).map((o: { Key: string }) => o.Key);
+    expect(keys).toEqual([`${transactionPrefix}sample_R1.fastq.gz`]);
+    expect(keys.some((k: string) => k.includes('/results/'))).toBe(false);
+    expect(body.Recursive).toBeUndefined();
+    expect(body.ListingTruncated).toBe(false);
+    expect(mockListBucketObjectsV2).not.toHaveBeenCalledWith(expect.objectContaining({ Prefix: resultsPrefix }));
+  });
+
+  it('skips workflow-definitions at lab root and does not list into it', async () => {
+    mockValidateOrgAdmin.mockReturnValue(true);
+    mockQueryByLaboratoryId.mockResolvedValue(mockLaboratory);
+
+    const workflowDefsPrefix = `${labRoot}workflow-definitions/`;
+
+    mockListBucketObjectsV2.mockImplementation(async (params: { Prefix?: string }) => {
+      const prefix = params.Prefix ?? '';
+      if (prefix === labRoot) {
+        return {
+          Contents: [],
+          CommonPrefixes: [{ Prefix: workflowDefsPrefix }, { Prefix: platformPrefix }],
+          IsTruncated: false,
+        };
+      }
+      if (prefix === platformPrefix) {
+        return { Contents: [], CommonPrefixes: [], IsTruncated: false };
+      }
+      if (prefix === workflowDefsPrefix) {
+        throw new Error('Should not list under workflow-definitions/');
+      }
+      throw new Error(`Unexpected prefix: ${prefix}`);
+    });
+
+    const response = await handler(createMockEvent({ LaboratoryId: 'test-lab-id' }), createMockContext(), jest.fn());
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body.Contents || []).toHaveLength(0);
+    expect(mockListBucketObjectsV2).not.toHaveBeenCalledWith(expect.objectContaining({ Prefix: workflowDefsPrefix }));
+  });
+
+  it('sets ListingTruncated when MaxTotalKeys is reached', async () => {
+    mockValidateOrgAdmin.mockReturnValue(true);
+    mockQueryByLaboratoryId.mockResolvedValue(mockLaboratory);
+
+    mockListBucketObjectsV2.mockImplementation(async (params: { Prefix?: string }) => {
+      const prefix = params.Prefix ?? '';
+      if (prefix === labRoot) {
+        return {
+          Contents: [],
+          CommonPrefixes: [{ Prefix: platformPrefix }],
+          IsTruncated: false,
+        };
+      }
+      if (prefix === platformPrefix) {
+        return {
+          Contents: [],
+          CommonPrefixes: [{ Prefix: transactionPrefix }, { Prefix: `${platformPrefix}txn-uuid-2/` }],
+          IsTruncated: false,
+        };
+      }
+      if (prefix.startsWith(platformPrefix)) {
+        const suffix = prefix === transactionPrefix ? '1' : '2';
+        return {
+          Contents: [
+            {
+              Key: `${prefix}file${suffix}.fastq.gz`,
+              Size: 1,
+              LastModified: new Date('2026-01-01'),
+              ETag: '"x"',
+              StorageClass: 'STANDARD',
+            },
+            {
+              Key: `${prefix}file${suffix}b.fastq.gz`,
+              Size: 1,
+              LastModified: new Date('2026-01-01'),
+              ETag: '"y"',
+              StorageClass: 'STANDARD',
+            },
+          ],
+          CommonPrefixes: [],
+          IsTruncated: false,
+        };
+      }
+      throw new Error(`Unexpected prefix: ${prefix}`);
+    });
+
+    const response = await handler(
+      createMockEvent({ LaboratoryId: 'test-lab-id', MaxTotalKeys: 2 }),
+      createMockContext(),
+      jest.fn(),
+    );
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body.ListingTruncated).toBe(true);
+    expect(body.ReturnedKeyCount).toBe(2);
+    expect((body.Contents || []).length).toBe(2);
+  });
+
+  it('rejects Recursive in request body', async () => {
+    mockValidateOrgAdmin.mockReturnValue(true);
+    mockQueryByLaboratoryId.mockResolvedValue(mockLaboratory);
+
+    const response = await handler(
+      createMockEvent({ LaboratoryId: 'test-lab-id', Recursive: true }),
+      createMockContext(),
+      jest.fn(),
+    );
+
+    expect(response.statusCode).not.toBe(200);
+    expect(mockListBucketObjectsV2).not.toHaveBeenCalled();
+  });
+});

--- a/packages/front-end/src/app/components/EGDataCollectionsExplorer.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsExplorer.vue
@@ -43,7 +43,7 @@
     search: string;
     /** Files returned for the current S3 prefix (before search / tag filters in the parent). */
     listingFileCount: number;
-    /** Recursive listing stopped at MaxTotalKeys; more objects exist in S3. */
+    /** Listing stopped at MaxTotalKeys or MaxTransactionFolders; more objects may exist in S3. */
     listingTruncated?: boolean;
     /** Active filter chips (scope + tags); each chip can be dismissed independently in the explorer header. */
     filterChips?: { chipId: string; label: string }[];

--- a/packages/front-end/src/app/components/EGDataCollectionsPage.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsPage.vue
@@ -489,7 +489,6 @@
     try {
       const res = await $api.dataCollections.requestLaboratoryBucketObjects({
         LaboratoryId: props.labId,
-        Recursive: true,
         MaxTotalKeys: 25_000,
       });
       const nextTruncated = !!res.ListingTruncated;

--- a/packages/front-end/src/app/repository/modules/data-collections.ts
+++ b/packages/front-end/src/app/repository/modules/data-collections.ts
@@ -9,10 +9,10 @@ import HttpFactory from '@FE/repository/factory';
 export type RequestLaboratoryBucketObjectsBody = {
   LaboratoryId: string;
   RelativePrefix?: string;
-  /** When true, returns all file objects under the prefix (flat), paginated until MaxTotalKeys. */
-  Recursive?: boolean;
-  /** Cap for recursive listing (default 15000, max 50000). */
+  /** Cap on file objects returned (default 15000, max 50000). */
   MaxTotalKeys?: number;
+  /** Cap on transaction folders walked (default 10000, max 50000). */
+  MaxTransactionFolders?: number;
   MaxKeys?: number;
 };
 
@@ -22,8 +22,7 @@ export type LaboratoryBucketObjectsResponse = {
   IsTruncated: boolean;
   S3Bucket: string;
   ResolvedPrefix: string;
-  Recursive?: boolean;
-  /** True when recursive listing stopped early because {@link MaxTotalKeys} was reached. */
+  /** True when listing stopped early because a cap was reached. */
   ListingTruncated?: boolean;
   ReturnedKeyCount?: number;
 };

--- a/packages/shared-lib/src/app/schema/easy-genomics/data-collections/request-laboratory-bucket-objects.ts
+++ b/packages/shared-lib/src/app/schema/easy-genomics/data-collections/request-laboratory-bucket-objects.ts
@@ -6,16 +6,16 @@ export const RequestLaboratoryBucketObjectsSchema = z
     /** Optional prefix relative to the lab root `${OrganizationId}/${LaboratoryId}/`. */
     RelativePrefix: z.string().optional(),
     /**
-     * When true, lists all object keys under the resolved prefix (no delimiter), paginated until
-     * {@link MaxTotalKeys} is reached or S3 has no more results.
-     */
-    Recursive: z.boolean().optional(),
-    /**
-     * Hard cap on how many file objects to return when {@link Recursive} is true (prevents huge payloads).
+     * Hard cap on how many file objects to return (prevents huge payloads).
      * Default 15_000; max 50_000.
      */
     MaxTotalKeys: z.number().int().min(1).max(50000).optional(),
-    /** Max keys per S3 ListObjectsV2 request page (1–1000). Applies to both modes. */
+    /**
+     * Max transaction folders to walk before stopping with {@link ListingTruncated}.
+     * Default 10_000; max 50_000.
+     */
+    MaxTransactionFolders: z.number().int().min(1).max(50000).optional(),
+    /** Max keys per S3 ListObjectsV2 request page (1–1000). */
     MaxKeys: z.number().int().positive().max(1000).optional(),
   })
   .strict();


### PR DESCRIPTION
## Limit Data Collections S3 listing to transaction input files

## Type of Change*
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
The Data Collections page previously loaded the entire lab bucket with a single recursive `ListObjectsV2` call (`Recursive: true`, up to 25k keys). That included every object under each run’s `results/` (and Seqera `work/`) folders—outputs the explorer does not need and that were often hidden only by the client-side “Workflow outputs & other” file-type filter.

This PR replaces recursive listing with a delimiter-based shallow walk:

1. List `{orgId}/{labId}/` (platform folders + any lab-root files)
2. List each platform prefix (transaction folders + any platform-root files)
3. List each transaction prefix **one level only** (input files at the transaction root)

The API never descends into `results/`, `work/`, or `workflow-definitions/` common prefixes, so S3 is not asked to enumerate workflow output trees.

**API changes**
- Removed `Recursive` from the request schema and response (strict schema rejects legacy callers sending `Recursive: true`).
- Added optional `MaxTransactionFolders` (default 10,000; max 50,000) alongside existing `MaxTotalKeys`.
- `ListingTruncated` is set when either cap is reached.

**Frontend**
- `EGDataCollectionsPage` no longer sends `Recursive: true`.
- Repository types updated accordingly; truncation banner copy notes folder caps.

## Testing*
- Added `request-laboratory-bucket-objects.lambda.test.ts` with mocked S3:
  - Returns transaction-root `.fastq` keys and never calls `ListObjects` under `results/`
  - Skips `workflow-definitions/` at lab root
  - Sets `ListingTruncated` when `MaxTotalKeys` is reached
  - Rejects requests that include `Recursive`
- Ran: `pnpm exec jest test/app/controllers/easy-genomics/data-collections/request-laboratory-bucket-objects.lambda.test.ts` (4 tests passed)

**Manual verification (recommended)**
- [ ] Open Data Collections for a lab with completed runs; confirm input FASTQs appear and results artifacts are absent from the listing
- [ ] Confirm truncation banner still appears when appropriate for very large labs
- [ ] Restart local backend after deploy so the updated lambda is loaded

## Impact
**Performance:** Fewer S3 objects listed and returned; smaller payloads and fewer `request-list-file-tags` batches when `results/` previously dominated object counts.

**Behaviour:** Data Collections now surfaces only files at lab/platform/transaction roots (intended inputs). Workflow outputs under `results/` and Seqera `work/` are no longer fetched. Omics `workflow-definitions/` uploads are excluded from the walk.

**Trade-off:** Listing uses more `ListObjectsV2` calls (one per platform + transaction folder, concurrency 15) instead of one recursive sweep. For buckets where outputs greatly outnumbered inputs, overall cost and latency should improve; labs with an extremely large number of transaction folders may hit `MaxTransactionFolders` and see `ListingTruncated`.

**Breaking change:** Clients sending `Recursive` on `POST /data-collections/request-laboratory-bucket-objects` will receive a 400 invalid request. Only the Data Collections page uses this endpoint today, and it has been updated.

## Additional Information
- File Manager (`request-top-level-bucket-objects`) is unchanged; run-scoped browsing still works as before.
- Seed/maintenance scripts that list S3 directly (e.g. `seed-workflow-tagging-test-runs`) are unchanged.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.