### PR TITLE
docs: add troubleshooting and contributing guidence

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -2,11 +2,11 @@
 
 For contributors working on the Easy Genomics codebase.
 
-| Doc                                            | What it covers                                                              | Status                                                    |
-| ---------------------------------------------- | --------------------------------------------------------------------------- | --------------------------------------------------------- |
-| [local-backend-dev.md](./local-backend-dev.md) | Running the back-end locally for development                                | ✅ Available                                              |
-| [contributing.md](./contributing.md)           | Branch/commit conventions, test runners, CDK audit; full contributing guide | ✅ Conventions available · 🚧 full guide owned by DOCS-05 |
-| docs-site-decision.md                          | Docs-site tooling evaluation (Docusaurus vs alternatives)                   | 🚧 Owned by DOCS-06 (spike)                               |
+| Doc                                            | What it covers                                                             | Status                      |
+| ---------------------------------------------- | -------------------------------------------------------------------------- | --------------------------- |
+| [local-backend-dev.md](./local-backend-dev.md) | Running the back-end locally for development                               | ✅ Available                |
+| [contributing.md](./contributing.md)           | Claiming work, AI coding principles, conventions, testing, and the PR flow | ✅ Available                |
+| docs-site-decision.md                          | Docs-site tooling evaluation (Docusaurus vs alternatives)                  | 🚧 Owned by DOCS-06 (spike) |
 
 > **Architecture overview:** a complete `ARCHITECTURE.md` exists outside the repo but has no owning ticket after the
 > renumbering. A follow-up ticket is needed to review and commit it as `docs/development/architecture.md`.

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -1,8 +1,37 @@
 # Contributing
 
