### PR TITLE
feat: add/reorder package readme

### DIFF
--- a/packages/back-end/README.md
+++ b/packages/back-end/README.md
@@ -1,1 +1,32 @@
-# replace this
+# Back-End
+
+CDK infrastructure and AWS Lambda handlers for the Easy Genomics API. This package defines the serverless back-end: the
+HTTP and SQS Lambda functions, the domain service layer they call, and the CDK constructs and stacks that provision
+every AWS resource.
+
+## Key directories
+
+| Directory               | Purpose                                                            |
+| ----------------------- | ------------------------------------------------------------------ |
+| `src/app/controllers/`  | Lambda handlers — thin controllers, one file per route             |
+| `src/app/services/`     | Domain and AWS-SDK service layer (business logic lives here)       |
+| `src/infra/constructs/` | Reusable CDK constructs (DynamoDB, SNS, S3, etc.)                  |
+| `src/infra/stacks/`     | CDK stacks composing constructs into deployable infrastructure     |
+| `src/local-server/`     | Local dev server that proxies HTTP requests to the Lambda handlers |
+
+## Conventions
+
+Lambda filename prefixes (`create-`, `read-`, `list-`, `update-`, `delete-`, …) determine the HTTP route. Handlers stay
+thin — business logic belongs in a domain service, never inline in the handler or in a direct AWS-SDK call. See
+[`docs/development/contributing.md`](../../docs/development/contributing.md) for the full set of contribution
+conventions.
+
+## Running locally
+
+The back-end runs against real AWS services via a local dev server. See
+[`docs/development/local-backend-dev.md`](../../docs/development/local-backend-dev.md) for setup and troubleshooting.
+
+## Where to look next
+
+- [Documentation index](../../docs/README.md)
+- [Contributing guide](../../docs/development/contributing.md)

--- a/packages/front-end/README.md
+++ b/packages/front-end/README.md
@@ -1,1 +1,31 @@
-# replace this
+# Front-End
+
+The Easy Genomics web application, built with Nuxt 3 and Vue 3. It is the user-facing UI for managing organisations,
+labs, data uploads, and workflow runs.
+
+## Key directories
+
+| Directory              | Purpose                                               |
+| ---------------------- | ----------------------------------------------------- |
+| `src/app/pages/`       | File-based routes (Nuxt pages)                        |
+| `src/app/components/`  | Reusable Vue components (`EG`-prefixed)               |
+| `src/app/stores/`      | Pinia stores — application state and actions          |
+| `src/app/composables/` | Shared business logic (`useAuth`, `useMultiplatform`) |
+| `src/app/repository/`  | API client modules; all HTTP calls go through here    |
+
+## Layered architecture
+
+Data flows **Pages → Stores → Composables → Repository**. Components never call the repository layer directly — they go
+through Pinia stores or composables, and only the repository modules talk to the API. Token refresh is handled centrally
+by the repository's `HttpFactory`.
+
+## Running locally
+
+```bash
+pnpm dev
+```
+
+## Where to look next
+
+- [Documentation index](../../docs/README.md)
+- [Contributing guide](../../docs/development/contributing.md)

--- a/packages/shared-lib/README.md
+++ b/packages/shared-lib/README.md
@@ -1,1 +1,31 @@
-# replace this
+# Shared-Lib
+
+Shared TypeScript types, Zod schemas, utilities, and constants consumed by both the back-end and front-end packages.
+Keeping them in one place stops the two apps drifting out of sync on request/response shapes and validation rules.
+
+## Key directories
+
+| Directory            | Purpose                                                         |
+| -------------------- | --------------------------------------------------------------- |
+| `src/app/types/`     | Shared TypeScript types and generated API types                 |
+| `src/app/schema/`    | Zod schemas for request/response validation (reused everywhere) |
+| `src/app/utils/`     | Shared helpers (`buildResponse`, `HttpError` subtypes, …)       |
+| `src/app/constants/` | Shared constant values                                          |
+
+## Generated types
+
+Nextflow Tower / Seqera types and Zod schemas are generated from `src/app/types/nf-tower/seqera-api-latest.yml` via the
+projen `nftower-spec-to-zod` script (using `typed-openapi` / `openapi-typescript`). Do not hand-edit the generated files
+in `src/app/types/nf-tower/` — regenerate them instead.
+
+> An `src/app/openapi/` layout for the Easy Genomics API spec is planned with API-01; it does not exist yet.
+
+## Error classes
+
+Shared `HttpError` subtypes — `InvalidRequestError`, `NotFoundError`, `UnauthorizedAccessError`, etc. — live in
+[`src/app/utils/HttpError.ts`](src/app/utils/HttpError.ts). Throw these (never a bare `Error`) so handlers map them to
+the correct EG-xxx code.
+
+## Where to look next
+
+- [Documentation index](../../docs/README.md)


### PR DESCRIPTION
## Title*
docs: replace package-level README stubs (DOCS-07)

## Type of Change*
- [ ] New feature
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
The three package-level READMEs (`packages/back-end`, `packages/front-end`, `packages/shared-lib`) were each a 1-line `# replace this` placeholder, leaving a new contributor opening any package with zero orientation. This replaces each stub with a concise (~30-line) overview following one shared structure: *what the package is* → *key directories* → *running locally* → *where to look next*.

Each README links into the in-repo `docs/` structure (created in DOCS-04) rather than duplicating content:
- **back-end** — CDK + Lambda API; directory map; Lambda route/handler conventions; links to `docs/development/local-backend-dev.md` and `docs/development/contributing.md`.
- **front-end** — Nuxt 3 / Vue 3 app; directory map; the layered **Pages → Stores → Composables → Repository** flow described inline; `pnpm dev` to run.
- **shared-lib** — shared types/schemas/utils; how the nf-tower/Seqera types are generated (`nftower-spec-to-zod`); where the shared `HttpError` subtypes live.

**Design note:** the ticket suggested linking into `CLAUDE.md`, but `CLAUDE.md` is not tracked in this repo (it lives at the workspace root), so those links would render broken on GitHub. Architecture/convention guidance is therefore described briefly inline and links point only at in-repo `docs/` targets.

Relates to DOCS-07 (EGV-169). Depends on DOCS-04 (docs restructure, already merged) so the `docs/` links resolve.

## Testing*
Documentation-only change — no application code touched, so no automated tests apply. Verified manually:
- Each README is 30–34 lines (within the ticket's 30–60 target, under the 100 cap).
- All relative links resolve to existing in-repo files: `docs/README.md`, `docs/development/contributing.md`, `docs/development/local-backend-dev.md`, `packages/shared-lib/src/app/utils/HttpError.ts`, and the nf-tower spec.
- No `CLAUDE.md` references remain in any package README.
- Markdown tables and links render correctly in GitHub preview.

## Impact
Documentation only. No runtime, build, dependency, or behavioural changes. Improves contributor onboarding by giving each package a clear entry point into the `docs/` structure.

## Additional Information
Follow-up worth a separate ticket: `CLAUDE.md` and `ARCHITECTURE.md` are not tracked in this repo, so deeper architecture links currently have no in-repo target. Committing them (or an in-repo architecture doc) would let these READMEs link to canonical convention/architecture references.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary. <!-- N/A — docs-only; no tests applicable -->
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas. <!-- N/A — Markdown only -->
