### PR TITLE
fix: dialog component break word instead of all

### DIFF
--- a/packages/front-end/src/app/components/EGDialog.vue
+++ b/packages/front-end/src/app/components/EGDialog.vue
@@ -50,7 +50,7 @@
       <template #header>
         <div class="flex flex-col">
           <div class="flex items-start gap-2">
-            <EGText tag="h3" class="mb-6 min-w-0 flex-1 break-all">{{ primaryMessage }}</EGText>
+            <EGText tag="h3" class="mb-6 min-w-0 flex-1 break-words">{{ primaryMessage }}</EGText>
             <div class="shrink-0">
               <UButton
                 @click="handleCancel"


### PR DESCRIPTION
## fix: dialog component break word instead of all

## Type of Change*
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [x] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Fix EGDIalog component to use break-word attribute so word don't get divided in the dialogs.

## Testing*
Tested on local environment.

## Impact
This only impacts the workd break property in the EG dialog title.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.