### PR TITLE
fix: s3 bucket errors for past runs

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/file/request-top-level-bucket-objects.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/file/request-top-level-bucket-objects.lambda.ts
@@ -93,18 +93,20 @@ export const handler: Handler = async (
       throw new InvalidRequestError('S3 bucket mismatch between S3Bucket and S3Prefix URI');
     }
 
-    // If a RunId is provided, authorize the requested S3 prefix against the run OutputS3Url (supports custom output dirs).
+    // If a RunId is provided, authorize against the run's stored S3 root (OutputS3Url, or InputS3Url for
+    // legacy runs). Mirrors the run detail File Manager, which prefers OutputS3Url then InputS3Url.
     // Otherwise, fall back to the original lab-owned prefix constraint.
     let normalizedPrefix = s3Prefix.endsWith('/') ? s3Prefix : `${s3Prefix}/`;
     if (request.RunId) {
       const run = await laboratoryRunService.get(laboratoryId, request.RunId);
-      const outputFromUri = run.OutputS3Url ? parseS3Uri(run.OutputS3Url) : null;
-      const outputBucket = outputFromUri?.bucket || laboratory.S3Bucket || requestBucket;
-      const outputPrefix = outputFromUri?.prefix || run.OutputS3Url || '';
+      const effectiveRunRootUrl = run.OutputS3Url || run.InputS3Url;
+      const rootFromUri = effectiveRunRootUrl ? parseS3Uri(effectiveRunRootUrl) : null;
+      const outputBucket = rootFromUri?.bucket || requestBucket || laboratory.S3Bucket || '';
+      const outputPrefix = rootFromUri?.prefix ?? '';
       const normalizedOutputPrefix = outputPrefix.endsWith('/') ? outputPrefix : `${outputPrefix}/`;
 
       if (!normalizedOutputPrefix || normalizedOutputPrefix === '/') {
-        throw new InvalidRequestError('Invalid OutputS3Url for run');
+        throw new InvalidRequestError('Invalid S3 location for run');
       }
 
       // Bucket must match the run output bucket

--- a/packages/back-end/test/app/controllers/easy-genomics/file/request-top-level-bucket-objects.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/file/request-top-level-bucket-objects.lambda.test.ts
@@ -247,6 +247,43 @@ describe('request-top-level-bucket-objects Lambda', () => {
     );
   });
 
