### PR TITLE
feat(EGV-179): analysis indicators on samples

### DIFF
--- a/packages/front-end/src/app/components/EGDataCollectionsPage.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsPage.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
   import type { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
-  import type { LaboratoryDataTag } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/data-collections';
+  import type {
+    LaboratoryDataTag,
+    LaboratoryRunUsageSummary,
+  } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/data-collections';
   import type {
     LaboratorySequenceCollection,
     LaboratorySample,
@@ -20,6 +23,10 @@
 
   const props = defineProps<{ labId: string }>();
 
+  const emit = defineEmits<{
+    'update:explorerTab': [tab: DataCollectionsTab];
+  }>();
+
   const { $api } = useNuxtApp();
   const labsStore = useLabsStore();
   const uiStore = useUiStore();
@@ -31,10 +38,13 @@
   const view = ref<View>('main');
   const activeTab = ref<DataCollectionsTab>('samples');
 
+  watch(activeTab, (tab) => emit('update:explorerTab', tab), { immediate: true });
+
   const tags = ref<LaboratoryDataTag[]>([]);
   const samples = ref<LaboratorySample[]>([]);
   const sequenceCollections = ref<LaboratorySequenceCollection[]>([]);
   const sampleIdToTagIds = ref<Record<string, string[]>>({});
+  const sampleIdToRunUsages = ref<Record<string, LaboratoryRunUsageSummary[]>>({});
   const unlinkedFiles = ref<Array<{ Key: string; Size?: number; LastModified?: string }>>([]);
   const unlinkedMeta = ref({ s3Bucket: '', resolvedPrefix: '', lastScanLabel: '' });
 
@@ -87,6 +97,7 @@
       if (res.Samples.length) {
         const CHUNK = 100;
         const tagMap: Record<string, string[]> = {};
+        const runUsagesMap: Record<string, LaboratoryRunUsageSummary[]> = {};
         for (let i = 0; i < res.Samples.length; i += CHUNK) {
           const chunk = res.Samples.slice(i, i + CHUNK).map((s) => s.SampleId);
           const tr = await $api.dataCollections.requestListSampleTags({
@@ -95,11 +106,14 @@
           });
           for (const a of tr.Samples) {
             tagMap[a.SampleId] = a.TagIds;
+            runUsagesMap[a.SampleId] = a.LaboratoryRunUsages ?? [];
           }
         }
         sampleIdToTagIds.value = tagMap;
+        sampleIdToRunUsages.value = runUsagesMap;
       } else {
         sampleIdToTagIds.value = {};
+        sampleIdToRunUsages.value = {};
       }
     } catch {
       toast.error('Failed to load samples.');
@@ -286,11 +300,6 @@
     />
 
     <template v-else>
-      <div class="mb-1">
-        <h1 class="text-2xl font-medium">Data Collections</h1>
-        <p class="text-sm text-gray-500">Saved bundles of samples, ready to launch a workflow on.</p>
-      </div>
-
       <EGDataCollectionsTabBar
         v-model:active-tab="activeTab"
         :collection-count="sequenceCollections.length"
@@ -317,6 +326,7 @@
         :samples="samples"
         :tags="tags"
         :sample-id-to-tag-ids="sampleIdToTagIds"
+        :sample-id-to-run-usages="sampleIdToRunUsages"
         :loading="loading"
         :selected-ids="selectedSampleIds"
         :search="sampleSearch"

--- a/packages/front-end/src/app/components/EGFileAnalysisHistoryTooltip.vue
+++ b/packages/front-end/src/app/components/EGFileAnalysisHistoryTooltip.vue
@@ -51,7 +51,7 @@
       if (runCount.value === 1) return 'Analyzed once — show analysis history';
       return `Analyzed ${runCount.value} times — show analysis history`;
     }
-    return `File analysis history: ${statusDescriptor.value.label}`;
+    return `Sample analysis history: ${statusDescriptor.value.label}`;
   });
 
   /** Subtitle string for the popover header: batch · standard tag names, joined by dots. */
@@ -215,7 +215,7 @@
               <button
                 type="button"
                 class="text-primary hover:bg-primary/10 flex w-12 shrink-0 flex-col items-center justify-center border-l border-gray-200 bg-gray-50/40 transition"
