### PR TITLE
[WIP] feat: group file with same name and add new popover functionality

### DIFF
--- a/packages/back-end/src/app/services/easy-genomics/laboratory-service.ts
+++ b/packages/back-end/src/app/services/easy-genomics/laboratory-service.ts
@@ -88,7 +88,7 @@ export class LaboratoryService extends DynamoDBService implements Service<Labora
   };
 
   public queryByLaboratoryId = async (laboratoryId: string): Promise<Laboratory> => {
-    const logRequestMessage = `Query Laboratory by LaboratoryId=${laboratoryId} request`;
+    const logRequestMessage = `11234Query Laboratory by LaboratoryId=${laboratoryId} request`;
     console.info(logRequestMessage);
 
     const response: QueryCommandOutput = await this.queryItems({
@@ -143,7 +143,7 @@ export class LaboratoryService extends DynamoDBService implements Service<Labora
   };
 
   public queryByOrganizationId = async (organizationId: string): Promise<Laboratory[]> => {
-    const logRequestMessage = `Query Laboratory by OrganizationId=${organizationId} request`;
+    const logRequestMessage = `123Query Laboratory by OrganizationId=${organizationId} request`;
     console.info(logRequestMessage);
 
     const response: QueryCommandOutput = await this.queryItems({

--- a/packages/back-end/src/app/services/easy-genomics/laboratory-service.ts
+++ b/packages/back-end/src/app/services/easy-genomics/laboratory-service.ts
@@ -88,7 +88,7 @@ export class LaboratoryService extends DynamoDBService implements Service<Labora
   };
 
   public queryByLaboratoryId = async (laboratoryId: string): Promise<Laboratory> => {
-    const logRequestMessage = `11234Query Laboratory by LaboratoryId=${laboratoryId} request`;
+    const logRequestMessage = `Query Laboratory by LaboratoryId=${laboratoryId} request`;
     console.info(logRequestMessage);
 
     const response: QueryCommandOutput = await this.queryItems({
@@ -143,7 +143,7 @@ export class LaboratoryService extends DynamoDBService implements Service<Labora
   };
 
   public queryByOrganizationId = async (organizationId: string): Promise<Laboratory[]> => {
-    const logRequestMessage = `123Query Laboratory by OrganizationId=${organizationId} request`;
+    const logRequestMessage = `Query Laboratory by OrganizationId=${organizationId} request`;
     console.info(logRequestMessage);
 
     const response: QueryCommandOutput = await this.queryItems({

--- a/packages/front-end/src/app/components/EGDataCollectionsExplorer.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsExplorer.vue
@@ -7,8 +7,14 @@
     LaboratoryDataTag,
     LaboratoryRunUsageSummary,
   } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/data-collections';
-  import type { DataCollectionFileTypeFilter, HiddenFileTypeBreakdownRow } from '@FE/utils/data-collections-file-type';
+  import type {
+    DataCollectionFileKind,
+    DataCollectionFileTypeFilter,
+    HiddenFileTypeBreakdownRow,
+  } from '@FE/utils/data-collections-file-type';
+  import { dataCollectionFileKind } from '@FE/utils/data-collections-file-type';
   import { formatFileSize } from '@FE/utils/file-size';
+  import { getSampleGroupId } from '@FE/utils/data-collections-to-sample-sheet';
 
   const props = defineProps<{
     /** Used to deep-link from the analysis history tooltip to a laboratory run detail page. */
@@ -57,7 +63,6 @@
     'update:search': [v: string];
     'update:fileTypeFilter': [value: DataCollectionFileTypeFilter];
     'update:selectedKeys': [keys: string[]];
-    toggleKey: [key: string];
     selectAllDisplayed: [];
     clearSelection: [];
     clearFilter: [chipId: string];
@@ -202,7 +207,7 @@
     () => !props.loading && props.listingFileCount > 0 && props.visibleFiles.length === 0,
   );
 
-  const visibleSampleNoun = computed(() => (props.visibleFiles.length === 1 ? 'sample' : 'samples'));
+  const visibleSampleNoun = computed(() => (visibleDisplayGroupCount.value === 1 ? 'sample' : 'samples'));
 
   const batchTagsResolved = computed(() => props.batchTags ?? []);
 
@@ -232,18 +237,227 @@
     base: '[@media(pointer:coarse)]:hidden min-h-0 h-auto max-h-[min(80vh,32rem)] overflow-y-auto overflow-x-hidden px-2.5 py-2 text-xs font-normal whitespace-normal break-all text-left relative',
   };
 
+  /**
+   * Display unit in the explorer grid / table. Multi-lane paired reads sharing a sample id
+   * (matched by `getSampleGroupId`) collapse into one group; everything else is a solo group
+   * keyed by its raw S3 Key.
+   */
+  type DisplayGroup = {
+    /** Stable group id — folder + sampleId for grouped reads, raw S3 key for solos. */
+    groupId: string;
+    /** Every S3 key in the group (1 for solos, ≥2 for paired-read groups). */
+    keys: string[];
+    files: { Key: string; Size?: number; LastModified?: string }[];
+    /** First key (key-sorted). Used for popover open-tracking, folder path, drag preview. */
+    primaryKey: string;
+    fileCount: number;
+    /** Display label: sampleId for grouped reads, basename for solos. */
+    label: string;
+    isGroup: boolean;
+  };
+
+  /** Folder portion of an S3 key (with trailing slash); '' for root-level keys. */
+  function folderPrefix(key: string): string {
+    const i = key.lastIndexOf('/');
+    return i >= 0 ? key.slice(0, i + 1) : '';
+  }
+
+  /**
+   * Group paired reads sharing a sample id within the same S3 folder. Non-paired files
+   * (txt, html, fasta, index reads, etc.) become solo groups.
+   */
+  function buildDisplayGroups(files: { Key: string; Size?: number; LastModified?: string }[]): DisplayGroup[] {
+    const groups = new Map<string, { sampleId: string; files: typeof files }>();
+    const solos: typeof files = [];
+    for (const f of files) {
+      const sampleId = getSampleGroupId(fileName(f.Key));
+      if (sampleId === null) {
+        solos.push(f);
+        continue;
+      }
+      const groupKey = folderPrefix(f.Key) + ' ' + sampleId;
+      const existing = groups.get(groupKey);
+      if (existing) {
+        existing.files.push(f);
+      } else {
+        groups.set(groupKey, { sampleId, files: [f] });
+      }
+    }
+    const result: DisplayGroup[] = [];
+    for (const [groupKey, { sampleId, files: gFiles }] of groups) {
+      const sorted = [...gFiles].sort((a, b) => a.Key.localeCompare(b.Key));
+      const keys = sorted.map((f) => f.Key);
+      result.push({
+        groupId: groupKey,
+        keys,
+        files: sorted,
+        primaryKey: keys[0],
+        fileCount: keys.length,
+        label: sampleId,
+        isGroup: keys.length > 1,
+      });
+    }
+    for (const f of solos) {
+      result.push({
+        groupId: f.Key,
+        keys: [f.Key],
+        files: [f],
+        primaryKey: f.Key,
+        fileCount: 1,
+        label: fileName(f.Key),
+        isGroup: false,
+      });
+    }
+    return result;
+  }
+
+  function isGroupSelected(g: DisplayGroup): boolean {
+    return g.keys.every((k) => props.selectedKeys.includes(k));
+  }
+
+  function isGroupPartiallySelected(g: DisplayGroup): boolean {
+    const sel = new Set(props.selectedKeys);
+    let some = false;
+    let all = true;
+    for (const k of g.keys) {
+      if (sel.has(k)) some = true;
+      else all = false;
+    }
+    return some && !all;
+  }
+
+  /** Atomic toggle: deselect all keys in the group if all are selected, otherwise add them all. */
+  function onGroupToggle(g: DisplayGroup): void {
+    const s = new Set(props.selectedKeys);
+    if (g.keys.every((k) => s.has(k))) {
+      for (const k of g.keys) s.delete(k);
+    } else {
+      for (const k of g.keys) s.add(k);
+    }
+    emit('update:selectedKeys', [...s]);
+  }
+
+  /** Run usages across every key in the group, deduped by RunId, sorted newest first. */
+  function groupRunUsages(g: DisplayGroup): LaboratoryRunUsageSummary[] {
+    const seen = new Set<string>();
+    const merged: LaboratoryRunUsageSummary[] = [];
+    for (const k of g.keys) {
+      const usages = props.keyToRunUsages?.[k] ?? [];
+      for (const u of usages) {
+        if (!seen.has(u.RunId)) {
+          seen.add(u.RunId);
+          merged.push(u);
+        }
+      }
+    }
+    merged.sort((a, b) => (b.RunCreatedAt || '').localeCompare(a.RunCreatedAt || ''));
+    return merged;
+  }
+
+  function groupHasAnyRunUsage(g: DisplayGroup): boolean {
+    for (const k of g.keys) {
+      if ((props.keyToRunUsages?.[k]?.length ?? 0) > 0) return true;
+    }
+    return false;
+  }
+
+  /** Union of standard tag ids across all keys in the group, dedup-by-first-seen. */
+  function groupStandardTagIds(g: DisplayGroup): string[] {
+    const seen = new Set<string>();
+    const result: string[] = [];
+    for (const k of g.keys) {
+      for (const tid of props.keyToTagIds[k] ?? []) {
+        if (!seen.has(tid)) {
+          seen.add(tid);
+          result.push(tid);
+        }
+      }
+    }
+    return result;
+  }
+
+  function groupStandardTagNames(g: DisplayGroup): string[] {
+    return groupStandardTagIds(g)
+      .map((id: string) => tagById(id)?.Name ?? id)
+      .filter((n: string) => !!n);
+  }
+
+  function isGroupAllPermanent(g: DisplayGroup): boolean {
+    return g.keys.every((k) => isFilePermanent(k));
+  }
+
+  function isGroupAnyPermanent(g: DisplayGroup): boolean {
+    return g.keys.some((k) => isFilePermanent(k));
+  }
+
+  function groupBatchId(g: DisplayGroup): string | undefined {
+    const primary = keyToBatchResolved.value[g.primaryKey];
+    if (primary) return primary;
+    for (const k of g.keys) {
+      const b = keyToBatchResolved.value[k];
+      if (b) return b;
+    }
+    return undefined;
+  }
+
+  function groupBatchName(g: DisplayGroup): string {
+    const bid = groupBatchId(g);
+    if (!bid) return '—';
+    const tag = batchTagsResolved.value.find((b: LaboratoryDataTag) => b.TagId === bid);
+    return tag?.Name ?? bid;
+  }
+
+  /** Earliest expiry across the group's run usages, or undefined when no usages have one. */
+  function groupSoonestExpiresAt(g: DisplayGroup): number | undefined {
+    let soonest: number | undefined;
+    for (const k of g.keys) {
+      const usages = props.keyToRunUsages?.[k] ?? [];
+      for (const u of usages) {
+        if (typeof u.ExpiresAt === 'number' && (soonest === undefined || u.ExpiresAt < soonest)) {
+          soonest = u.ExpiresAt;
+        }
+      }
+    }
+    return soonest;
+  }
+
+  function groupExpiresLabel(g: DisplayGroup): string {
+    if (isGroupAllPermanent(g)) return 'Never';
+    const epoch = groupSoonestExpiresAt(g);
+    if (epoch === undefined) return '—';
+    const now = Math.floor(Date.now() / 1000);
+    const diffDays = Math.round((epoch - now) / 86400);
+    if (diffDays <= 0) return 'Expired';
+    if (diffDays === 1) return 'in 1 day';
+    if (diffDays < 30) return `in ${diffDays} days`;
+    const months = Math.round(diffDays / 30);
+    return months <= 1 ? 'in ~1 month' : `in ~${months} months`;
+  }
+
+  /** Payload for the analysis tooltip's "Files (N)" section. */
+  function groupFilesForPopover(
+    g: DisplayGroup,
+  ): { Key: string; fileName: string; size?: number; fileKind: DataCollectionFileKind }[] {
+    return g.files.map((f) => ({
+      Key: f.Key,
+      fileName: fileName(f.Key),
+      size: f.Size,
+      fileKind: dataCollectionFileKind(f.Key),
+    }));
+  }
+
   function batchSectionHeaderParts(sec: {
     batchId: string | null;
     title: string;
-    files: readonly { Key: string }[];
+    groups: readonly DisplayGroup[];
   }): BatchSectionHeaderParts {
-    const n = sec.files.length;
+    const n = sec.groups.length;
     const sampleNoun = n === 1 ? 'sample' : 'samples';
     const titleBold = sec.title;
     let notYetAnalyzed = 0;
     let analyzed = 0;
-    for (const f of sec.files) {
-      if (runCountForFileKey(f.Key) > 0) analyzed += 1;
+    for (const g of sec.groups) {
+      if (groupHasAnyRunUsage(g)) analyzed += 1;
       else notYetAnalyzed += 1;
     }
     return {
@@ -255,34 +469,35 @@
     };
   }
 
-  /** Group visible files by batch for section headers (single scroll, not nested folders). */
+  /** Group visible files by batch, then collapse paired reads into DisplayGroups per section. */
   const fileSections = computed(() => {
     type Row = (typeof props.visibleFiles)[number];
     const nameById = new Map<string, string>(
       batchTagsResolved.value.map((t: LaboratoryDataTag) => [t.TagId, t.Name] as [string, string]),
     );
-    const groups = new Map<string | null, Row[]>();
+    const byBatch = new Map<string | null, Row[]>();
     for (const f of props.visibleFiles) {
       const bid = keyToBatchResolved.value[f.Key] ?? null;
-      if (!groups.has(bid)) groups.set(bid, []);
-      groups.get(bid)!.push(f);
+      if (!byBatch.has(bid)) byBatch.set(bid, []);
+      byBatch.get(bid)!.push(f);
     }
-    const batchEntries = [...groups.entries()].filter(([k]) => k !== null) as [string, Row[]][];
+    const batchEntries = [...byBatch.entries()].filter(([k]) => k !== null) as [string, Row[]][];
     batchEntries.sort((a, b) => {
       const na = nameById.get(a[0]) ?? a[0];
       const nb = nameById.get(b[0]) ?? b[0];
       return na.localeCompare(nb);
     });
-    const sections: { batchId: string | null; title: string; files: Row[] }[] = [];
-    const unbatched = groups.get(null);
+    const sections: { batchId: string | null; title: string; files: Row[]; groups: DisplayGroup[] }[] = [];
+    const unbatched = byBatch.get(null);
     if (unbatched?.length) {
-      sections.push({ batchId: null, title: 'Unbatched', files: unbatched });
+      sections.push({ batchId: null, title: 'Unbatched', files: unbatched, groups: buildDisplayGroups(unbatched) });
     }
     for (const [bid, files] of batchEntries) {
       sections.push({
         batchId: bid,
         title: nameById.get(bid) ?? bid,
         files,
+        groups: buildDisplayGroups(files),
       });
     }
     return sections.map((sec) => ({
@@ -290,6 +505,9 @@
       headerParts: batchSectionHeaderParts(sec),
     }));
   });
+
+  /** Total display-group count across all sections — used for the "X samples" header counter. */
+  const visibleDisplayGroupCount = computed(() => fileSections.value.reduce((n, sec) => n + sec.groups.length, 0));
 
   function batchDisplayName(key: string): string {
     const bid = keyToBatchResolved.value[key];
@@ -360,8 +578,12 @@
     scrollEl.value?.querySelectorAll('[data-file-card]').forEach((el) => {
       const h = el as HTMLElement;
       if (h.classList.contains('eg-data-collections-lasso-hit')) {
-        const id = h.dataset.key;
-        if (id) added.push(id);
+        // Each card carries every key in its display group (space-separated) so a single
+        // DOM hit pulls all paired-read files into the selection at once.
+        const raw = h.dataset.keys ?? h.dataset.key ?? '';
+        for (const k of raw.split(' ')) {
+          if (k) added.push(k);
+        }
       }
       h.classList.remove('eg-data-collections-lasso-hit');
     });
@@ -382,8 +604,11 @@
     window.removeEventListener('mouseup', onWindowMouseUp);
   });
 
-  function onCardDragStart(e: DragEvent, key: string): void {
-    const keys = props.selectedKeys.includes(key) ? [...props.selectedKeys] : [key];
+  function onCardDragStart(e: DragEvent, group: DisplayGroup): void {
+    // If the dragged group is fully selected, drag the whole current selection (existing
+    // multi-select behavior); otherwise drag exactly the keys in this group.
+    const groupSelected = group.keys.every((k) => props.selectedKeys.includes(k));
+    const keys = groupSelected ? [...props.selectedKeys] : [...group.keys];
     e.dataTransfer?.setData('application/x-eg-keys', JSON.stringify(keys));
     e.dataTransfer?.setData('text/plain', 'keys');
   }
@@ -434,7 +659,7 @@
     </motion.div>
     <div class="border-border-muted flex flex-wrap items-center gap-2 border-b bg-gray-50 px-4 py-2">
       <span class="text-xs font-semibold leading-snug text-gray-900">
-        {{ visibleFiles.length }} {{ visibleSampleNoun }}
+        {{ visibleDisplayGroupCount }} {{ visibleSampleNoun }}
       </span>
       <motion.div class="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
         <EGDataCollectionsHiddenFileTypesPopover
@@ -471,7 +696,7 @@
           :disabled="!visibleFiles.length || loading"
           @click="emit('selectAllDisplayed')"
         >
-          Select all ({{ visibleFiles.length }})
+          Select all ({{ visibleDisplayGroupCount }})
         </UButton>
       </div>
     </div>
@@ -534,61 +759,75 @@
             </button>
           </div>
           <div
-            v-for="f in sec.files"
-            :key="f.Key"
+            v-for="g in sec.groups"
+            :key="g.groupId"
             data-file-card
-            :data-key="f.Key"
+            :data-keys="g.keys.join(' ')"
             draggable="true"
             class="border-border-muted relative min-w-0 cursor-pointer rounded-xl border bg-white p-3 shadow-sm transition"
             :class="{
-              'bg-primary-muted ring-primary ring-2': selectedKeys.includes(f.Key),
-              'z-[80]': analysisPopoverOpenKey === f.Key,
+              'bg-primary-muted ring-primary ring-2': isGroupSelected(g),
+              'z-[80]': analysisPopoverOpenKey === g.primaryKey,
             }"
-            @click="emit('toggleKey', f.Key)"
-            @dragstart="onCardDragStart($event, f.Key)"
+            @click="onGroupToggle(g)"
+            @dragstart="onCardDragStart($event, g)"
             @dragend="onFileCardDragEnd"
           >
             <div class="absolute right-2 top-2 flex items-center gap-1.5" @mousedown.stop @click.stop>
               <UIcon
-                v-if="isFilePermanent(f.Key)"
+                v-if="isGroupAnyPermanent(g)"
                 name="i-heroicons-lock-closed"
                 class="h-3.5 w-3.5 shrink-0 text-red-600"
-                title="This file is protected from auto-deletion when run retention expires."
-                aria-label="Protected from auto-deletion"
+                :title="
+                  isGroupAllPermanent(g)
+                    ? 'This sample is protected from auto-deletion when run retention expires.'
+                    : 'Some files in this sample are protected from auto-deletion when run retention expires.'
+                "
+                :aria-label="
+                  isGroupAllPermanent(g) ? 'Protected from auto-deletion' : 'Some files protected from auto-deletion'
+                "
               />
-              <UCheckbox :model-value="selectedKeys.includes(f.Key)" @update:model-value="emit('toggleKey', f.Key)" />
+              <UCheckbox
+                :model-value="isGroupSelected(g)"
+                :indeterminate="isGroupPartiallySelected(g)"
+                @update:model-value="onGroupToggle(g)"
+              />
             </div>
             <div class="absolute left-0 top-0 z-[1]" @mousedown.stop @click.stop>
               <EGFileAnalysisHistoryTooltip
                 :lab-id="labId"
-                :file-key="f.Key"
-                :file-name="fileName(f.Key)"
-                :batch-name="batchDisplayName(f.Key) === '—' ? undefined : batchDisplayName(f.Key)"
-                :standard-tag-names="standardTagNamesForFileKey(f.Key)"
-                :run-usages="runUsagesForFileKey(f.Key)"
+                :file-key="g.primaryKey"
+                :file-name="g.label"
+                :batch-name="groupBatchName(g) === '—' ? undefined : groupBatchName(g)"
+                :standard-tag-names="groupStandardTagNames(g)"
+                :run-usages="groupRunUsages(g)"
+                :group-files="g.isGroup ? groupFilesForPopover(g) : undefined"
                 variant="card"
                 @select-run-files="emit('selectRunFiles', $event)"
-                @update:open="onAnalysisPopoverOpen(f.Key, $event)"
+                @update:open="onAnalysisPopoverOpen(g.primaryKey, $event)"
               />
             </div>
             <UTooltip :open-delay="500" :ui="s3PathTooltipUi">
               <template #text>
-                {{ s3ObjectTooltip(f.Key) }}
+                {{ s3ObjectTooltip(g.primaryKey) }}
               </template>
               <div class="w-full min-w-0 pr-8">
                 <div class="mt-7 line-clamp-2 w-full min-w-0 break-all text-sm font-medium leading-snug">
-                  {{ fileName(f.Key) }}
+                  {{ g.label }}
                 </div>
-                <div v-if="folderPathUnderLab(f.Key)" class="text-muted mt-0.5 truncate text-[11px]">
-                  {{ folderPathUnderLab(f.Key) }}
+                <div v-if="folderPathUnderLab(g.primaryKey)" class="text-muted mt-0.5 truncate text-[11px]">
+                  {{ folderPathUnderLab(g.primaryKey) }}
                 </div>
               </div>
             </UTooltip>
-            <div class="text-muted mt-1 text-xs">{{ formatFileSize(f.Size) }}</div>
+            <div class="text-muted mt-1 text-xs">
+              <template v-if="g.isGroup">{{ g.fileCount }} files</template>
+              <template v-else>{{ formatFileSize(g.files[0].Size) }}</template>
+            </div>
             <div class="mt-2 flex min-h-[1.25rem] min-w-0 max-w-full flex-wrap gap-1">
-              <template v-if="standardTagIdsForFileKey(f.Key).length">
+              <template v-if="groupStandardTagIds(g).length">
                 <span
-                  v-for="tid in standardTagIdsForFileKey(f.Key)"
+                  v-for="tid in groupStandardTagIds(g)"
                   :key="tid"
                   class="inline-flex min-w-0 max-w-full overflow-hidden rounded-full px-2 py-0.5 text-[10px] font-medium"
                   :title="tagById(tid)?.Name || tid"
@@ -667,70 +906,81 @@
                 </td>
               </tr>
               <tr
-                v-for="f in sec.files"
-                :key="f.Key"
+                v-for="g in sec.groups"
+                :key="g.groupId"
                 data-file-card
-                :data-key="f.Key"
+                :data-keys="g.keys.join(' ')"
                 draggable="true"
                 class="border-border-muted cursor-pointer border-b transition last:border-b-0"
                 :class="{
-                  'bg-primary-muted ring-primary ring-2 ring-inset': selectedKeys.includes(f.Key),
-                  'hover:bg-gray-50/80': !selectedKeys.includes(f.Key),
-                  'relative z-[80]': analysisPopoverOpenKey === f.Key,
+                  'bg-primary-muted ring-primary ring-2 ring-inset': isGroupSelected(g),
+                  'hover:bg-gray-50/80': !isGroupSelected(g),
+                  'relative z-[80]': analysisPopoverOpenKey === g.primaryKey,
                 }"
-                @click="emit('toggleKey', f.Key)"
-                @dragstart="onCardDragStart($event, f.Key)"
+                @click="onGroupToggle(g)"
+                @dragstart="onCardDragStart($event, g)"
                 @dragend="onFileCardDragEnd"
               >
                 <td class="px-3 py-2 align-middle" @mousedown.stop @click.stop>
                   <UCheckbox
-                    :model-value="selectedKeys.includes(f.Key)"
-                    @update:model-value="emit('toggleKey', f.Key)"
+                    :model-value="isGroupSelected(g)"
+                    :indeterminate="isGroupPartiallySelected(g)"
+                    @update:model-value="onGroupToggle(g)"
                   />
                 </td>
                 <td class="min-w-0 max-w-[14rem] overflow-hidden px-3 py-2 align-middle">
                   <UTooltip :open-delay="500" :ui="s3PathTooltipUi">
                     <template #text>
-                      {{ s3ObjectTooltip(f.Key) }}
+                      {{ s3ObjectTooltip(g.primaryKey) }}
                     </template>
                     <div class="min-w-0">
                       <div class="flex min-w-0 items-center gap-1.5">
                         <UIcon
-                          v-if="isFilePermanent(f.Key)"
+                          v-if="isGroupAnyPermanent(g)"
                           name="i-heroicons-lock-closed"
                           class="h-3.5 w-3.5 shrink-0 text-red-600"
-                          title="This file is protected from auto-deletion when run retention expires."
-                          aria-label="Protected from auto-deletion"
+                          :title="
+                            isGroupAllPermanent(g)
+                              ? 'This sample is protected from auto-deletion when run retention expires.'
+                              : 'Some files in this sample are protected from auto-deletion when run retention expires.'
+                          "
+                          :aria-label="
+                            isGroupAllPermanent(g)
+                              ? 'Protected from auto-deletion'
+                              : 'Some files protected from auto-deletion'
+                          "
                         />
-                        <span class="truncate font-medium text-gray-900">{{ fileName(f.Key) }}</span>
+                        <span class="truncate font-medium text-gray-900">{{ g.label }}</span>
                       </div>
-                      <div v-if="folderPathUnderLab(f.Key)" class="text-muted truncate text-xs">
-                        {{ folderPathUnderLab(f.Key) }}
+                      <div v-if="g.isGroup" class="text-muted truncate text-xs">{{ g.fileCount }} files</div>
+                      <div v-else-if="folderPathUnderLab(g.primaryKey)" class="text-muted truncate text-xs">
+                        {{ folderPathUnderLab(g.primaryKey) }}
                       </div>
                     </div>
                   </UTooltip>
                 </td>
-                <td class="text-muted px-3 py-2 align-middle">{{ batchDisplayName(f.Key) }}</td>
+                <td class="text-muted px-3 py-2 align-middle">{{ groupBatchName(g) }}</td>
                 <td class="px-3 py-2 align-middle">
                   <span class="inline-flex w-fit max-w-full align-middle" @mousedown.stop @click.stop>
                     <EGFileAnalysisHistoryTooltip
                       :lab-id="labId"
-                      :file-key="f.Key"
-                      :file-name="fileName(f.Key)"
-                      :batch-name="batchDisplayName(f.Key) === '—' ? undefined : batchDisplayName(f.Key)"
-                      :standard-tag-names="standardTagNamesForFileKey(f.Key)"
-                      :run-usages="runUsagesForFileKey(f.Key)"
+                      :file-key="g.primaryKey"
+                      :file-name="g.label"
+                      :batch-name="groupBatchName(g) === '—' ? undefined : groupBatchName(g)"
+                      :standard-tag-names="groupStandardTagNames(g)"
+                      :run-usages="groupRunUsages(g)"
+                      :group-files="g.isGroup ? groupFilesForPopover(g) : undefined"
                       variant="table"
                       @select-run-files="emit('selectRunFiles', $event)"
-                      @update:open="onAnalysisPopoverOpen(f.Key, $event)"
+                      @update:open="onAnalysisPopoverOpen(g.primaryKey, $event)"
                     />
                   </span>
                 </td>
                 <td class="min-w-0 px-3 py-2 align-middle">
                   <div class="flex min-h-[1.25rem] min-w-0 max-w-full flex-wrap gap-1">
-                    <template v-if="standardTagIdsForFileKey(f.Key).length">
+                    <template v-if="groupStandardTagIds(g).length">
                       <span
-                        v-for="tid in standardTagIdsForFileKey(f.Key)"
+                        v-for="tid in groupStandardTagIds(g)"
                         :key="tid"
                         class="inline-flex min-w-0 max-w-full overflow-hidden rounded-full px-2 py-0.5 text-[10px] font-medium"
                         :title="tagById(tid)?.Name || tid"
@@ -748,13 +998,13 @@
                 </td>
                 <td class="text-muted px-3 py-2 align-middle">
                   <UIcon
-                    v-if="isFilePermanent(f.Key)"
+                    v-if="isGroupAllPermanent(g)"
                     name="i-heroicons-lock-closed"
                     class="inline-block h-3.5 w-3.5 text-red-600"
-                    title="This file is protected from auto-deletion when run retention expires. It does not expire with run retention."
+                    title="This sample is protected from auto-deletion when run retention expires. It does not expire with run retention."
                     aria-label="Protected from auto-deletion; does not expire with run retention"
                   />
-                  <span v-else class="tabular-nums">{{ formatExpiresLabel(f.Key) }}</span>
+                  <span v-else class="tabular-nums">{{ groupExpiresLabel(g) }}</span>
                 </td>
               </tr>
             </template>

--- a/packages/front-end/src/app/components/EGDataCollectionsExplorer.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsExplorer.vue
@@ -14,7 +14,7 @@
   } from '@FE/utils/data-collections-file-type';
   import { dataCollectionFileKind } from '@FE/utils/data-collections-file-type';
   import { formatFileSize } from '@FE/utils/file-size';
-  import { getSampleGroupId } from '@FE/utils/data-collections-to-sample-sheet';
+  import { getReadDirection, getSampleGroupId } from '@FE/utils/data-collections-to-sample-sheet';
 
   const props = defineProps<{
     /** Used to deep-link from the analysis history tooltip to a laboratory run detail page. */
@@ -380,6 +380,20 @@
     return groupStandardTagIds(g)
       .map((id: string) => tagById(id)?.Name ?? id)
       .filter((n: string) => !!n);
+  }
+
+  /** True when the group contains at least one R1 and one R2 file (a true paired-end sample). */
+  function isGroupPaired(g: DisplayGroup): boolean {
+    if (!g.isGroup) return false;
+    let hasR1 = false;
+    let hasR2 = false;
+    for (const f of g.files) {
+      const dir = getReadDirection(fileName(f.Key));
+      if (dir === 'R1') hasR1 = true;
+      else if (dir === 'R2') hasR2 = true;
+      if (hasR1 && hasR2) return true;
+    }
+    return false;
   }
 
   function isGroupAllPermanent(g: DisplayGroup): boolean {
@@ -820,6 +834,15 @@
                 </div>
               </div>
             </UTooltip>
+            <div v-if="isGroupPaired(g)" class="mt-1.5">
+              <span
+                class="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[10px] font-medium text-emerald-700"
+                title="Paired-end reads (R1 + R2)"
+              >
+                <UIcon name="i-heroicons-link" class="h-3 w-3 shrink-0" aria-hidden="true" />
+                Paired
+              </span>
+            </div>
             <div class="text-muted mt-1 text-xs">
               <template v-if="g.isGroup">{{ g.fileCount }} files</template>
               <template v-else>{{ formatFileSize(g.files[0].Size) }}</template>

--- a/packages/front-end/src/app/components/EGDataCollectionsPage.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsPage.vue
@@ -766,13 +766,6 @@
     }
   }
 
-  function toggleKey(key: string): void {
-    const s = new Set(selectedKeys.value);
-    if (s.has(key)) s.delete(key);
-    else s.add(key);
-    selectedKeys.value = [...s];
-  }
-
   function selectAllDisplayed(): void {
     selectedKeys.value = visibleFiles.value.map((f) => f.Key);
   }
@@ -1405,7 +1398,6 @@
             @update:search="search = $event"
             @update:file-type-filter="fileTypeFilterEnabled = $event"
             @update:selected-keys="selectedKeys = $event"
-            @toggle-key="toggleKey"
             @select-all-displayed="selectAllDisplayed"
             @clear-selection="selectedKeys = []"
             @clear-filter="clearExplorerFilter($event)"

--- a/packages/front-end/src/app/components/EGFileAnalysisHistoryTooltip.vue
+++ b/packages/front-end/src/app/components/EGFileAnalysisHistoryTooltip.vue
@@ -6,6 +6,8 @@
    */
   import { format } from 'date-fns';
   import type { LaboratoryRunUsageSummary } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/data-collections';
+  import type { DataCollectionFileKind } from '@FE/utils/data-collections-file-type';
+  import { formatFileSize } from '@FE/utils/file-size';
 
   const props = defineProps<{
     labId: string;
@@ -19,6 +21,12 @@
     runUsages: LaboratoryRunUsageSummary[];
     /** Card = dot (+ count when N>1) + trailing chevron; table = dot + status label. */
     variant?: 'card' | 'table';
+    /**
+     * When set with length > 1, the panel renders an extra "Files (N)" section between
+     * the header and "Analysis History" — used when the card/row represents a sample
+     * group (paired reads across one or more lanes). Single-file callers omit this.
+     */
+    groupFiles?: { Key: string; fileName: string; size?: number; fileKind: DataCollectionFileKind }[];
   }>();
 
   const emit = defineEmits<{
@@ -32,6 +40,16 @@
   const STATUS_COLOR_MULTIPLE = '#5B4FD4';
 
   const runCount = computed(() => props.runUsages.length);
+
+  /** True when the popover should show the group "Files (N)" section. */
+  const showGroupFiles = computed(() => !!props.groupFiles && props.groupFiles.length > 1);
+
+  /** Label for the file-kind pill in the Files section. */
+  function fileKindLabel(kind: DataCollectionFileKind): string {
+    if (kind === 'fastq') return 'FASTQ';
+    if (kind === 'fasta') return 'FASTA';
+    return 'Other';
+  }
 
   const statusDescriptor = computed(() => {
     if (runCount.value === 0) {
@@ -163,6 +181,35 @@
           <div v-if="subtitleParts.length" class="text-muted mt-0.5 break-words text-xs leading-snug">
             {{ subtitleParts.join(' \u00b7 ') }}
           </div>
+        </div>
+
+        <!-- Group files section: appears between header and analysis history when the trigger represents a multi-file sample group. -->
+        <div v-if="showGroupFiles" class="border-b border-gray-200 py-3">
+          <div class="px-4 pb-2 text-xs font-semibold uppercase tracking-wide text-gray-700">
+            Files ({{ groupFiles!.length }})
+          </div>
+          <ul class="space-y-1">
+            <li v-for="gf in groupFiles" :key="gf.Key" class="flex items-center gap-2 px-4 py-1 text-xs">
+              <span
+                class="text-muted inline-flex shrink-0 items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium"
+              >
+                <span
+                  class="inline-block h-1.5 w-1.5 rounded-full"
+                  :class="{
+                    'bg-emerald-500': gf.fileKind === 'fastq',
+                    'bg-sky-500': gf.fileKind === 'fasta',
+                    'bg-gray-400': gf.fileKind === 'other',
+                  }"
+                  aria-hidden="true"
+                />
+                {{ fileKindLabel(gf.fileKind) }}
+              </span>
+              <span class="min-w-0 flex-1 break-all font-mono text-[11px] text-gray-900">{{ gf.fileName }}</span>
+              <span v-if="gf.size !== undefined" class="text-muted shrink-0 text-[11px] tabular-nums">
+                {{ formatFileSize(gf.size) }}
+              </span>
+            </li>
+          </ul>
         </div>
 
         <!-- Run list: section title inset from tooltip edge; rows keep tight right edge vs check column -->

--- a/packages/front-end/src/app/utils/data-collections-to-sample-sheet.ts
+++ b/packages/front-end/src/app/utils/data-collections-to-sample-sheet.ts
@@ -38,6 +38,21 @@ export function getSampleIdFromRFileName(fileName: string, sampleIdSplitPattern?
   return fileName.substring(0, fileName.lastIndexOf('_R')) || null;
 }
 
+/**
+ * Sample id for grouping multi-lane paired reads in the data collections explorer.
+ * Matches <sample>(_L<digits>)?_R[12](_<set>)?.f(ast)?q[.gz] — case-insensitive on the
+ * R direction. The lane suffix is only consumed when it directly precedes _R[12], so
+ * sample names that happen to contain "_L<digits>_" elsewhere are preserved.
+ *
+ * Returns null when the filename is not a paired read (txt, html, fasta, index reads,
+ * etc.); the caller treats those as solo display groups.
+ */
+export function getSampleGroupId(fileName: string): string | null {
+  const nameNoExt = getFileNameWithoutExt(fileName);
+  const m = nameNoExt.match(/^(.+?)(?:_L\d+)?_R[12](?:_.*)?$/i);
+  return m ? m[1] : null;
+}
+
 function getSharedSampleIdFromPair(
   r1Name?: string,
   r2Name?: string,

--- a/packages/front-end/test/app/utils/data-collections-sample-grouping.test.ts
+++ b/packages/front-end/test/app/utils/data-collections-sample-grouping.test.ts
@@ -1,0 +1,50 @@
+import { getSampleGroupId } from '../../../src/app/utils/data-collections-to-sample-sheet';
+
+describe('getSampleGroupId', () => {
+  it('groups multi-lane paired reads under the same sample id', () => {
+    expect(getSampleGroupId('WI-Jan-2024-S005_L001_R1_001.fastq.gz')).toBe('WI-Jan-2024-S005');
+    expect(getSampleGroupId('WI-Jan-2024-S005_L001_R2_001.fastq.gz')).toBe('WI-Jan-2024-S005');
+    expect(getSampleGroupId('WI-Jan-2024-S005_L002_R1_001.fastq.gz')).toBe('WI-Jan-2024-S005');
+    expect(getSampleGroupId('WI-Jan-2024-S005_L002_R2_001.fastq.gz')).toBe('WI-Jan-2024-S005');
+  });
+
+  it('handles single-lane paired reads (no _L<digits>)', () => {
+    expect(getSampleGroupId('Jan-2024-S001_R1_001.fastq.gz')).toBe('Jan-2024-S001');
+    expect(getSampleGroupId('Jan-2024-S001_R2_001.fastq.gz')).toBe('Jan-2024-S001');
+  });
+
+  it('handles paired reads with no trailing set number', () => {
+    expect(getSampleGroupId('SampleA_R1.fastq')).toBe('SampleA');
+    expect(getSampleGroupId('SampleA_R2.fastq.gz')).toBe('SampleA');
+  });
+
+  it('handles .fq and .fq.gz extensions', () => {
+    expect(getSampleGroupId('SampleA_R2_001.fq.gz')).toBe('SampleA');
+    expect(getSampleGroupId('SampleA_R1_001.fq')).toBe('SampleA');
+  });
+
+  it('is case-insensitive on the R direction marker', () => {
+    expect(getSampleGroupId('SampleA_r1_001.fastq.gz')).toBe('SampleA');
+    expect(getSampleGroupId('SampleA_r2_001.fastq.gz')).toBe('SampleA');
+  });
+
+  it('returns null for files that are not paired reads', () => {
+    expect(getSampleGroupId('multiqc_report.html')).toBeNull();
+    expect(getSampleGroupId('notes.txt')).toBeNull();
+    expect(getSampleGroupId('reference_genome_hg38.fasta')).toBeNull();
+  });
+
+  it('returns null for index reads (_I1, _I2) — they stay solo', () => {
+    expect(getSampleGroupId('SampleA_I1_001.fastq.gz')).toBeNull();
+    expect(getSampleGroupId('SampleA_L001_I2_001.fastq.gz')).toBeNull();
+  });
+
+  it('returns null when a lane is present but no R direction follows', () => {
+    expect(getSampleGroupId('Sample_L01_extra.fastq.gz')).toBeNull();
+  });
+
+  it('only consumes _L<digits> when it directly precedes _R[12]', () => {
+    // Lane is part of the sample name, not the lane suffix — keep it in the group id.
+    expect(getSampleGroupId('Lib_L99_thing_R1_001.fastq.gz')).toBe('Lib_L99_thing');
+  });
+});


### PR DESCRIPTION
## Title*
Group paired-read FASTQ files into one sample card/row in Data Collections

## Type of Change*
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
In the Data Collections explorer, every S3 object rendered as its own card / table row. Multi-lane paired-read samples therefore showed up as 2–8 separate "samples" — e.g. `WI-Jan-2024-S005_L001_R1`, `_L001_R2`, `_L002_R1`, `_L002_R2` appeared as four cards instead of one. This obscured the sample-level view lab users care about.

This PR collapses all files that share a sample base name into one display unit per sample:

- **New utility** `getSampleGroupId()` (`packages/front-end/src/app/utils/data-collections-to-sample-sheet.ts`) extracts a sample id from `<sample>(_L<digits>)?_R[12](_<set>)?.f(ast)?q[.gz]`, collapsing all lanes of a sample. It reuses the existing `getFileNameWithoutExt` and is case-insensitive. Non-paired files (`.txt`, `.fasta`, index reads `_I1`/`_I2`, etc.) return `null` and stay as solo cards.
- **Explorer** (`packages/front-end/src/app/components/EGDataCollectionsExplorer.vue`): introduces an internal `DisplayGroup` type and `buildDisplayGroups()`; each batch section now carries `groups`. Cards and table rows iterate groups. Grouping is scoped per S3 folder so identically-named samples in different folders don't merge.
  - Card label = sample id; meta shows `N files` for groups (file size unchanged for solos).
  - Selection, drag-and-drop, and lasso operate atomically on all keys in a group; checkbox is tri-state (all / partial / none).
  - Tags shown are the union across the group; status counts, "X samples" header, and "Select all (N)" count groups; expiry is the soonest across the group; the permanent lock shows for any-permanent with "Some files…" tooltip text when partial.
- **Analysis history popover** (`packages/front-end/src/app/components/EGFileAnalysisHistoryTooltip.vue`): additive `groupFiles` prop renders a new "Files (N)" section between the header and Analysis History, listing each file's type pill (FASTQ/FASTA/Other) + filename + size. Run usages are deduped by `RunId` across the group. Single-file callers are unchanged.
- Removed the now-dead `toggleKey` emit and its parent handler in `EGDataCollectionsPage.vue`, since card/row clicks now toggle whole groups via `update:selectedKeys`.

## Testing*
- **Unit tests** — new `packages/front-end/test/app/utils/data-collections-sample-grouping.test.ts` with 9 cases for `getSampleGroupId`: multi-lane, single-lane, no trailing set number, `.fq`/`.fq.gz` extensions, case-insensitive `_r1_`, non-paired files (`null`), index reads `_I1`/`_I2` (`null`), lane-without-direction (`null`), and lane-in-sample-name preservation. All 4 utils suites pass (35 tests).
- **Type check** — production source (`.ts`/`.vue`) emits no new TypeScript errors. Lint clean on the touched `.ts` files.
- **Manual E2E** — seed a lab with a 4-file multi-lane sample (`S005`), a 2-file single-lane pair (`S006`), and a non-paired file (`notes.txt`); confirm 3 cards ("4 files", "2 files", file size), group select/lasso/drag-tag operate on all keys, popover "Files (N)" section renders, partial-permanent lock + tooltip, and the table view mirrors card behavior.

## Impact
- UI-only change to the Data Collections explorer and its analysis popover; no API, schema, or backend changes.
- Parent (`EGDataCollectionsPage`) data shape (`visibleFiles` and the per-key maps) is unchanged; only the internal rendering and the now-removed `toggleKey` event differ.
- No new dependencies.

## Additional Information
- Grouping rule confirmed with design: all lanes of a sample collapse into one card; card meta shows just `N files` (no date — "Jan-2024" in the mockup was part of the test filename).
- Edge-case decisions: tags = union (not intersection); batch = primary key's batch with first-non-null fallback (no "mixed" marker in v1); permanent = lock shown if any file in the group is permanent.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.
