### PR TITLE
fix: organizations table org switch with context

### DIFF
--- a/packages/front-end/src/app/components/EGOrgsList.vue
+++ b/packages/front-end/src/app/components/EGOrgsList.vue
@@ -7,6 +7,11 @@
   }>();
 
   const emit = defineEmits<{
+    /** Row click — select org and open Labs for that org (org admins) */
+    (event: 'select-org', org: Organization): void;
+    /** Action menu — open org management after switching context */
+    (event: 'manage-org', org: Organization): void;
+    /** @deprecated Use select-org / manage-org; kept for superuser admin list */
     (event: 'click-org', org: Organization): void;
   }>();
 
@@ -58,7 +63,7 @@
       [
         {
           label: 'View / Edit',
-          click: async () => viewOrg(org),
+          click: async () => manageOrg(org),
         },
       ],
     ];
@@ -79,8 +84,20 @@
     return items;
   }
 
-  function viewOrg(org: Organization) {
-    emit('click-org', org);
+  function selectOrg(org: Organization) {
+    if (props.superuser) {
+      emit('click-org', org);
+    } else {
+      emit('select-org', org);
+    }
+  }
+
+  function manageOrg(org: Organization) {
+    if (props.superuser) {
+      emit('click-org', org);
+    } else {
+      emit('manage-org', org);
+    }
   }
 
   // delete org stuff
@@ -120,7 +137,7 @@
   </EGPageHeader>
 
   <EGTable
-    :row-click-action="viewOrg"
+    :row-click-action="selectOrg"
     :table-data="orgsDisplayList"
     :columns="tableColumns"
     :is-loading="isLoading"

--- a/packages/front-end/src/app/components/EGSwitchOrgModal.vue
+++ b/packages/front-end/src/app/components/EGSwitchOrgModal.vue
@@ -6,36 +6,19 @@
   }>();
   const model = defineModel();
 
-  const { $api } = useNuxtApp();
   const $router = useRouter();
-
-  const userStore = useUserStore();
   const uiStore = useUiStore();
+  const { switchTo } = useSwitchOrganization();
 
   async function doSwitchOrg(): Promise<void> {
-    uiStore.setRequestPending('switchOrg');
+    if (!props.switchToOrgId) {
+      return;
+    }
 
     try {
-      userStore.mostRecentLab.LaboratoryId = null; // Reset
-
-      // update default org/lab in api
-      await $api.users.updateUserLastAccessInfo(userStore.currentUserDetails.id!, props.switchToOrgId, undefined);
-
-      // refresh values from api
-      await useAuth().getRefreshedToken();
-      await useUser().setCurrentUserDataFromToken();
-
+      await switchTo(props.switchToOrgId);
       $router.push('/');
-
-      // I hate this delay but there's a really screwy race condition otherwise
-      // it causes a bad bug where the new org will open to the previous org's lab, which shouldn't even be possible
-      setTimeout(() => {
-        uiStore.incrementRemountAppKey();
-        useToastStore().success('You have switched organizations');
-        uiStore.setRequestComplete('switchOrg');
-      }, 100);
     } catch (e) {
-      uiStore.setRequestComplete('switchOrg');
       throw e;
     }
   }

--- a/packages/front-end/src/app/composables/useSwitchOrganization.ts
+++ b/packages/front-end/src/app/composables/useSwitchOrganization.ts
@@ -1,0 +1,38 @@
+/**
+ * Switches the user's active organization (DefaultOrganization + JWT claims).
+ * Must match EGSwitchOrgModal so Labs and other org-scoped views use the correct context.
+ */
+export default function useSwitchOrganization() {
+  async function switchTo(orgId: string, options?: { showToast?: boolean }): Promise<void> {
+    const userStore = useUserStore();
+    const uiStore = useUiStore();
+    const { $api } = useNuxtApp();
+
+    userStore.mostRecentLab.LaboratoryId = null;
+
+    if (userStore.currentOrgId === orgId) {
+      return;
+    }
+
+    uiStore.setRequestPending('switchOrg');
+
+    try {
+      await $api.users.updateUserLastAccessInfo(userStore.currentUserDetails.id!, orgId, undefined);
+
+      await useAuth().getRefreshedToken();
+      await useUser().setCurrentUserDataFromToken();
+
+      // Avoid race where the new org opens the previous org's lab (see EG-1096)
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      uiStore.incrementRemountAppKey();
+
+      if (options?.showToast !== false) {
+        useToastStore().success('You have switched organizations');
+      }
+    } finally {
+      uiStore.setRequestComplete('switchOrg');
+    }
+  }
+
+  return { switchTo };
+}

--- a/packages/front-end/src/app/pages/orgs/[orgId]/index.vue
+++ b/packages/front-end/src/app/pages/orgs/[orgId]/index.vue
@@ -4,11 +4,13 @@
 
   const userStore = useUserStore();
 
-  const orgId = $route.params.orgId as string;
+  const orgId = computed(() => $route.params.orgId as string);
 
-  if (!userStore.canManageOrg(orgId)) {
-    $router.push({ path: '/' });
-  }
+  onMounted(() => {
+    if (!userStore.canManageOrg(orgId.value)) {
+      $router.push({ path: '/' });
+    }
+  });
 </script>
 
 <template>

--- a/packages/front-end/src/app/pages/orgs/index.vue
+++ b/packages/front-end/src/app/pages/orgs/index.vue
@@ -1,11 +1,24 @@
 <script setup lang="ts">
+  import { Organization } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/organization';
+
   const $router = useRouter();
+  const { switchTo } = useSwitchOrganization();
 
   if (!useUserStore().canManageAnyOrgs()) {
     $router.push({ path: '/' });
   }
+
+  async function onSelectOrg(org: Organization): Promise<void> {
+    await switchTo(org.OrganizationId, { showToast: false });
+    await navigateTo('/');
+  }
+
+  async function onManageOrg(org: Organization): Promise<void> {
+    await switchTo(org.OrganizationId, { showToast: false });
+    await navigateTo(`/orgs/${org.OrganizationId}`);
+  }
 </script>
 
 <template>
-  <EGOrgsList @click-org="(org) => $router.push({ path: '/orgs/' + org.OrganizationId })" />
+  <EGOrgsList @select-org="onSelectOrg" @manage-org="onManageOrg" />
 </template>


### PR DESCRIPTION
## fix: organizations table org switch with context

## Type of Change*
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [x] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Fix for organizations table navigation to new organization. The Organizations list navigates to /orgs/:id without running the org-switch flow (update last access, refresh token, clear mostRecentLab, remount). Made changes to run org switch flow on organizations table as well.

## Testing*
Tested manually on local environment

## Impact
This impacts org switching in organizations table.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.