-                :aria-label="`Select ${run.InputFileCount} file(s) used in ${run.RunName || run.RunId}`"
+                :aria-label="`Select ${run.InputFileCount} sample(s) used in ${run.RunName || run.RunId}`"
                 @click.stop="onSelectRunSamples(run, close)"
               >
                 <span class="relative inline-flex h-5 w-5 shrink-0 items-center justify-center" aria-hidden="true">

--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -16,6 +16,7 @@
   import { WorkflowListItem as OmicsWorkflow } from '@aws-sdk/client-omics';
   import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory-run';
   import EGDataCollectionsPage from '@FE/components/EGDataCollectionsPage.vue';
+  import type { DataCollectionsTab } from '@FE/components/EGDataCollectionsTabBar.vue';
   import { TableSort } from './EGTable.vue';
 
   const props = defineProps<{
@@ -140,13 +141,23 @@
 
   const activeTabKey = computed(() => tabItems.value[tabIndex.value]?.key || '');
 
+  const dataCollectionsExplorerTab = ref<DataCollectionsTab>('samples');
+
+  const dataCollectionsDescriptions: Record<DataCollectionsTab, string> = {
+    samples: 'Build the Sequence Collections you run workflows from — starting with the samples in your lab.',
+    collections: 'Saved bundles of samples ready to launch a workflow on.',
+    files:
+      "Files sitting in the lab's S3 bucket that didn't come through an import — instrument dumps, manual drops, leftovers. Not grouped into samples yet.",
+  };
+
   const pageDescription = computed(() => {
+    if (activeTabKey.value === 'dataCollections') {
+      return dataCollectionsDescriptions[dataCollectionsExplorerTab.value];
+    }
     const descriptions: Record<string, string> = {
       runs: 'View your pipeline runs',
       seqeraPipelines: 'View your Seqera pipelines',
       omicsWorkflows: 'View your HealthOmics workflows',
-      dataCollections:
-        "All of your lab's sequencing data lives here. Tag samples by organism, run, or any other grouping that makes sense for your lab, then use those tags to select what goes into a workflow.",
       users: 'View your lab users',
       details: 'View your lab settings',
     };
@@ -811,7 +822,7 @@
     class="mt-4"
   >
     <h2 class="sr-only">Sequence collections</h2>
-    <EGDataCollectionsPage :lab-id="labId" />
+    <EGDataCollectionsPage :lab-id="labId" @update:explorer-tab="dataCollectionsExplorerTab = $event" />
   </div>
 
   <!-- Runs tab -->

--- a/packages/front-end/src/app/components/EGSamplesTab.vue
+++ b/packages/front-end/src/app/components/EGSamplesTab.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
-  import type { LaboratoryDataTag } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/data-collections';
+  import type {
+    LaboratoryDataTag,
+    LaboratoryRunUsageSummary,
+  } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/data-collections';
   import type { LaboratorySample } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/samples';
+  import EGFileAnalysisHistoryTooltip from '@FE/components/EGFileAnalysisHistoryTooltip.vue';
   import EGSampleTagSidebar from '@FE/components/EGSampleTagSidebar.vue';
   import { useToastStore, useUiStore } from '@FE/stores';
   import { SAMPLE_LAYOUT_LABELS } from '@FE/utils/data-collections-selection';
@@ -11,6 +15,7 @@
     samples: LaboratorySample[];
     tags: LaboratoryDataTag[];
     sampleIdToTagIds: Record<string, string[]>;
+    sampleIdToRunUsages: Record<string, LaboratoryRunUsageSummary[]>;
     loading: boolean;
     selectedIds: string[];
     search: string;
@@ -50,6 +55,12 @@
 
   /** Cards grid vs tabular layout (matches file explorer). */
   const explorerView = ref<'cards' | 'table'>('cards');
+
+  /** While a sample's analysis popover is open, that card/row is stacked above siblings. */
+  const analysisPopoverOpenKey = ref<string | null>(null);
+
+  const BATCH_HEADER_DOT_NOT_ANALYZED = '#EF9F27';
+  const BATCH_HEADER_DOT_ANALYZED = '#2DB48F';
 
   const presetColors = ['#5B4FD4', '#85B7EB', '#F09595', '#97C459', '#ED93B1', '#EF9F27', '#B4B2A9'];
 
@@ -182,6 +193,59 @@
   function batchDisplayName(sample: LaboratorySample): string {
     if (!sample.BatchTagId) return '—';
     return tagById(sample.BatchTagId)?.Name ?? sample.BatchTagId;
+  }
+
+  function runUsagesForSample(sampleId: string): LaboratoryRunUsageSummary[] {
+    return props.sampleIdToRunUsages[sampleId] ?? [];
+  }
+
+  function runCountForSample(sampleId: string): number {
+    return runUsagesForSample(sampleId).length;
+  }
+
+  function standardTagNamesForSample(sampleId: string): string[] {
+    return tagIdsForSet(sampleId).map((tid) => tagById(tid)?.Name ?? tid);
+  }
+
+  function onAnalysisPopoverOpen(sampleId: string, open: boolean): void {
+    if (open) {
+      analysisPopoverOpenKey.value = sampleId;
+    } else if (analysisPopoverOpenKey.value === sampleId) {
+      analysisPopoverOpenKey.value = null;
+    }
+  }
+
+  type BatchSectionHeaderParts = {
+    titleBold: string;
+    sampleCount: number;
+    sampleNoun: string;
+    notYetAnalyzed: number;
+    analyzed: number;
+  };
+
+  function batchSectionHeaderParts(sec: SampleSection): BatchSectionHeaderParts {
+    const n = sec.samples.length;
+    const sampleNoun = n === 1 ? 'sample' : 'samples';
+    let notYetAnalyzed = 0;
+    let analyzed = 0;
+    for (const s of sec.samples) {
+      if (runCountForSample(s.SampleId) > 0) analyzed += 1;
+      else notYetAnalyzed += 1;
+    }
+    return {
+      titleBold: sec.title,
+      sampleCount: n,
+      sampleNoun,
+      notYetAnalyzed,
+      analyzed,
+    };
+  }
+
+  function selectSamplesForRun(runId: string): void {
+    const ids = props.samples
+      .filter((s) => runUsagesForSample(s.SampleId).some((u) => u.RunId === runId))
+      .map((s) => s.SampleId);
+    emit('update:selectedIds', ids);
   }
 
   function batchSectionFullySelected(sec: SampleSection): boolean {
@@ -550,13 +614,36 @@
                 :class="secIdx === 0 ? 'mt-0' : 'mt-6'"
                 role="presentation"
               >
-                <h3 class="text-muted min-w-0 flex-1 text-xs font-normal leading-snug tracking-wide">
-                  <span class="inline-flex flex-wrap items-baseline gap-x-1.5">
-                    <span class="font-semibold text-gray-900">
-                      <template v-if="sec.batchId !== null">Batch {{ sec.title }}</template>
-                      <template v-else>{{ sec.title }}</template>
+                <h3 class="text-muted min-w-0 flex-1 whitespace-normal text-xs font-normal leading-snug tracking-wide">
+                  <span class="inline-flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                    <span class="inline-flex min-w-0 flex-wrap items-baseline gap-x-1.5">
+                      <span class="font-semibold text-gray-900">
+                        <template v-if="sec.batchId !== null">
+                          Batch {{ batchSectionHeaderParts(sec).titleBold }}
+                        </template>
+                        <template v-else>{{ batchSectionHeaderParts(sec).titleBold }}</template>
+                      </span>
+                      <span>
+                        {{ batchSectionHeaderParts(sec).sampleCount }}
+                        {{ batchSectionHeaderParts(sec).sampleNoun }}
+                      </span>
                     </span>
-                    <span>{{ sec.samples.length }} sample{{ sec.samples.length === 1 ? '' : 's' }}</span>
+                    <span class="inline-flex items-center gap-1.5">
+                      <span
+                        class="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+                        :style="{ backgroundColor: BATCH_HEADER_DOT_NOT_ANALYZED }"
+                        aria-hidden="true"
+                      />
+                      <span>{{ batchSectionHeaderParts(sec).notYetAnalyzed }} not yet analyzed</span>
+                    </span>
+                    <span class="inline-flex items-center gap-1.5">
+                      <span
+                        class="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+                        :style="{ backgroundColor: BATCH_HEADER_DOT_ANALYZED }"
+                        aria-hidden="true"
+                      />
+                      <span>{{ batchSectionHeaderParts(sec).analyzed }} analyzed</span>
+                    </span>
                   </span>
                 </h3>
                 <button
@@ -576,25 +663,48 @@
                 class="border-border-muted focus-visible:ring-primary relative min-w-0 cursor-pointer rounded-xl border bg-white p-3 shadow-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
                 :class="{
                   'bg-primary-muted ring-primary ring-2': isSelected(s.SampleId),
+                  'z-[80]': analysisPopoverOpenKey === s.SampleId,
                 }"
                 :aria-selected="isSelected(s.SampleId)"
                 :aria-label="`${s.Name}, ${contentsLabel(s)}`"
                 @click="toggle(s.SampleId)"
                 @keydown="onSampleItemKeydown($event, s.SampleId)"
               >
+                <div class="absolute left-0 top-0 z-[1]" @mousedown.stop @click.stop>
+                  <EGFileAnalysisHistoryTooltip
+                    :lab-id="labId"
+                    :file-key="s.SampleId"
+                    :file-name="s.Name"
+                    :batch-name="batchDisplayName(s) === '—' ? undefined : batchDisplayName(s)"
+                    :standard-tag-names="standardTagNamesForSample(s.SampleId)"
+                    :run-usages="runUsagesForSample(s.SampleId)"
+                    variant="card"
+                    @select-run-files="selectSamplesForRun($event.runId)"
+                    @update:open="onAnalysisPopoverOpen(s.SampleId, $event)"
+                  />
+                </div>
                 <div class="absolute right-2 top-2" @mousedown.stop @click.stop>
                   <UCheckbox :model-value="isSelected(s.SampleId)" @update:model-value="toggle(s.SampleId)" />
                 </div>
                 <div class="w-full min-w-0 pr-8">
-                  <div class="line-clamp-2 w-full min-w-0 break-all text-sm font-medium leading-snug text-gray-900">
+                  <div
+                    class="mt-7 line-clamp-2 w-full min-w-0 break-all text-sm font-medium leading-snug text-gray-900"
+                  >
                     {{ s.Name }}
                   </div>
                   <div class="text-muted mt-1 text-xs">{{ contentsLabel(s) }}</div>
                 </div>
                 <div class="mt-2 flex min-h-[1.25rem] min-w-0 max-w-full flex-wrap gap-1">
-                  <template v-if="tagIdsForSet(s.SampleId).length">
+                  <span
+                    v-if="!standardTagIdsForSet(s.SampleId).length"
+                    class="inline-flex min-w-0 max-w-full overflow-hidden rounded-full bg-gray-200 px-2 py-0.5 text-[10px] font-medium text-gray-600"
+                    @click.stop
+                  >
+                    <span class="truncate">Untagged</span>
+                  </span>
+                  <template v-else>
                     <span
-                      v-for="tid in tagIdsForSet(s.SampleId)"
+                      v-for="tid in standardTagIdsForSet(s.SampleId)"
                       :key="tid"
                       class="inline-flex min-w-0 max-w-full overflow-hidden rounded-full px-2 py-0.5 text-[10px] font-medium"
                       :title="tagById(tid)?.Name || tid"
@@ -608,41 +718,56 @@
                     </span>
                   </template>
                 </div>
-                <div class="text-muted mt-2 flex items-center justify-between gap-2 text-[10px]">
-                  <span class="min-w-0 truncate">{{ s.ImportSource?.label || '—' }}</span>
-                  <span class="shrink-0">
-                    {{ s.CreatedAt ? new Date(s.CreatedAt).toLocaleDateString() : '—' }}
-                  </span>
-                </div>
               </div>
             </template>
           </div>
 
           <div v-else class="overflow-x-auto">
-            <table class="w-full min-w-[52rem] border-collapse text-left text-sm" aria-label="Samples">
+            <table class="w-full min-w-[36rem] border-collapse text-left text-sm" aria-label="Samples">
               <thead class="sticky top-0 z-10 bg-gray-50">
                 <tr>
                   <th class="w-10 p-3" />
                   <th class="p-3 text-left text-xs uppercase text-gray-400">Sample ID</th>
-                  <th class="p-3 text-left text-xs uppercase text-gray-400">Batch</th>
                   <th class="p-3 text-left text-xs uppercase text-gray-400">Contents</th>
                   <th class="p-3 text-left text-xs uppercase text-gray-400">Tags</th>
-                  <th class="p-3 text-left text-xs uppercase text-gray-400">Source</th>
-                  <th class="p-3 text-left text-xs uppercase text-gray-400">Created</th>
+                  <th class="p-3 text-left text-xs uppercase text-gray-400">Run Status</th>
                 </tr>
               </thead>
               <tbody>
                 <template v-for="sec in sampleSections" :key="sec.batchId ?? 'unbatched-table'">
                   <tr class="bg-gray-50/95">
-                    <td colspan="7" class="border-t border-gray-100 px-3 py-2.5" scope="colgroup">
+                    <td colspan="5" class="border-t border-gray-100 px-3 py-2.5" scope="colgroup">
                       <div class="flex w-full min-w-0 flex-wrap items-start justify-between gap-x-3 gap-y-2">
                         <span class="text-muted min-w-0 flex-1 text-xs font-normal leading-snug tracking-wide">
-                          <span class="inline-flex flex-wrap items-baseline gap-x-1.5">
-                            <span class="font-semibold text-gray-900">
-                              <template v-if="sec.batchId !== null">Batch {{ sec.title }}</template>
-                              <template v-else>{{ sec.title }}</template>
+                          <span class="inline-flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                            <span class="inline-flex min-w-0 flex-wrap items-baseline gap-x-1.5">
+                              <span class="font-semibold text-gray-900">
+                                <template v-if="sec.batchId !== null">
+                                  Batch {{ batchSectionHeaderParts(sec).titleBold }}
+                                </template>
+                                <template v-else>{{ batchSectionHeaderParts(sec).titleBold }}</template>
+                              </span>
+                              <span>
+                                {{ batchSectionHeaderParts(sec).sampleCount }}
+                                {{ batchSectionHeaderParts(sec).sampleNoun }}
+                              </span>
                             </span>
-                            <span>{{ sec.samples.length }} sample{{ sec.samples.length === 1 ? '' : 's' }}</span>
+                            <span class="inline-flex items-center gap-1.5">
+                              <span
+                                class="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+                                :style="{ backgroundColor: BATCH_HEADER_DOT_NOT_ANALYZED }"
+                                aria-hidden="true"
+                              />
+                              <span>{{ batchSectionHeaderParts(sec).notYetAnalyzed }} not yet analyzed</span>
+                            </span>
+                            <span class="inline-flex items-center gap-1.5">
+                              <span
+                                class="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+                                :style="{ backgroundColor: BATCH_HEADER_DOT_ANALYZED }"
+                                aria-hidden="true"
+                              />
+                              <span>{{ batchSectionHeaderParts(sec).analyzed }} analyzed</span>
+                            </span>
                           </span>
                         </span>
                         <button
@@ -661,7 +786,10 @@
                     :key="s.SampleId"
                     tabindex="0"
                     class="border-t border-gray-100 hover:bg-gray-50 focus:outline-none focus-visible:bg-gray-50"
-                    :class="{ 'bg-primary-50': isSelected(s.SampleId) }"
+                    :class="{
+                      'bg-primary-50': isSelected(s.SampleId),
+                      'relative z-[80]': analysisPopoverOpenKey === s.SampleId,
+                    }"
                     :aria-selected="isSelected(s.SampleId)"
                     @click="toggle(s.SampleId)"
                     @keydown="onSampleItemKeydown($event, s.SampleId)"
@@ -670,24 +798,47 @@
                       <UCheckbox :model-value="isSelected(s.SampleId)" @update:model-value="toggle(s.SampleId)" />
                     </td>
                     <td class="p-3 font-medium">{{ s.Name }}</td>
-                    <td class="p-3 text-gray-600">{{ batchDisplayName(s) }}</td>
                     <td class="p-3 text-gray-600">{{ contentsLabel(s) }}</td>
                     <td class="p-3">
-                      <span
-                        v-for="tid in tagIdsForSet(s.SampleId)"
-                        :key="tid"
-                        class="mr-1 inline-block rounded-full px-2 py-0.5 text-xs"
-                        :style="{
-                          background: (tagById(tid)?.ColorHex || '#eee') + '33',
-                          color: tagById(tid)?.ColorHex,
-                        }"
-                      >
-                        {{ tagById(tid)?.Name || tid }}
-                      </span>
+                      <div class="flex min-w-0 max-w-full flex-wrap gap-1">
+                        <span
+                          v-if="!standardTagIdsForSet(s.SampleId).length"
+                          class="inline-flex min-w-0 max-w-full overflow-hidden rounded-full bg-gray-200 px-2 py-0.5 text-[10px] font-medium text-gray-600"
+                          @click.stop
+                        >
+                          <span class="truncate">Untagged</span>
+                        </span>
+                        <template v-else>
+                          <span
+                            v-for="tid in standardTagIdsForSet(s.SampleId)"
+                            :key="tid"
+                            class="inline-flex min-w-0 max-w-full overflow-hidden rounded-full px-2 py-0.5 text-[10px] font-medium"
+                            :title="tagById(tid)?.Name || tid"
+                            :style="{
+                              background: tagById(tid)?.ColorHex || '#e2e2e8',
+                              color: pillTextColor(tagById(tid)?.ColorHex || '#e2e2e8'),
+                            }"
+                            @click.stop
+                          >
+                            <span class="truncate">{{ tagById(tid)?.Name || tid }}</span>
+                          </span>
+                        </template>
+                      </div>
                     </td>
