### PR TITLE
docs: update migration for s3 staging

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -410,6 +410,8 @@ backEndApp.addScripts({
   ['invoke-process-handler']: 'tsx src/local-server/invoke-process-handler.ts',
   ['backfill-omics-run-tags']: 'tsx scripts/backfill-omics-run-tags.ts',
   ['backfill-omics-run-tags:dry-run']: 'tsx scripts/backfill-omics-run-tags.ts --dry-run',
+  ['migrate-lab-s3-bucket-refs']: 'tsx scripts/migrate-lab-s3-bucket-refs.ts',
+  ['migrate-lab-s3-bucket-refs:dry-run']: 'tsx scripts/migrate-lab-s3-bucket-refs.ts --dry-run',
 });
 
 if (backEndApp.eslint) {

--- a/docs/EASY_GENOMICS_PROD_MIGRATION.md
+++ b/docs/EASY_GENOMICS_PROD_MIGRATION.md
@@ -119,11 +119,38 @@ is that the REST API **invoke URL will change** because the easy-genomics API Ga
 stack. The front-end must be redeployed with the new URL (either via `AWS_EASY_GENOMICS_API_URL` or, in envs that have
 it, via the `ApiDomainStack` custom domain).
 
-### S3 buckets (out of scope for this migration)
+### S3 lab upload buckets (stateful for non-prod; MUST be backed up and copied)
 
-Only the non-prod data-provisioning lab bucket is CDK-managed, and its `removalPolicy` is still `DESTROY`. If your lower
-environment has lab files in that bucket that you want to keep, back them up separately via `aws s3 sync` before
-Phase 2. Prod lab buckets are not managed by this stack and are unaffected.
+In **non-prod** environments (`dev`, `demo`, `pre-prod`), the shared laboratory upload bucket is created by
+`DataProvisioningNestedStack` in `packages/back-end/src/infra/stacks/data-provisioning-nested-stack.ts` with
+`RemovalPolicy.DESTROY` and `autoDeleteObjects: true` (see `packages/back-end/src/infra/constructs/s3-construct.ts`).
+Unlike the eight DynamoDB tables, **there is no `cdk import` path for this bucket** — it cannot be adopted into the new
+stack with its existing physical name.
+
+**What the split changes**
+
+| Layout     | Where `DataProvisioningNestedStack` lives                                      | Lab bucket                                     |
+| ---------- | ------------------------------------------------------------------------------ | ---------------------------------------------- |
+| Pre-split  | `OLD_STACK` (`*-main-back-end-stack`), sibling to `easy-genomics-nested-stack` | One physical bucket owned by that nested stack |
+| Post-split | `NEW_STACK` (`*-easy-genomics-api-stack`)                                      | A **new** bucket is created on Phase 3.2       |
+
+**Phase 2 deletes the old lab bucket.** Deploying the split-stack template to `OLD_STACK` removes
+`data-provisioning-nested-stack` from that stack (it is no longer declared on `BackEndStack`). CloudFormation deletes
+the nested stack and, for non-prod, **empties and destroys** the S3 bucket it owned. This happens in the same Phase 2
+deploy that detaches `easy-genomics-nested-stack`; the runbook's DynamoDB retain steps do **not** protect S3.
+
+**DynamoDB keeps old S3 URLs.** Imported tables retain historical `S3Bucket` values on laboratory records and full
+`s3://…` URIs on laboratory-run records (`InputS3Url`, `OutputS3Url`, `SampleSheetS3Url`, etc.) from before migration.
+Phase 3.2 seeding overwrites the **default** laboratory row's `S3Bucket` with the new bucket name, but it does **not**
+rewrite per-run URLs. Without copying objects into the new bucket (or updating those records), older runs will point at
+a bucket that no longer exists.
+
+**Prod** lab buckets are not managed by this CDK app and are unaffected by this runbook.
+
+**Operator requirement (non-prod):** complete
+[Phase 1.5 — Lab S3 backup and inventory](#15-lab-s3-backup-and-inventory-mandatory-for-non-prod) before Phase 2, then
+[Phase 3.5 — Restore lab objects into the new bucket](#35-restore-lab-objects-into-the-new-bucket-non-prod) after Phase
+3.2. See [Appendix D](#appendix-d--lab-s3-migration-reference) for discovery commands and troubleshooting.
 
 ### What does NOT move (preserved automatically)
 
@@ -155,6 +182,8 @@ export ENV_TYPE=dev                # dev | demo | pre-prod | prod
 export NAME_PREFIX="${ENV_TYPE}-${ENV_NAME}"
 export OLD_STACK="${NAME_PREFIX}-main-back-end-stack"
 export NEW_STACK="${NAME_PREFIX}-easy-genomics-api-stack"
+export AWS_ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+export INTENDED_LAB_BUCKET="${AWS_ACCOUNT_ID}-${NAME_PREFIX}-lab-bucket"
 
 export EG_TABLES=(
   "${NAME_PREFIX}-organization-table"
@@ -463,16 +492,99 @@ for t in "${EG_TABLES[@]}"; do
 done
 ```
 
-### 1.5 (Optional) Back up the non-prod data-provisioning lab bucket
+### 1.5 Lab S3 backup and inventory (mandatory for non-prod)
 
-Only applies if the environment has a `${account}-${NAME_PREFIX}-lab-bucket` and you care about its contents:
+Skip this section only for `ENV_TYPE=prod`. For every other environment, treat lab S3 migration as **required**, not
+optional — Phase 2 will destroy the old bucket even if you skip backup.
+
+#### 1.5.1 Discover the **physical** bucket name (do not assume `INTENDED_LAB_BUCKET`)
+
+The name written into seed data (`${AWS_ACCOUNT_ID}-${NAME_PREFIX}-lab-bucket`) is the **intended** stable name, but
+many environments still have a **CloudFormation-generated** physical bucket from an earlier deploy (for example
+`pre-prod-quality-main-bac-preprodqualitydataprovis-qnef7o7lyeju`). Always resolve the bucket from CloudFormation or
+from live laboratory / run records — never sync from `INTENDED_LAB_BUCKET` unless you have confirmed it exists and holds
+your data.
 
 ```bash
-aws s3 sync "s3://${AWS_ACCOUNT_ID}-${NAME_PREFIX}-lab-bucket" \
-           "./backups/${NAME_PREFIX}-lab-bucket-${TS}"
+# Nested stack logical ID on OLD_STACK (pre-split layout)
+DATA_PROV_NESTED=$(aws cloudformation describe-stack-resources \
+  --region "$AWS_REGION" \
+  --stack-name "$OLD_STACK" \
+  --query "StackResources[?LogicalResourceId=='data-provisioning-nested-stack'].PhysicalResourceId" \
+  --output text)
+
+# S3 bucket inside that nested stack
+OLD_LAB_BUCKET=$(aws cloudformation list-stack-resources \
+  --region "$AWS_REGION" \
+  --stack-name "$DATA_PROV_NESTED" \
+  --query "StackResourceSummaries[?ResourceType=='AWS::S3::Bucket'].PhysicalResourceId" \
+  --output text)
+
+echo "OLD_LAB_BUCKET=${OLD_LAB_BUCKET}"
+aws s3 ls "s3://${OLD_LAB_BUCKET}/" --summarize --human-readable
 ```
 
-Restore is symmetrical after Phase 3 once the new bucket exists.
+If `OLD_LAB_BUCKET` is empty, the environment may never have provisioned data-provisioning S3 (fresh env) — confirm with
+your team before proceeding.
+
+Cross-check against DynamoDB (optional but recommended — surfaces buckets referenced by historical runs):
+
+```bash
+aws dynamodb scan \
+  --region "$AWS_REGION" \
+  --table-name "${NAME_PREFIX}-laboratory-table" \
+  --projection-expression "LaboratoryId, S3Bucket" \
+  --output table
+
+# Sample distinct buckets from run records (adjust limit as needed)
+aws dynamodb scan \
+  --region "$AWS_REGION" \
+  --table-name "${NAME_PREFIX}-laboratory-run-table" \
+  --projection-expression "SampleSheetS3Url, InputS3Url, OutputS3Url" \
+  --max-items 20 \
+  --output json \
+  | jq -r '[.[].SampleSheetS3Url, .[].InputS3Url, .[].OutputS3Url][]? | select(startswith("s3://")) | split("/")[2]] | unique | .[]'
+```
+
+Record `OLD_LAB_BUCKET` and any additional bucket names from run URLs in the change ticket. If more than one bucket
+appears, back up **each** bucket that still holds data you need (unusual, but possible after manual lab configuration).
+
+#### 1.5.2 Back up objects locally (or to a durable staging bucket)
+
+```bash
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+export OLD_LAB_BUCKET   # from step 1.5.1
+
+aws s3 sync "s3://${OLD_LAB_BUCKET}/" \
+  "./backups/${NAME_PREFIX}-lab-bucket-${TS}/" \
+  --only-show-errors
+
+# Verify the backup is non-empty when the source had objects
+find "./backups/${NAME_PREFIX}-lab-bucket-${TS}" -type f | wc -l
+du -sh "./backups/${NAME_PREFIX}-lab-bucket-${TS}"
+```
+
+For large environments, sync to a **separate** S3 bucket in the same account (or cross-account) instead of local disk:
+
+```bash
+STAGING_BUCKET="your-org-migration-staging-${AWS_ACCOUNT_ID}"
+aws s3 sync "s3://${OLD_LAB_BUCKET}/" "s3://${STAGING_BUCKET}/${NAME_PREFIX}/${TS}/"
+```
+
+Do **not** delete the backup until Phase 3.5 restore is verified and Phase 4 S3 smoke tests pass.
+
+#### 1.5.3 (Optional) Retain the old bucket without copying yet
+
+If you need a safety net beyond a sync backup, you can detach the bucket from CloudFormation **before** Phase 2 so Phase
+2 does not delete it. This is advanced and only needed when backup size or restore time is a concern:
+
+1. In the AWS console (or CLI), note the bucket policy and encryption settings on `OLD_LAB_BUCKET`.
+2. Remove the `AWS::S3::Bucket` resource from stack management via **Stack actions → Delete resources from stack** on
+   `DATA_PROV_NESTED`, selecting only the bucket, **or** use the resource-retain workflow your org standardizes on.
+3. After Phase 2, the bucket remains as an orphaned bucket; copy objects to the new bucket in Phase 3.5, then delete the
+   orphan manually once no records reference it.
+
+Most teams should rely on **1.5.2 + 3.5** instead of retention; document whichever path you choose in the change ticket.
 
 ### 1.6 Switch back to the merged branch for the remaining phases
 
@@ -493,6 +605,10 @@ Phases 2–5 all run from `development` (the merged split code).
 
 Goal: remove the easy-genomics nested stack (and everything inside it) from `OLD_STACK` with `Retain` semantics so the
 physical tables survive as **orphaned AWS resources** — no longer tracked by CloudFormation but fully intact.
+
+**S3 warning:** this deploy also removes `data-provisioning-nested-stack` from `OLD_STACK`. In non-prod, that **deletes
+the old lab upload bucket** (`OLD_LAB_BUCKET` from Phase 1.5). There is no rollback for bucket contents after deletion
+unless you completed Phase 1.5. Do not start Phase 2 until lab S3 backup is verified.
 
 ### 2.1 Announce maintenance window
 
@@ -522,9 +638,18 @@ Watch the CloudFormation events. You should see:
 
 - `UPDATE_IN_PROGRESS` on `OLD_STACK`.
 - `DELETE_IN_PROGRESS` / `DELETE_COMPLETE` on the `easy-genomics-nested-stack` and its child resources.
+- `DELETE_IN_PROGRESS` / `DELETE_COMPLETE` on `data-provisioning-nested-stack` and its child resources (including the
+  lab S3 bucket in non-prod). **Expected** for the split; irreversible for bucket contents unless Phase 1.5 was
+  completed.
 - For each table, `DELETE_SKIPPED (DeletionPolicy: Retain)` — this is the desired signal, and it only happens because
   Phase 1 put `DeletionPolicy: Retain` into the deployed template.
 - Eventually `UPDATE_COMPLETE` on `OLD_STACK`.
+
+After `UPDATE_COMPLETE`, confirm the old lab bucket is gone (non-prod):
+
+```bash
+aws s3 ls "s3://${OLD_LAB_BUCKET}/" 2>&1 || echo "OLD_LAB_BUCKET no longer exists (expected after Phase 2)"
+```
 
 If any table shows `DELETE_IN_PROGRESS` instead of `DELETE_SKIPPED`, **halt immediately**: Phase 1 did not actually land
 the retain metadata. Deletion protection (Phase 0) will still reject the delete call and CloudFormation will roll back,
@@ -705,6 +830,56 @@ aws cloudformation describe-stacks --region "$AWS_REGION" --stack-name "$NEW_STA
 Record this value — you will feed it to the front-end in Phase 4 as `AWS_EASY_GENOMICS_API_URL` (or wire it behind the
 `ApiDomainStack` custom domain if enabled for the environment).
 
+### 3.5 Restore lab objects into the new bucket (non-prod)
+
+After Phase 3.2, resolve the **new** physical bucket from `NEW_STACK` (do not assume it matches `INTENDED_LAB_BUCKET`
+until verified):
+
+```bash
+NEW_DATA_PROV_NESTED=$(aws cloudformation describe-stack-resources \
+  --region "$AWS_REGION" \
+  --stack-name "$NEW_STACK" \
+  --query "StackResources[?LogicalResourceId=='data-provisioning-nested-stack'].PhysicalResourceId" \
+  --output text)
+
+NEW_LAB_BUCKET=$(aws cloudformation list-stack-resources \
+  --region "$AWS_REGION" \
+  --stack-name "$NEW_DATA_PROV_NESTED" \
+  --query "StackResourceSummaries[?ResourceType=='AWS::S3::Bucket'].PhysicalResourceId" \
+  --output text)
+
+echo "NEW_LAB_BUCKET=${NEW_LAB_BUCKET}"
+echo "INTENDED_LAB_BUCKET=${INTENDED_LAB_BUCKET}"
+```
+
+Restore from the Phase 1.5 backup (adjust paths if you used a staging bucket):
+
+```bash
+TS=<timestamp-from-phase-1.5>
+aws s3 sync "./backups/${NAME_PREFIX}-lab-bucket-${TS}/" "s3://${NEW_LAB_BUCKET}/" --only-show-errors
+```
+
+Verify object counts and spot-check a few keys that older runs reference (sample sheets, uploads):
+
+```bash
+aws s3 ls "s3://${NEW_LAB_BUCKET}/" --recursive --summarize --human-readable | tail -5
+```
+
+**Historical run URLs:** copying objects preserves keys under the same prefix layout (`<org-id>/<lab-id>/…`), so
+`s3://${OLD_LAB_BUCKET}/…` paths often work after restore **only if** you either:
+
+1. **Copy into `NEW_LAB_BUCKET` and update DynamoDB** — change `S3Bucket` on affected laboratories and replace the
+   bucket host in each stored `s3://` URI on `laboratory-run-table` rows (recommended when `NEW_LAB_BUCKET` ≠
+   `OLD_LAB_BUCKET`), or
+2. **Retained `OLD_LAB_BUCKET` as an orphan** (Phase 1.5.3) — leave run URLs unchanged until you migrate records.
+
+The application's File Manager and download APIs authorize against the bucket embedded in each run record; after
+restore, open an **older** lab run in the UI and confirm listed files download successfully.
+
+If `NEW_LAB_BUCKET` differs from `INTENDED_LAB_BUCKET`, that is expected when CDK assigns an auto-generated physical
+name. The seeded laboratory row may still show `INTENDED_LAB_BUCKET` in DynamoDB — confirm the live bucket via
+CloudFormation (above) and align `Laboratory.S3Bucket` if uploads fail.
+
 ---
 
 ## Phase 4 — Smoke-test and re-enable traffic
@@ -720,6 +895,18 @@ curl -H "Authorization: Bearer $COGNITO_TOKEN" \
 
 Expected: the list returned reflects existing data (organizations, labs, users, lab runs) — **not** an empty result. If
 it returns empty, the import didn't actually adopt the tables; go to the rollback procedure.
+
+### 4.1.1 Lab S3 smoke tests (non-prod)
+
+After Phase 3.5:
+
+1. Pick a **pre-migration** laboratory run that stored files under `OLD_LAB_BUCKET` (from your change ticket).
+2. In the UI, open that run's File Manager (or call the list-objects API with the run's `RunId`) and confirm objects
+   list and download without `NoSuchBucket` errors.
+3. Upload a small test file to the lab and confirm it lands under `NEW_LAB_BUCKET` (prefix layout unchanged).
+
+If (2) fails but the Phase 1.5 backup is intact, the objects were likely not synced or run records still reference the
+deleted bucket name — re-run Phase 3.5 and/or update `laboratory-run-table` URIs as described in Phase 3.5.
 
 ### 4.2 Front-end rollout
 
@@ -746,9 +933,13 @@ Traffic can resume. Monitor CloudWatch for 5xx on either API for ~30 min.
 
 1. Delete the on-demand backups from Phase 0.4 / Phase 1.4 only after a retention window you're comfortable with
    (recommend ≥ 7 days in non-prod, ≥ 30 days in prod).
-2. Keep PITR and deletion protection enabled permanently — they're now enforced by code in the new stack.
-3. Update any env-specific runbooks / SSM parameters / secret stores with the new API URL.
-4. Verify the next CI auto-deploy against this environment goes **green**. Once the migration is complete,
+2. Delete the **lab S3 sync backup** from Phase 1.5 only after Phase 4.1.1 passes and you no longer need to re-sync
+   (same retention window as DynamoDB backups is reasonable).
+3. If you retained an orphaned `OLD_LAB_BUCKET` (Phase 1.5.3), delete it only after all `laboratory-run-table` URIs and
+   laboratory `S3Bucket` fields no longer reference it.
+4. Keep PITR and deletion protection enabled permanently — they're now enforced by code in the new stack.
+5. Update any env-specific runbooks / SSM parameters / secret stores with the new API URL.
+6. Verify the next CI auto-deploy against this environment goes **green**. Once the migration is complete,
    `cdk deploy --all` is once again a safe no-op for both stacks on this environment.
 
 ---
@@ -778,6 +969,12 @@ If Phase 2 fails (old stack update rolls back):
 
 - `DeletionPolicy: Retain` (Phase 1) + deletion protection (Phase 0) means the tables are untouched.
 - Investigate the failure, fix, and re-run Phase 2.
+
+If Phase 2 **succeeds** but lab files are missing afterward (non-prod):
+
+- The old lab bucket was likely deleted during the `data-provisioning-nested-stack` removal. Restore from the Phase 1.5
+  backup via Phase 3.5. If run records still reference `OLD_LAB_BUCKET` in `s3://` URIs, copy objects to
+  `NEW_LAB_BUCKET` and update those URIs (see Phase 3.5 and Appendix D). PITR on DynamoDB does not restore S3 objects.
 
 If Phase 3.1 (`cdk import`) fails before completion:
 
@@ -898,3 +1095,39 @@ pnpm cdk destroy "${NEW_STACK}" "${OLD_STACK}"
 ```
 
 Only run the above against environments you are certain you no longer need.
+
+---
+
+## Appendix D — Lab S3 migration reference
+
+### Why the old bucket name often does not match `INTENDED_LAB_BUCKET`
+
+`DataProvisioningNestedStack` seeds DynamoDB with `S3Bucket: ${account}-${namePrefix}-lab-bucket`, but the CDK
+`S3Construct` may provision a **different physical bucket** depending on code version and construct arguments. Always
+discover the live bucket from CloudFormation (Phase 1.5.1) before backup.
+
+### What gets deleted, and when
+
+| Event                                                | Lab bucket in non-prod                                   |
+| ---------------------------------------------------- | -------------------------------------------------------- |
+| Phase 2 `cdk deploy` of `OLD_STACK` (split template) | Old bucket deleted with `data-provisioning-nested-stack` |
+| Phase 3.2 `cdk deploy` of `NEW_STACK`                | New bucket created (empty until Phase 3.5 sync)          |
+| DynamoDB `cdk import`                                | No effect on S3                                          |
+| Preflight-blocked CI deploy                          | No effect on S3                                          |
+
+### Minimum checklist (non-prod)
+
+- [ ] Phase 1.5.1: `OLD_LAB_BUCKET` recorded from CloudFormation (and cross-checked against run URIs if needed)
+- [ ] Phase 1.5.2: `aws s3 sync` backup verified non-empty (when source had data)
+- [ ] Phase 2: CloudFormation shows `data-provisioning-nested-stack` deleted; old bucket gone
+- [ ] Phase 3.5: objects synced to `NEW_LAB_BUCKET`; spot-check keys for a pre-migration run
+- [ ] Phase 4.1.1: File Manager / download works for at least one pre-migration run
+- [ ] (If needed) `laboratory-run-table` / `laboratory-table` URIs updated to `NEW_LAB_BUCKET`
+
+### Symptom: pre-migration runs show missing files after migration
+
+1. Confirm `OLD_LAB_BUCKET` no longer exists (`aws s3 ls`).
+2. Confirm whether Phase 1.5 backup exists and Phase 3.5 was run against `NEW_LAB_BUCKET`.
+3. Inspect a failing run's `SampleSheetS3Url` / `InputS3Url` — if the host is still `OLD_LAB_BUCKET`, either restore
+   into that name (only possible if you retained the orphan bucket) or copy objects to `NEW_LAB_BUCKET` **and** update
+   the stored URI to use the new host (same object key suffix).

--- a/docs/EASY_GENOMICS_PROD_MIGRATION.md
+++ b/docs/EASY_GENOMICS_PROD_MIGRATION.md
@@ -865,20 +865,39 @@ Verify object counts and spot-check a few keys that older runs reference (sample
 aws s3 ls "s3://${NEW_LAB_BUCKET}/" --recursive --summarize --human-readable | tail -5
 ```
 
-**Historical run URLs:** copying objects preserves keys under the same prefix layout (`<org-id>/<lab-id>/…`), so
-`s3://${OLD_LAB_BUCKET}/…` paths often work after restore **only if** you either:
+**Historical run URLs:** copying objects preserves keys under the same prefix layout (`<org-id>/<lab-id>/…`). When
+`NEW_LAB_BUCKET` ≠ `OLD_LAB_BUCKET`, you must also update DynamoDB (step 3.5.1 below) so run records and laboratory
+`S3Bucket` fields reference the new host. If you retained `OLD_LAB_BUCKET` as an orphan (Phase 1.5.3), you can defer URI
+updates until after you copy objects and run 3.5.1.
 
-1. **Copy into `NEW_LAB_BUCKET` and update DynamoDB** — change `S3Bucket` on affected laboratories and replace the
-   bucket host in each stored `s3://` URI on `laboratory-run-table` rows (recommended when `NEW_LAB_BUCKET` ≠
-   `OLD_LAB_BUCKET`), or
-2. **Retained `OLD_LAB_BUCKET` as an orphan** (Phase 1.5.3) — leave run URLs unchanged until you migrate records.
+#### 3.5.1 Rewrite DynamoDB bucket references (when hosts differ)
 
-The application's File Manager and download APIs authorize against the bucket embedded in each run record; after
-restore, open an **older** lab run in the UI and confirm listed files download successfully.
+Use the maintenance script
+[`packages/back-end/scripts/migrate-lab-s3-bucket-refs.ts`](../packages/back-end/scripts/migrate-lab-s3-bucket-refs.ts)
+after the object sync above. It updates `Laboratory.S3Bucket` and rewrites `InputS3Url`, `OutputS3Url`, and
+`SampleSheetS3Url` on every `laboratory-run-table` row whose URI host matches `--oldBucket`.
 
-If `NEW_LAB_BUCKET` differs from `INTENDED_LAB_BUCKET`, that is expected when CDK assigns an auto-generated physical
-name. The seeded laboratory row may still show `INTENDED_LAB_BUCKET` in DynamoDB — confirm the live bucket via
-CloudFormation (above) and align `Laboratory.S3Bucket` if uploads fail.
+From `packages/back-end` with `.env.local` pointing at the target environment (`NAME_PREFIX`, `REGION`):
+
+```bash
+# Preview changes
+pnpm tsx scripts/migrate-lab-s3-bucket-refs.ts \
+  --oldBucket "${OLD_LAB_BUCKET}" \
+  --newBucket "${NEW_LAB_BUCKET}" \
+  --dry-run
+
+# Apply
+pnpm tsx scripts/migrate-lab-s3-bucket-refs.ts \
+  --oldBucket "${OLD_LAB_BUCKET}" \
+  --newBucket "${NEW_LAB_BUCKET}"
+```
+
+The application's File Manager and download APIs authorize against the bucket embedded in each run record; after 3.5 and
+3.5.1, open an **older** lab run in the UI and confirm listed files download successfully.
+
+New deployments use a stable physical bucket name `${AWS_ACCOUNT_ID}-${NAME_PREFIX}-lab-bucket` (see
+`S3Construct.createBucket` and `DataProvisioningNestedStack`). Environments migrated before that fix may still have had
+an auto-generated `OLD_LAB_BUCKET`; the script and sync steps above remain required for those envs.
 
 ---
 
@@ -1102,9 +1121,22 @@ Only run the above against environments you are certain you no longer need.
 
 ### Why the old bucket name often does not match `INTENDED_LAB_BUCKET`
 
-`DataProvisioningNestedStack` seeds DynamoDB with `S3Bucket: ${account}-${namePrefix}-lab-bucket`, but the CDK
-`S3Construct` may provision a **different physical bucket** depending on code version and construct arguments. Always
-discover the live bucket from CloudFormation (Phase 1.5.1) before backup.
+`DataProvisioningNestedStack` seeds DynamoDB with `S3Bucket: ${account}-${namePrefix}-lab-bucket`. Older deploys could
+still provision a **CloudFormation-generated** physical bucket when `createBucket` was called with reversed arguments or
+when `bucketName` was omitted for non-prod. Always discover the live bucket from CloudFormation (Phase 1.5.1) before
+backup. Current code passes `(envType, s3BucketFullName)` and sets `bucketName` for all environments when the name is
+supplied.
+
+### Bulk DynamoDB URI rewrite (script)
+
+| Step    | Command                                                                                                                |
+| ------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Dry run | `pnpm tsx scripts/migrate-lab-s3-bucket-refs.ts --oldBucket "$OLD_LAB_BUCKET" --newBucket "$NEW_LAB_BUCKET" --dry-run` |
+| Apply   | `pnpm tsx scripts/migrate-lab-s3-bucket-refs.ts --oldBucket "$OLD_LAB_BUCKET" --newBucket "$NEW_LAB_BUCKET"`           |
+
+Requires `NAME_PREFIX` and `REGION` in `packages/back-end/.env.local` (or the environment). The script scans
+`laboratory-table` and `laboratory-run-table`; it does not modify S3 objects — run Phase 3.5 `aws s3 sync` first so keys
+exist under `NEW_LAB_BUCKET`.
 
 ### What gets deleted, and when
 
@@ -1122,12 +1154,12 @@ discover the live bucket from CloudFormation (Phase 1.5.1) before backup.
 - [ ] Phase 2: CloudFormation shows `data-provisioning-nested-stack` deleted; old bucket gone
 - [ ] Phase 3.5: objects synced to `NEW_LAB_BUCKET`; spot-check keys for a pre-migration run
 - [ ] Phase 4.1.1: File Manager / download works for at least one pre-migration run
-- [ ] (If needed) `laboratory-run-table` / `laboratory-table` URIs updated to `NEW_LAB_BUCKET`
+- [ ] Phase 3.5.1: `migrate-lab-s3-bucket-refs.ts` dry-run + apply when `OLD_LAB_BUCKET` ≠ `NEW_LAB_BUCKET`
 
 ### Symptom: pre-migration runs show missing files after migration
 
 1. Confirm `OLD_LAB_BUCKET` no longer exists (`aws s3 ls`).
 2. Confirm whether Phase 1.5 backup exists and Phase 3.5 was run against `NEW_LAB_BUCKET`.
 3. Inspect a failing run's `SampleSheetS3Url` / `InputS3Url` — if the host is still `OLD_LAB_BUCKET`, either restore
-   into that name (only possible if you retained the orphan bucket) or copy objects to `NEW_LAB_BUCKET` **and** update
-   the stored URI to use the new host (same object key suffix).
+   into that name (only possible if you retained the orphan bucket) or copy objects to `NEW_LAB_BUCKET` **and** run
+   Phase 3.5.1 (`migrate-lab-s3-bucket-refs.ts`) to update the stored URI hosts (same object key suffix).

--- a/packages/back-end/package.json
+++ b/packages/back-end/package.json
@@ -28,7 +28,9 @@
     "local-server:watch": "tsx watch src/local-server/index.ts",
     "invoke-process-handler": "tsx src/local-server/invoke-process-handler.ts",
     "backfill-omics-run-tags": "tsx scripts/backfill-omics-run-tags.ts",
-    "backfill-omics-run-tags:dry-run": "tsx scripts/backfill-omics-run-tags.ts --dry-run"
+    "backfill-omics-run-tags:dry-run": "tsx scripts/backfill-omics-run-tags.ts --dry-run",
+    "migrate-lab-s3-bucket-refs": "tsx scripts/migrate-lab-s3-bucket-refs.ts",
+    "migrate-lab-s3-bucket-refs:dry-run": "tsx scripts/migrate-lab-s3-bucket-refs.ts --dry-run"
   },
   "author": {
     "name": "DEPT Agency",

--- a/packages/back-end/scripts/lib/lab-s3-uri-migration.ts
+++ b/packages/back-end/scripts/lib/lab-s3-uri-migration.ts
@@ -1,0 +1,34 @@
+import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory-run';
+
+export const S3_URI_FIELDS = ['InputS3Url', 'OutputS3Url', 'SampleSheetS3Url'] as const;
+
+export function rewriteS3UriHost(uri: string | undefined, oldBucket: string, newBucket: string): string | undefined {
+  if (uri == null || uri === '') return uri;
+  if (!uri.startsWith('s3://')) return uri;
+  const withoutScheme = uri.slice('s3://'.length);
+  const slash = withoutScheme.indexOf('/');
+  const host = slash === -1 ? withoutScheme : withoutScheme.slice(0, slash);
+  const suffix = slash === -1 ? '' : withoutScheme.slice(slash);
+  if (host !== oldBucket) return uri;
+  return `s3://${newBucket}${suffix}`;
+}
+
+export function rewriteLaboratoryRun(run: LaboratoryRun, oldBucket: string, newBucket: string): LaboratoryRun | null {
+  let changed = false;
+  const next: LaboratoryRun = { ...run };
+
+  for (const field of S3_URI_FIELDS) {
+    const current = run[field];
+    const rewritten = rewriteS3UriHost(current, oldBucket, newBucket);
+    if (rewritten !== current) {
+      if (rewritten === undefined) {
+        delete next[field];
+      } else {
+        next[field] = rewritten;
+      }
+      changed = true;
+    }
+  }
+
+  return changed ? next : null;
+}

--- a/packages/back-end/scripts/migrate-lab-s3-bucket-refs.ts
+++ b/packages/back-end/scripts/migrate-lab-s3-bucket-refs.ts
@@ -1,0 +1,113 @@
+/**
+ * One-off script to rewrite laboratory and laboratory-run DynamoDB fields after a lab
+ * S3 bucket migration (e.g. stack split where objects were synced to NEW_LAB_BUCKET but
+ * historical records still reference OLD_LAB_BUCKET in s3:// URIs).
+ *
+ * Run from packages/back-end (after Phase 3.5 object sync):
+ *   pnpm tsx scripts/migrate-lab-s3-bucket-refs.ts \
+ *     --oldBucket <physical-old-bucket> \
+ *     --newBucket <physical-new-bucket> \
+ *     [--dry-run]
+ *
+ * Requires .env.local (or env) with: NAME_PREFIX, REGION.
+ * Uses default AWS credentials (dynamodb:Scan, dynamodb:UpdateItem, dynamodb:PutItem).
+ */
+
+import path from 'path';
+import dotenv from 'dotenv';
+import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
+import { S3_URI_FIELDS, rewriteLaboratoryRun } from './lib/lab-s3-uri-migration';
+import { LaboratoryService } from '../src/app/services/easy-genomics/laboratory-service';
+import { LaboratoryRunService } from '../src/app/services/easy-genomics/laboratory-run-service';
+
+function loadEnv(): void {
+  const envPath = path.resolve(process.cwd(), '.env.local');
+  dotenv.config({ path: envPath });
+  if (process.env.REGION && !process.env.AWS_REGION) {
+    process.env.AWS_REGION = process.env.REGION;
+  }
+  const required = ['NAME_PREFIX', 'REGION'];
+  const missing = required.filter((k) => !process.env[k]);
+  if (missing.length > 0) {
+    console.error(`Missing required env: ${missing.join(', ')}. Set in .env.local or environment.`);
+    process.exit(1);
+  }
+}
+
+function argValue(flag: string): string | undefined {
+  const idx = process.argv.indexOf(flag);
+  if (idx === -1) return undefined;
+  return process.argv[idx + 1];
+}
+
+async function main(): Promise<void> {
+  loadEnv();
+
+  const oldBucket = argValue('--oldBucket');
+  const newBucket = argValue('--newBucket');
+  const dryRun = process.argv.includes('--dry-run');
+
+  if (!oldBucket || !newBucket) {
+    console.error(
+      'Usage: pnpm tsx scripts/migrate-lab-s3-bucket-refs.ts --oldBucket <name> --newBucket <name> [--dry-run]',
+    );
+    process.exit(1);
+  }
+  if (oldBucket === newBucket) {
+    console.error('--oldBucket and --newBucket must differ.');
+    process.exit(1);
+  }
+
+  if (dryRun) console.log('DRY RUN: no DynamoDB records will be modified.\n');
+
+  const laboratoryService = new LaboratoryService();
+  const laboratoryRunService = new LaboratoryRunService();
+
+  console.log(`Rewriting S3 bucket host: ${oldBucket} -> ${newBucket}\n`);
+
+  const laboratories = await laboratoryService.listAllLaboratories();
+  let labsUpdated = 0;
+  for (const lab of laboratories) {
+    if (lab.S3Bucket !== oldBucket) continue;
+    const updated: Laboratory = { ...lab, S3Bucket: newBucket };
+    if (dryRun) {
+      console.log(`[dry-run] Laboratory ${lab.LaboratoryId}: S3Bucket ${oldBucket} -> ${newBucket}`);
+    } else {
+      const existing = await laboratoryService.get(lab.OrganizationId, lab.LaboratoryId);
+      await laboratoryService.update(updated, existing);
+      console.log(`Updated laboratory ${lab.LaboratoryId} S3Bucket`);
+    }
+    labsUpdated++;
+  }
+
+  const allRuns = await laboratoryRunService.listAllLaboratoryRuns();
+  let runsUpdated = 0;
+  let runsSkipped = 0;
+
+  for (const run of allRuns) {
+    const updated = rewriteLaboratoryRun(run, oldBucket, newBucket);
+    if (!updated) {
+      runsSkipped++;
+      continue;
+    }
+    if (dryRun) {
+      const fields = S3_URI_FIELDS.filter((f) => run[f] !== updated[f]);
+      console.log(
+        `[dry-run] Run ${run.RunId} (lab ${run.LaboratoryId}): ${fields.map((f) => `${f}=${updated[f]}`).join(', ')}`,
+      );
+    } else {
+      await laboratoryRunService.update(updated);
+      console.log(`Updated run ${run.RunId} (lab ${run.LaboratoryId})`);
+    }
+    runsUpdated++;
+  }
+
+  console.log(
+    `\nDone. Laboratories updated: ${labsUpdated}. Runs updated: ${runsUpdated}. Runs unchanged: ${runsSkipped}.`,
+  );
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/back-end/src/infra/constructs/s3-construct.ts
+++ b/packages/back-end/src/infra/constructs/s3-construct.ts
@@ -14,10 +14,11 @@ export class S3Construct extends Construct {
 
   public createBucket = (envType: string, envBucketName?: string): Bucket => {
     const removalPolicy = envType !== 'prod' ? RemovalPolicy.DESTROY : undefined; // Only for Non-Prod
-    const constructId = envBucketName ?? `bucket-${Math.floor(Math.random() * 10000)}`;
+    // Logical ID must not start with a digit (account-prefixed bucket names do).
+    const constructId = envBucketName ? 'lab-data-bucket' : `bucket-${Math.floor(Math.random() * 10000)}`;
 
     const bucket = new Bucket(this, constructId, {
-      bucketName: envType === 'prod' ? envBucketName : undefined,
+      bucketName: envBucketName,
       objectOwnership: ObjectOwnership.BUCKET_OWNER_ENFORCED,
       blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
       encryption: BucketEncryption.S3_MANAGED,

--- a/packages/back-end/src/infra/stacks/data-provisioning-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/data-provisioning-nested-stack.ts
@@ -68,7 +68,7 @@ export class DataProvisioningNestedStack extends NestedStack {
       if (s3BucketFullName && s3BucketFullName.length > 63) {
         throw new Error(`S3 Bucket Name: "${s3BucketFullName}" is too long`);
       }
-      this.s3Construct.createBucket(s3BucketFullName, this.props.envType);
+      this.s3Construct.createBucket(this.props.envType, s3BucketFullName);
 
       // Add seed data to DynamoDB Tables
       this.addDynamoDBSeedData<Organization>(

--- a/packages/back-end/test/scripts/migrate-lab-s3-bucket-refs.test.ts
+++ b/packages/back-end/test/scripts/migrate-lab-s3-bucket-refs.test.ts
@@ -1,0 +1,28 @@
+import { rewriteS3UriHost } from '../../scripts/lib/lab-s3-uri-migration';
+
+describe('rewriteS3UriHost', () => {
+  const oldBucket = 'pre-prod-quality-main-bac-preprodqualitydataprovis-qnef7o7lyeju';
+  const newBucket = '654654609030-pre-prod-quality-lab-bucket';
+
+  it('rewrites bucket host and preserves key suffix', () => {
+    const uri =
+      's3://pre-prod-quality-main-bac-preprodqualitydataprovis-qnef7o7lyeju/org/lab/aws-healthomics/run/samplesheet.csv';
+    expect(rewriteS3UriHost(uri, oldBucket, newBucket)).toBe(
+      's3://654654609030-pre-prod-quality-lab-bucket/org/lab/aws-healthomics/run/samplesheet.csv',
+    );
+  });
+
+  it('leaves URIs for other buckets unchanged', () => {
+    const uri = 's3://other-bucket/org/lab/file.csv';
+    expect(rewriteS3UriHost(uri, oldBucket, newBucket)).toBe(uri);
+  });
+
+  it('returns undefined and empty string unchanged', () => {
+    expect(rewriteS3UriHost(undefined, oldBucket, newBucket)).toBeUndefined();
+    expect(rewriteS3UriHost('', oldBucket, newBucket)).toBe('');
+  });
+
+  it('returns non-s3 values unchanged', () => {
+    expect(rewriteS3UriHost('https://example.com/x', oldBucket, newBucket)).toBe('https://example.com/x');
+  });
+});


### PR DESCRIPTION
## Document and remediate lab S3 bucket loss during stack-split migration

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [x] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
During UAT testing after the API stack-split migration, pre-migration pipeline runs could not access their files because:

1. **Phase 2 removes `data-provisioning-nested-stack` from `*-main-back-end-stack`**, which deletes the non-prod lab upload bucket (`RemovalPolicy.DESTROY` + `autoDeleteObjects`).
2. **Phase 3.2 creates a new bucket** in `*-easy-genomics-api-stack`; objects are not moved automatically.
3. **DynamoDB import preserves historical `s3://` URIs** on `laboratory-run-table` rows, so older runs keep pointing at the deleted bucket host.

The runbook previously described S3 as “out of scope” and suggested backing up `${account}-${namePrefix}-lab-bucket`, which often does not match the **physical** CloudFormation-generated bucket name.

This PR:

### Migration runbook (`docs/EASY_GENOMICS_PROD_MIGRATION.md`)
- Replaces the S3 section with a clear warning that Phase 2 **destroys** the old lab bucket.
- Adds **Phase 1.5** (mandatory for non-prod): discover `OLD_LAB_BUCKET` from CloudFormation, back up via `aws s3 sync`, optional retain-or-orphan path.
- Adds **Phase 3.5** / **3.5.1**: restore objects into `NEW_LAB_BUCKET` and rewrite DynamoDB references.
- Updates Phase 2 expected CloudFormation events, Phase 4.1.1 S3 smoke tests, Phase 5 cleanup, rollback notes, and **Appendix D** (checklist + troubleshooting).

### `S3Construct` fix
- Corrects `DataProvisioningNestedStack` to call `createBucket(envType, s3BucketFullName)` (arguments were reversed since `7ceebbfa`).
- Sets `bucketName` whenever `envBucketName` is provided (not only for `prod`), so new non-prod deploys use `${account}-${namePrefix}-lab-bucket` consistently with seed data.

### `migrate-lab-s3-bucket-refs` maintenance script
- New script + `scripts/lib/lab-s3-uri-migration.ts` to rewrite `Laboratory.S3Bucket` and run fields `InputS3Url`, `OutputS3Url`, `SampleSheetS3Url` when the bucket host changes after migration.
- Registered in `.projenrc.ts` as `migrate-lab-s3-bucket-refs` and `migrate-lab-s3-bucket-refs:dry-run`.

**Related:** Complements #769 (File Manager / listing fixes for legacy runs when the bucket still exists). This PR addresses **data survival and DynamoDB alignment** across bucket replacement.

## Testing*
- [x] `pnpm exec jest test/scripts/migrate-lab-s3-bucket-refs.test.ts` — unit tests for `rewriteS3UriHost` (host rewrite, unchanged other buckets, non-S3 URIs).
- [ ] Manual (operators, post-merge): run migration runbook Phase 1.5 → 3.5 → 3.5.1 on a lower environment; verify pre-migration run File Manager access after sync + script dry-run/apply.

Example (from `packages/back-end`, with `.env.local` / `.env.quality.local` for the target env):

pnpm run migrate-lab-s3-bucket-refs:dry-run -- \
  --oldBucket "<OLD_LAB_BUCKET>" \
  --newBucket "<NEW_LAB_BUCKET>"

pnpm run migrate-lab-s3-bucket-refs -- \
  --oldBucket "<OLD_LAB_BUCKET>" \
  --newBucket "<NEW_LAB_BUCKET>"

## Impact
- Operators: Non-prod migrations must include lab S3 backup/restore; skipping Phase 1.5 is irreversible without an external backup.
- CDK: Next deploy to environments that already have an auto-generated lab bucket may still plan a bucket replacement if the template now sets an explicit bucketName; coordinate that separately. Greenfield / post-migration envs get stable bucket naming going forward.
- No new runtime dependencies. Script uses existing DynamoDB services and AWS credentials (same pattern as other packages/back-end/scripts/* tools).
- No production lab bucket CDK changes (envType === 'prod' still skips data-provisioning bucket creation).

## Additional Information
Recommended recovery order for environments already migrated without S3 backup:

- Restore objects from any Phase 1.5 backup (if available) into NEW_LAB_BUCKET.
- Run migrate-lab-s3-bucket-refs with --oldBucket / --newBucket from the change ticket.
- Re-run Phase 4.1.1 smoke tests from the runbook.
- If no backup exists and the old bucket was deleted in Phase 2, S3 data cannot be recovered via this PR alone.