+  it('allows listing for legacy runs with only InputS3Url when OutputS3Url is missing', async () => {
+    mockValidateOrgAdmin.mockReturnValue(true);
+    mockQueryByLaboratoryId.mockResolvedValue({
+      ...mockLaboratory,
+      S3Bucket: 'current-lab-bucket',
+    });
+    mockGetLaboratoryRun.mockResolvedValue({
+      LaboratoryId: 'test-lab-id',
+      RunId: 'run-legacy',
+      InputS3Url: 's3://original-bucket/test-org-id/test-lab-id/runs/run-legacy/input',
+    });
+    mockListBucketObjectsV2.mockResolvedValue({
+      Contents: [{ Key: 'test-org-id/test-lab-id/runs/run-legacy/input/sample.fq.gz', Size: 1 }],
+      CommonPrefixes: [],
+      IsTruncated: false,
+    });
+
+    const result = await handler(
+      createMockEvent({
+        LaboratoryId: 'test-lab-id',
+        RunId: 'run-legacy',
+        S3Bucket: 'original-bucket',
+        S3Prefix: 'test-org-id/test-lab-id/runs/run-legacy/input',
+      }),
+      createMockContext(),
+      () => {},
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(mockListBucketObjectsV2).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Bucket: 'original-bucket',
+        Prefix: 'test-org-id/test-lab-id/runs/run-legacy/input/',
+      }),
+    );
+  });
+
   it('defaults to the run OutputS3Url prefix when RunId is provided and S3Prefix is omitted', async () => {
     mockValidateOrgAdmin.mockReturnValue(true);
     mockQueryByLaboratoryId.mockResolvedValue(mockLaboratory);

--- a/packages/front-end/src/app/pages/labs/[labId]/run/[labRunId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/run/[labRunId].vue
@@ -254,12 +254,16 @@
       <!-- File Manager -->
       <div v-if="item.key === 'fileManager'" class="space-y-3">
         <EGFileExplorer
+          v-if="s3Bucket && s3Prefix"
           :lab-id="labId"
           :run-id="labRunId"
           :s3-bucket="s3Bucket"
           :s3-prefix="s3Prefix"
           :start-path="outputPath"
         />
+        <p v-else-if="labRun && !isLoading" class="text-muted rounded-lg border border-dashed p-6 text-center text-sm">
+          No S3 location is recorded for this run, so files cannot be listed.
+        </p>
       </div>
     </template>
   </UTabs>

--- a/packages/front-end/src/app/pages/labs/[labId]/seqera-run/[seqeraRunId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/seqera-run/[seqeraRunId].vue
@@ -1,13 +1,12 @@
 <script setup lang="ts">
   import { getDate, getTime } from '@FE/utils/date-time';
-  import { useLabsStore, useRunStore } from '@FE/stores';
+  import { useRunStore } from '@FE/stores';
   import { useDebounceFn } from '@vueuse/core';
 
   const { $api } = useNuxtApp();
   const $router = useRouter();
   const $route = useRoute();
   const runStore = useRunStore();
-  const labsStore = useLabsStore();
 
   const labId = $route.params.labId as string;
   const seqeraRunId = $route.params.seqeraRunId as string;
@@ -21,8 +20,16 @@
   }
 
   const labRunId = computed<string | null>(() => runStore.labRunByExternalId(seqeraRunId)?.RunId ?? null);
-  const s3Bucket = computed<string>(() => labsStore.labs[labId]?.S3Bucket ?? '');
-  const s3Prefix = computed<string>(() => `${useUserStore().currentOrgId}/${labId}/next-flow/${labRunId.value ?? ''}`);
+  const labRun = computed(() => (labRunId.value ? (runStore.labRuns[labRunId.value] ?? null) : null));
+  const effectiveRootS3Url = computed<string | null>(
+    () => labRun.value?.OutputS3Url ?? labRun.value?.InputS3Url ?? null,
+  );
+  const s3Bucket = computed<string | null>(
+    () => effectiveRootS3Url.value?.match(/(?<=^s3:\/\/)([a-z0-9][a-z0-9-]{1,61}[a-z0-9])(?=\/*)/g)?.toString() ?? null,
+  );
+  const s3Prefix = computed<string | null>(
+    () => effectiveRootS3Url.value?.match(/(?<=^s3:\/\/[a-z0-9][a-z0-9-]{1,61}[a-z0-9]\/)(.*)/g)?.toString() ?? null,
+  );
   const tabItems = computed(() => [
     { key: 'runDetails', label: 'Run Details' },
     { key: 'fileManager', label: 'File Manager' },
@@ -132,12 +139,15 @@
     <template #item="{ item }">
       <div v-show="item.key === 'fileManager'" class="space-y-3">
         <EGFileExplorer
-          v-if="labRunId && s3Bucket"
+          v-if="labRunId && s3Bucket && s3Prefix"
           :lab-id="labId"
           :run-id="labRunId"
           :s3-bucket="s3Bucket"
           :s3-prefix="s3Prefix"
         />
+        <p v-else-if="labRun" class="text-muted rounded-lg border border-dashed p-6 text-center text-sm">
+          No S3 location is recorded for this run, so files cannot be listed.
+        </p>
       </div>
       <div v-if="item.key === 'runDetails'" class="space-y-3">
         <section


### PR DESCRIPTION
## Title*
Fix S3 URL resolution for older laboratory runs (EGV-151)

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Fixes file visibility and listing errors for older laboratory runs after a lab's default S3 bucket is configured or changed.

**Problem**

When opening the File Manager for historical runs, users saw a "Failed to load folder contents" alert and could not browse run files. Newer runs worked as expected. This was most visible after configuring a default S3 bucket on a test lab that previously had none.

Root cause: the run detail File Manager resolves its S3 root as `OutputS3Url ?? InputS3Url`, but the `request-top-level-bucket-objects` API only authorized against `OutputS3Url`. Legacy runs often have `InputS3Url` only (or store files in the original bucket referenced by that URL). The API rejected those requests or resolved the wrong bucket when the lab's current `S3Bucket` differed from the run record.

The legacy Seqera run page (`/labs/{labId}/seqera-run/{seqeraRunId}`) also hard-coded `{orgId}/{labId}/next-flow/{runId}` using the lab's current bucket, which does not match where many runs actually store inputs/outputs.

**Changes**

- **Back-end:** When `RunId` is provided, authorize file listing against `OutputS3Url || InputS3Url`, matching the run detail UI. Prefer the bucket from the run's stored URL over the lab's configured bucket.
- **Front-end (run detail):** Only mount `EGFileExplorer` when bucket and prefix are available; show a clear empty state when no S3 location is recorded on the run.
- **Front-end (Seqera run page):** Resolve bucket/prefix from the laboratory run's stored S3 URLs instead of the hard-coded `next-flow/` path and lab default bucket.
- **Tests:** Add coverage for legacy runs with only `InputS3Url` when `OutputS3Url` is missing.

**Note:** Data Collections continues to list only the lab's configured `S3Bucket`. Input files that remain in a different bucket will not appear there until the lab bucket points at that location or data is migrated. This PR addresses run File Manager access, not multi-bucket Data Collections listing.

## Testing*
- [x] Reproduced the UAT issue locally against quality/UAT data: old run File Manager failed before fix, succeeded after.
- [x] Verified today's run File Manager still loads correctly.
- [x] Ran unit tests:
  `cd packages/back-end`
  `pnpm exec jest test/app/controllers/easy-genomics/file/request-top-level-bucket-objects.lambda.test.ts`
- [x] All 8 tests pass, including the new legacy InputS3Url-only case.

 Manual UAT verification after deploy (recommended): open an old run → File Manager tab on the affected test lab.

## Impact
- Behaviour: Older runs with only InputS3Url (or files in a bucket different from the lab's current default) can list files again in the run File Manager.
- Security: Run-scoped listing still requires the requested prefix to fall within the run's stored S3 root (or its immediate parent). Bucket must match the run record, not an arbitrary bucket.
- Performance / dependencies: No new dependencies or meaningful performance impact.
- Data Collections: Unchanged; still scoped to Laboratory.S3Bucket.

## Additional Information
N/A

## Checklist*
[ ] No new errors or warnings have been introduced.
[ ] All tests pass successfully and new tests added as necessary.
[ ] Documentation has been updated accordingly.
[ ] Code adheres to the coding and style guidelines of the project.
[ ] Code has been commented in particularly hard-to-understand areas.