-                    <td class="p-3 text-xs text-gray-400">{{ s.ImportSource?.label || '—' }}</td>
-                    <td class="p-3 text-xs text-gray-400">
-                      {{ s.CreatedAt ? new Date(s.CreatedAt).toLocaleDateString() : '—' }}
+                    <td class="px-3 py-2 align-middle">
+                      <span class="inline-flex w-fit max-w-full align-middle" @mousedown.stop @click.stop>
+                        <EGFileAnalysisHistoryTooltip
+                          :lab-id="labId"
+                          :file-key="s.SampleId"
+                          :file-name="s.Name"
+                          :batch-name="batchDisplayName(s) === '—' ? undefined : batchDisplayName(s)"
+                          :standard-tag-names="standardTagNamesForSample(s.SampleId)"
+                          :run-usages="runUsagesForSample(s.SampleId)"
+                          variant="table"
+                          @select-run-files="selectSamplesForRun($event.runId)"
+                          @update:open="onAnalysisPopoverOpen(s.SampleId, $event)"
+                        />
+                      </span>
                     </td>
                   </tr>
                 </template>
@@ -709,7 +860,7 @@
           <UButton size="sm" variant="outline" :disabled="bulkPanelBusy" @click="openChangeBatchModal">
             Change batch
           </UButton>