-> **Note:** This page holds the contribution conventions and test/audit commands relocated from the root `README.md`.
-> The full contributing guide — including the AI Coding Principles from `CLAUDE.md`, PR review expectations, and the
-> testing requirements from `TESTING.md` — is owned by DOCS-05 and will expand this page.
+How to contribute to Easy Genomics — for human and AI contributors alike. This page covers claiming work, the coding
+principles every change must follow, branch/commit conventions, testing expectations, and the pull-request flow.
+
+## Before you start
+
+Work is tracked as JIRA tickets identified by an `EG-XXX` code (the same code that goes into your branch name and
+commits — see [Branch Naming convention](#branch-naming-convention)).
+
+1. **Claim the ticket.** Assign the JIRA ticket to yourself (or create one) before writing code, so the work isn't
+   duplicated. External contributors without JIRA access should open a GitHub issue describing the change first and wait
+   for a maintainer to confirm before starting.
+2. **Reference `EG-XXX`** in your branch name and commit messages so the work is traceable.
+
+## AI Coding Principles
+
+Every change — whether written by a human or with AI assistance — must follow the **AI Coding Principles** and
+**Architecture Rules** defined in `CLAUDE.md` at the repo root. `CLAUDE.md` is the authoritative source; the summary
+below is a pointer, not a replacement — read it before contributing.
+
+- **Write for humans first** — descriptive names, explicit over clever, comment _why_ (not _what_).
+- **Be specific and consistent** — match the naming, structure, and patterns already in the codebase; don't invent new
+  ones where an established one fits.
+- **DRY** — reuse the shared utilities, services, and Zod schemas in `packages/shared-lib` and the domain services
+  before writing anything new.
+- **KISS** — the simplest solution that fully satisfies the requirement; Lambda handlers stay thin (≤ ~50 lines),
+  business logic lives in services.
+- **SOLID** — single-responsibility services, extend via new files, handlers depend on service abstractions (never AWS
+  SDK clients directly).
+- **Minimise noise** — read only what you need, show diffs not whole files, keep changes small.
+
+Error handling follows the typed-error rules in `ERROR_HANDLING.md` (repo root): use the typed error classes and
+`buildErrorResponse(err, event)`; never throw bare `Error`s or swallow failures silently.
 
 ## Test Runners
 
@@ -125,3 +154,29 @@ or
 
 [easy-genomics/packages/front-end]$ pnpm run cdk-audit
 ```
+
+## Testing expectations
+
+Testing standards are defined in `CLAUDE.md` (**Testing Standards**); `TESTING.md` at the repo root is the running
+manual test log. For any change:
+
+- **New happy paths need an end-to-end test.** E2E tests run against a fully deployed `quality` environment with
+  Playwright + Chromium (`pnpm run test-e2e` — see [Test Runners](#test-runners) above). Don't mock AWS services; the
+  suite makes real calls.
+- **New error paths** should at minimum be manually tested and logged in `TESTING.md`.
+- **Unit tests** (where they exist) live alongside the source file they test — follow the existing naming pattern in
+  that package.
+
+## Pull requests
+
+1. **Fill in the PR template.** Opening a PR pre-populates
+   [`.github/pull_request_template.md`](../../.github/pull_request_template.md): a descriptive **Title**, the **Type of
+   Change**, a **Description** with context and linked `EG-XXX`/issue, the **Testing** you performed, the **Impact**,
+   and the **Checklist**.
+2. **Review the diff.** Run the **PR Review Prompt** in `CLAUDE.md` against the diff between your branch and the target
+   branch. It focuses on the four things that block a merge: potential bugs, performance, security, and correctness —
+   not style nits.
+3. **Sign off** with the outcome: ✅ approved, or ☑️ issues found (with the issues listed). Address any ☑️ findings and
+   re-test before requesting a human review.
+
+Keep PRs focused: one ticket, the minimal change to satisfy it, no unrelated refactoring.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -2,10 +2,10 @@
 
 Day-2 operational guides: troubleshooting and migration runbooks.
 
-| Doc                                          | What it covers                                                   | Status              |
-| -------------------------------------------- | ---------------------------------------------------------------- | ------------------- |
-| troubleshooting.md                           | Common deploy/auth/run failures and the EG-xxx error-code lookup | 🚧 Owned by DOCS-05 |
-| [migration-runbooks/](./migration-runbooks/) | Environment migration runbooks                                   | ✅ Available        |
+| Doc                                          | What it covers                                                   | Status       |
+| -------------------------------------------- | ---------------------------------------------------------------- | ------------ |
+| [troubleshooting.md](./troubleshooting.md)   | Common deploy/auth/run failures and the EG-xxx error-code lookup | ✅ Available |
+| [migration-runbooks/](./migration-runbooks/) | Environment migration runbooks                                   | ✅ Available |
 
 ## migration-runbooks/
 

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -1,0 +1,176 @@
+# Troubleshooting
+
+Diagnosing failures in a deployed Easy Genomics environment: failed deploys, sign-in and invite problems, failed
+pipeline runs, and rejected file uploads.
+
+> Running the back-end locally instead? Local-dev issues (module resolution, `401 Unauthorized` against the local
+> server, expired AWS credentials) are covered in
+> [development/local-backend-dev.md](../development/local-backend-dev.md#troubleshooting).
+
+## How to diagnose any failure
+
+1. **Note the `EG-xxx` code.** Every API error carries one (in the response body and the front-end toast). It tells you
+   the HTTP status and the failing domain — see [Reading EG-xxx error codes](#reading-eg-xxx-error-codes).
+2. **Read the logs.** The code points at the domain; the logs tell you why — see [Finding logs](#finding-logs).
+3. **Match the symptom** to one of the sections below.
+
+---
+
+## Reading EG-xxx error codes
+
+Easy Genomics returns a stable `EG-xxx` application code alongside the HTTP status on every error response. The full
+catalogue is in `ERROR_HANDLING.md` (repo root) under **§ Error Code Reference**; HealthOmics run-failure reasons are
+under **§ AWS HealthOmics Run Failure Codes**.
+
+**Lookup workflow:**
+
+1. Copy the `EG-xxx` value from the failed request (API response body, or the browser toast / Network tab).
+2. Find it in `ERROR_HANDLING.md` → **Error Code Reference**. The row gives you the HTTP status and a one-line meaning.
+3. The first digit after `EG-` identifies the domain: `1xx` cross-cutting, `2xx` organization, `3xx` laboratory, `4xx`
+   user, `5xx` omics workflow, `6xx` Seqera. Use that to decide which Lambda log group to read (see below).
+
+The codes you will see most often:
+
+| Code   | HTTP | Meaning                                                                 |
+| ------ | ---- | ----------------------------------------------------------------------- |
+| EG-100 | 400  | Generic / unclassified error — should be rare; check Lambda logs        |
+| EG-101 | 404  | Not found                                                               |
+| EG-102 | 400  | Invalid request / missing required field                                |
+| EG-103 | 403  | Unauthorized access                                                     |
+| EG-110 | 409  | Expired organization access — front-end refreshes the token and retries |
+| EG-308 | 400  | Laboratory Seqera credentials incorrect                                 |
+| EG-315 | 403  | Missing AWS HealthOmics access                                          |
+| EG-316 | 403  | Missing Seqera Cloud / Nextflow Tower access                            |
+| EG-600 | 400  | Seqera Cloud API error                                                  |
+
+> **EG-110 is expected, not a bug.** It signals the user's org-access token has expired; the front-end catches it,
+> refreshes, and retries automatically. You only need to act if requests keep returning EG-110 in a loop (token refresh
+> itself is failing — treat it as an auth issue below).
+
+---
+
+## Finding logs
+
+| Source               | Where                                                                                                   |
+| -------------------- | ------------------------------------------------------------------------------------------------------- |
+| API Gateway access   | CloudWatch log group for the API stage (JSON-formatted access logs — request path, status, latency)     |
+| Lambda handlers      | CloudWatch log group `/aws/lambda/{NAME_PREFIX}-{handler-name}` (e.g. `dev-demo-create-laboratory-run`) |
+| HealthOmics run/task | The log stream linked in the run's `statusMessage` (see [Run failures](#run-failures))                  |
+
+> **⚠️ Lambda log retention is one day.** Capture the logs for a failure quickly — by tomorrow they are gone. Logs are
+> currently unstructured `console.*` output, so search the relevant group by time window and request path rather than by
+> `requestId`/`userId`.
+
+Map the `EG-xxx` domain digit to the handler prefix to find the right group: a `3xx` laboratory error came from a
+`*-laboratory-*` handler, a `4xx` user error from a `*-user-*` handler, and so on.
+
+---
+
+## Deploy failures
+
+Setup steps for a production deploy are in [deployment/production.md](../deployment/production.md) and
+[deployment/configuration.md](../deployment/configuration.md). This section covers the failures that most commonly
+interrupt a deploy.
+
+### 1. CDK bootstrap
+
+| Symptom                                                                                                        | Cause                                                                                 | Fix                                                                                                                                                                                                                                     |
+| -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `This stack uses assets, so the toolkit stack must be deployed` / `SSM parameter /cdk-bootstrap/... not found` | The target account/region was never bootstrapped, or the `CDKToolkit` stack is stale. | `pnpm run build-and-deploy` bootstraps automatically. From a CI/CD pipeline the pipeline role must be allowed to create/update the `CDKToolkit` stack — see [production.md § CDK bootstrap](../deployment/production.md#cdk-bootstrap). |
+
+### 2. IAM permissions
+
+| Symptom                                                                       | Cause                                                                                                                                                          | Fix                                                                                                                                                                                                                                                    |
+| ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `AccessDenied` / `is not authorized to perform: <action>` during `cdk deploy` | The deploying principal lacks the broad permissions Easy Genomics needs (it provisions IAM, Lambda, DynamoDB, Cognito, API Gateway, CloudFront, S3, SNS, SQS). | Deploy with `AdministratorAccess` or an equivalent CDK-bootstrap-compatible policy. For pipelines, prefer GitHub Actions OIDC + an IAM role over long-lived keys — see [production.md § IAM permissions](../deployment/production.md#iam-permissions). |
+
+### 3. ACM / Route 53 wiring
+
+| Symptom                                                          | Cause                                                                                                                        | Fix                                                                                                                                                                      |
+| ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Deploy fails resolving the certificate, or CloudFront rejects it | The ACM certificate is not in `us-east-1`. CloudFront **requires** the cert in `us-east-1` regardless of your deploy region. | Re-request the certificate in `us-east-1` and use that ARN — see [production.md § ACM certificate](../deployment/production.md#3-acm-certificate).                       |
+| Certificate stuck in `PENDING_VALIDATION`                        | DNS validation CNAME records are missing or not yet propagated.                                                              | Add the ACM-provided CNAME records to the Route 53 hosted zone (or use ACM's "Create records in Route 53"); wait for `Status: ISSUED`.                                   |
+| Custom domain does not resolve after deploy                      | The hosted zone is a subdomain whose NS records were never delegated from the parent zone.                                   | Copy the four NS records from the new hosted zone into the parent zone — see [production.md § Route 53 hosted zone](../deployment/production.md#2-route-53-hosted-zone). |
+
+---
+
+## Auth issues
+
+For local-server `401 Unauthorized`, see
+[development/local-backend-dev.md § 401 Unauthorized](../development/local-backend-dev.md#401-unauthorized). In a
+deployed environment:
+
+| Symptom                                              | Cause                                                                                                        | Fix                                                                                                                     |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| Sign-in loops or rejects a valid password            | Cognito MFA challenge not completed, or the device/time is out of sync for TOTP.                             | Complete the MFA challenge; if using an authenticator app, confirm the device clock is accurate.                        |
+| API calls start returning `401` / EG-103 mid-session | The Cognito access/ID token expired and the session was not refreshed.                                       | Sign out and back in. Persistent expiry points at a clock skew or a Cognito app-client token-validity misconfiguration. |
+| EG-110 returned repeatedly                           | Org-access token refresh is failing (normally EG-110 self-heals — see [above](#reading-eg-xxx-error-codes)). | Treat as a token-refresh failure: re-authenticate; if it persists, inspect the auth Lambda logs.                        |
+| Invite link returns an error or "expired"            | The invitation token is single-use and time-limited; the link was already used or has lapsed.                | Re-send the invitation from the organization/lab admin screen and use the new link promptly.                            |
+
+---
+
+## Run failures
+
+A pipeline run can fail at **submission** (the wizard's API calls) or **during execution** (on the Seqera or HealthOmics
+side).
+
+**Submission failures** surface immediately in the run wizard with a specific message. `ERROR_HANDLING.md` **§ Run
+Submission — Per-Step Error Handling** maps each wizard API call to its meaning. The one to watch for: _"Run launched
+but failed to record"_ means the run is live on the provider but missing from Easy Genomics — capture the
+`externalRunId` from the message before retrying, or you risk a duplicate run.
+
+**Execution failures (AWS HealthOmics):** open the run and read its `failureReason` and `statusMessage`.
+`ERROR_HANDLING.md` **§ AWS HealthOmics Run Failure Codes** classifies every `failureReason` and names the owner (Lab vs
+Bioinformatician vs transient AWS). Quick triage:
+
+- `IMPORT_FAILED`, `INPUT_URI_NOT_FOUND`, `INVALID_URI_INPUT` → **Lab**: an input S3 path is wrong or the run role can't
+  read it.
+- `ASSUME_ROLE_FAILED`, `ECR_PERMISSION_ERROR`, `OUT_OF_MEMORY_ERROR`, `WORKFLOW_VER_VALIDATION_FAILED` →
+  **Bioinformatician**: run-role trust, container access, or workflow-definition fixes.
+- `INSTANCE_RESERVATION_FAILED`, `SERVICE_ERROR` → **transient AWS**: wait and retry.
+- `RUN_TASK_FAILED` / `WORKFLOW_RUN_FAILED` → **ambiguous**: the root cause is only in the CloudWatch engine/task log
+  stream linked in `statusMessage`. A `statusMessage` naming `SAMPLESHEET_CHECK` points at a data/sample-sheet problem
+  rather than a workflow bug.
+
+**Execution failures (Seqera Cloud):** Seqera has no standardised error codes — failures arrive as free-text Nextflow
+output in `workflow.errorMessage`. Read that message and the Seqera run logs directly.
+
+**Stuck (not failing, not progressing) runs:** confirm the run's actual state on the provider (HealthOmics `GetRun` /
+the Seqera console) rather than trusting the cached Easy Genomics status — a recording failure at submission can leave
+the two out of sync.
+
+---
+
+## File upload failures
+
+Easy Genomics validates uploads in the browser before they reach S3; the `create-file-upload-sample-sheet` Lambda
+applies the same sample-sheet rules server-side.
+
+**Sequencing data files** (`EGRunFormUploadData`):
+
+| Message                                                                | Cause                                          | Fix                                                       |
+| ---------------------------------------------------------------------- | ---------------------------------------------- | --------------------------------------------------------- |
+| `File <name> is not a .gz file`                                        | Only gzipped FASTQ (`.gz`) files are accepted. | Upload the gzipped files (e.g. `..._R1_001.fastq.gz`).    |
+| `File <name> is too small` / `too large … Maximum allowed size is 5GB` | Files must be between 1 byte and 5 GB.         | Re-check the file; split or re-export anything over 5 GB. |
+
+For paired-end reads, the two files of a pair must share the same sample-ID prefix (e.g.
+`GOL2051A67473_S133_L002_R1_001.fastq.gz` and `…_R2_001.fastq.gz`) so they are grouped correctly.
+
+**Sample sheets** (CSV):
+
+| Message                                                       | Cause                                                        | Fix                                                                |
+| ------------------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------ |
+| `Only CSV files are accepted as sample sheets.`               | The file is not a `.csv`.                                    | Export the sample sheet as CSV.                                    |
+| `The sample sheet file is empty` / `missing a header row`     | The CSV has no content or no header line.                    | Ensure the first non-empty line is a header row with column names. |
+| `Sample sheet validation failed — check the required format.` | The CSV failed validation (empty, unreadable, or no header). | Open the CSV, confirm it has a header row and data, and re-upload. |
+
+> The uploaded sample-sheet S3 object name must not contain spaces. Easy Genomics derives a safe
+> `samplesheet[-<run>].csv` key automatically, so a run name with spaces is fine — but a manually supplied filename with
+> spaces or unusual characters is normalised or rejected.
+
+---
+
+## Still stuck?
+
+If the `EG-xxx` code, the run `failureReason`, and the CloudWatch logs don't explain it, capture all three (plus the
+`externalRunId` for run failures) before they age out of the one-day log retention, and escalate with that evidence.


### PR DESCRIPTION
## Title*
docs(DOCS-05): add troubleshooting guide and complete the contributing guide

## Type of Change*
- [ ] New feature
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Closes the two medium-impact gaps flagged in the docs audit. Builds on the audience-separated folder structure merged in DOCS-04.

**New — `docs/operations/troubleshooting.md`.** Previously the only troubleshooting coverage was the local-dev `401` section in `docs/development/local-backend-dev.md`; there was nothing for users hitting failures in a *deployed* environment. The new guide covers:
- **Reading EG-xxx error codes** — the lookup workflow (code → `ERROR_HANDLING.md` → HTTP status + domain digit → which Lambda log group), plus a table of the most common codes.
- **Finding logs** — API Gateway access logs and `/aws/lambda/{NAME_PREFIX}-…` groups, with the one-day Lambda log-retention caveat called out.
- **Deploy failures** — CDK bootstrap, IAM permissions, and ACM/Route 53 wiring, each as symptom → cause → fix, cross-linked to `production.md`/`configuration.md`.
- **Auth issues** — Cognito MFA, expired tokens, EG-110 refresh behaviour, invite-link failures.
- **Run failures** — HealthOmics `failureReason` triage by owner (Lab / Bioinformatician / transient AWS) and Seqera free-text failures.
- **File upload failures** — sample-sheet (`.csv` + header row) and sequencing-file (`.gz`, 1 byte–5 GB, paired-end naming) validation, grounded in the front-end validation and `create-file-upload-sample-sheet` Lambda.

**Expanded — `docs/development/contributing.md`.** It previously held only the conventions relocated from the README in DOCS-04. Added: claiming work via JIRA `EG-XXX`, an **AI Coding Principles** section that references (does not duplicate) `CLAUDE.md`, testing expectations per `CLAUDE.md`/`TESTING.md`, and the PR template + review/sign-off flow. Existing convention sections are unchanged.

**Index updates.** `operations/README.md` and `development/README.md` statuses flipped to ✅; troubleshooting is now linked.

Related: JIRA **DOCS-05** · depends on **DOCS-04** (merged).

## Testing*
Documentation-only change; no automated tests apply. Verified manually:
- All intra-repo relative links and heading anchors resolve (`troubleshooting.md` → `production.md#cdk-bootstrap`, `#iam-permissions`, `#3-acm-certificate`, `#2-route-53-hosted-zone`; `local-backend-dev.md#401-unauthorized`; `contributing.md` → `.github/pull_request_template.md`).
- Confirmed the out-of-repo reference docs (`CLAUDE.md`, `ERROR_HANDLING.md`, `TESTING.md`) are cited by name only, with **zero** relative hyperlinks across the repo boundary (would otherwise break).
- All EG-xxx codes, HealthOmics `failureReason` values, and upload limits cross-checked against `ERROR_HANDLING.md` and the front-end source.

## Impact
Documentation only — no code, dependencies, or runtime behaviour changes. Improves first-response time for deploy/auth/run failures and lowers the onboarding bar for external contributors.

## Additional Information
One deliberate deviation from the ticket's literal wording: the local-dev `401` content stays in `docs/development/local-backend-dev.md` (its correct home for dev-only content) and `troubleshooting.md` cross-references it, rather than physically moving it — DOCS-04 already removed the README's 401 section, so there was nothing left there to relocate.

Two pre-existing follow-ups remain out of scope and are noted in `development/README.md`: committing `ARCHITECTURE.md` into the repo, and the Docusaurus docs-site spike (DOCS-06).

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary. *(docs-only; no tests apply)*
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas. *(N/A — prose only)*