-          <UButton size="sm" variant="soft" :disabled="bulkPanelBusy" @click="openAddBulkPanel">Add Tags</UButton>
+          <UButton size="sm" variant="outline" :disabled="bulkPanelBusy" @click="openAddBulkPanel">Add Tags</UButton>
           <UButton size="sm" variant="outline" :disabled="bulkPanelBusy" @click="openRemoveBulkPanel">
             Remove Tags
           </UButton>


### PR DESCRIPTION
## Analysis indicators on samples

## Type of Change*
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
Third and final PR in the EGV-179 stack. Adds analysis indicators to the samples experience:

- Analysis status/history indicators on the samples tab
- Updates to `EGLabView`, `EGDataCollectionsPage`, and `EGFileAnalysisHistoryTooltip`

**Stack order:**
1. PR 1: #792 (sequence sets foundation) → `development`
2. PR 2: #793 (rename to samples/sequence collections) → `feat/egv-179-A-dc-sequence-sets`
3. **This PR** → `feat/egv-179-B-dc-sequence-sets`

## Testing*
- [ ] Manual testing of analysis indicators on samples with existing run history

## Impact
Small, focused UI enhancement on top of the data collections rework. Depends on PRs #792 and #793.

## Additional Information
Review this PR against PR #793 only — 4 files changed. This is the smallest layer in the stack.

## Checklist*
- [ ] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [ ] Code adheres to the coding and style guidelines of the project.
- [ ] Code has been commented in particularly hard-to-understand areas.

Made with [Cursor](https://cursor.com)