### PR TITLE
feat: polish data collections UI and fix sample rename tests

### DIFF
--- a/packages/back-end/src/app/services/easy-genomics/laboratory-data-tagging-service.ts
+++ b/packages/back-end/src/app/services/easy-genomics/laboratory-data-tagging-service.ts
@@ -1880,7 +1880,7 @@ export class LaboratoryDataTaggingService extends DynamoDBService {
 
     for (const setId of sequenceSetIds) {
       try {
-        // Step 1: ensure the SEQUENCE_SET# row has a map at `LaboratoryRunUsages`. UpdateItem with
+        // Step 1: ensure the SAMPLE# row has a map at `LaboratoryRunUsages`. UpdateItem with
         // a SET on a nested path requires the parent map to exist.
         await this.updateItem({
           TableName: TABLE_NAME,

--- a/packages/back-end/test/app/services/easy-genomics/laboratory-sample-service.test.ts
+++ b/packages/back-end/test/app/services/easy-genomics/laboratory-sample-service.test.ts
@@ -272,7 +272,6 @@ describe('LaboratorySampleService.addSampleIdToFileRow', () => {
         'my-bucket',
         'org-1/lab-1/a.fq.gz',
         'sample-1',
-        'user-1',
       ),
     ).rejects.toThrow('ProvisionedThroughputExceededException');
     expect(mockPutItem).not.toHaveBeenCalled();

--- a/packages/front-end/src/app/components/EGDataCollectionBuilder.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionBuilder.vue
@@ -29,15 +29,50 @@
 
   const isEditing = computed(() => Boolean(props.editingCollection));
 
+  function columnsMatchPreset(cols: SampleSheetColumnDef[], preset: SampleSheetColumnDef[]): boolean {
+    if (cols.length !== preset.length) return false;
+    return cols.every((col, i) => {
+      const p = preset[i];
+      return col.columnName === p.columnName && col.role === p.role && col.required === p.required;
+    });
+  }
+
+  function detectMatchingPresetKey(cols: SampleSheetColumnDef[]): string {
+    for (const key of Object.keys(SAMPLE_SHEET_SCHEMA_PRESETS)) {
+      if (columnsMatchPreset(cols, SAMPLE_SHEET_SCHEMA_PRESETS[key])) return key;
+    }
+    return 'custom';
+  }
+
+  const initialColumns: SampleSheetColumnDef[] = props.editingCollection?.Columns?.length
+    ? props.editingCollection.Columns.map((col) => ({ ...col }))
+    : SAMPLE_SHEET_SCHEMA_PRESETS.nf_core_paired_end.map((c) => ({ ...c }));
+
   const name = ref(props.initialName || props.editingCollection?.Name || '');
   const selectedSetIds = ref<Set<string>>(new Set(props.initialSetIds));
-  const columns = ref<SampleSheetColumnDef[]>(
-    props.editingCollection?.Columns?.length
-      ? props.editingCollection.Columns.map((col) => ({ ...col }))
-      : [...SAMPLE_SHEET_SCHEMA_PRESETS.nf_core_paired_end],
+  const columns = ref<SampleSheetColumnDef[]>(initialColumns);
+  const presetKey = ref(
+    props.editingCollection?.Columns?.length ? detectMatchingPresetKey(initialColumns) : 'nf_core_paired_end',
   );
   const setSearch = ref('');
   const saving = ref(false);
+
+  const presetOptions = computed(() => {
+    const options = Object.keys(SAMPLE_SHEET_SCHEMA_PRESETS).map((k) => ({
+      label: k.replace(/_/g, ' '),
+      value: k,
+    }));
+    if (presetKey.value === 'custom') {
+      return [{ label: 'Custom', value: 'custom' }, ...options];
+    }
+    return options;
+  });
+
+  watch(presetKey, (key) => {
+    if (key === 'custom') return;
+    const preset = SAMPLE_SHEET_SCHEMA_PRESETS[key];
+    if (preset) columns.value = preset.map((c) => ({ ...c }));
+  });
 
   const selectedSets = computed(() => props.samples.filter((s) => selectedSetIds.value.has(s.SampleId)));
 
@@ -63,16 +98,14 @@
     selectedSetIds.value = next;
   }
 
-  function applyPreset(key: keyof typeof SAMPLE_SHEET_SCHEMA_PRESETS): void {
-    columns.value = [...SAMPLE_SHEET_SCHEMA_PRESETS[key]];
-  }
-
   function addColumn(): void {
     columns.value.push({ columnName: `col_${columns.value.length + 1}`, role: 'metadata', required: false });
+    presetKey.value = 'custom';
   }
 
   function removeColumn(idx: number): void {
     columns.value.splice(idx, 1);
+    presetKey.value = 'custom';
   }
 
   async function save(): Promise<void> {
@@ -150,14 +183,7 @@
         <div>
           <div class="mb-2 flex items-center justify-between">
             <label class="text-sm font-medium">Schema</label>
-            <USelect
-              :options="
-                Object.keys(SAMPLE_SHEET_SCHEMA_PRESETS).map((k) => ({ label: k.replace(/_/g, ' '), value: k }))
-              "
-              placeholder="Preset"
-              class="w-48"
-              @update:model-value="applyPreset($event as keyof typeof SAMPLE_SHEET_SCHEMA_PRESETS)"
-            />
+            <USelect v-model="presetKey" :options="presetOptions" class="w-48" />
           </div>
           <table class="w-full overflow-hidden rounded-lg border border-gray-200 text-sm">
             <thead class="bg-gray-50">

--- a/packages/front-end/src/app/components/EGDataCollectionsPage.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsPage.vue
@@ -162,10 +162,6 @@
     await loadSamples();
   }
 
-  async function onSampleBatchUpdated(): Promise<void> {
-    await Promise.all([loadTags(), loadSamples()]);
-  }
-
   async function onSampleTagCreated(): Promise<void> {
     await loadTags();
   }
@@ -314,7 +310,6 @@
         :search="collectionSearch"
         @update:search="collectionSearch = $event"
         @new-collection="openBuilder()"
-        @import="openImport"
         @launch-workflow="launchWorkflow"
         @edit-collection="openBuilderForEdit"
         @delete-collection="openDeleteCollectionDialog"
@@ -339,7 +334,6 @@
         @import="openImport"
         @build-collection="openBuilder(selectedSampleIds)"
         @tags-updated="onSampleTagsUpdated"
-        @batch-updated="onSampleBatchUpdated"
         @tag-created="onSampleTagCreated"
         @tag-deleted="onSampleTagDeleted"
       />

--- a/packages/front-end/src/app/components/EGImportDataWizard.vue
+++ b/packages/front-end/src/app/components/EGImportDataWizard.vue
@@ -40,6 +40,8 @@
   const toast = useToastStore();
   const uiStore = useUiStore();
 
+  const IMPORT_STEPS = ['Source', 'Group files', 'Review samples', 'Confirm'] as const;
+
   const step = ref(1);
   const importSource = ref<ImportSourceKind>('s3');
   const sourcePath = ref('');
@@ -348,12 +350,12 @@
     <div class="flex min-h-0 flex-1 flex-col overflow-hidden rounded-t-xl border border-gray-200 bg-white">
       <div class="flex border-b border-gray-200 bg-gray-50 text-sm">
         <div
-          v-for="n in 4"
-          :key="n"
-          class="flex-1 border-r border-gray-100 px-4 py-3"
-          :class="{ 'bg-white font-medium': step === n }"
+          v-for="(title, index) in IMPORT_STEPS"
+          :key="title"
+          class="flex-1 border-r border-gray-100 px-4 py-3 last:border-r-0"
+          :class="{ 'bg-white font-medium': step === index + 1 }"
         >
-          Step {{ n }}
+          {{ title }}
         </div>
       </div>
 

--- a/packages/front-end/src/app/components/EGSamplesTab.vue
+++ b/packages/front-end/src/app/components/EGSamplesTab.vue
@@ -8,7 +8,7 @@
   import EGSampleTagSidebar from '@FE/components/EGSampleTagSidebar.vue';
   import { useToastStore, useUiStore } from '@FE/stores';
   import { SAMPLE_LAYOUT_LABELS } from '@FE/utils/data-collections-selection';
-  import { exceedsBatchNameMaxLength, exceedsTagNameMaxLength } from '@FE/utils/data-collections-name-validation';
+  import { exceedsTagNameMaxLength } from '@FE/utils/data-collections-name-validation';
 
   const props = defineProps<{
     labId: string;
@@ -31,7 +31,6 @@
     import: [];
     'build-collection': [];
     'tags-updated': [];
-    'batch-updated': [];
     'tag-created': [];
     'tag-deleted': [tagId: string];
   }>();
@@ -49,9 +48,6 @@
   const inlineNewTagName = ref('');
   const inlineNewTagColor = ref('#5B4FD4');
   const bulkPanelContentEl = ref<HTMLElement | null>(null);
-  const showChangeBatchModal = ref(false);
-  const changeBatchSelectedBatchId = ref<string | LaboratoryDataTag | undefined>(undefined);
-  const changeBatchNewName = ref('');
 
   /** Cards grid vs tabular layout (matches file explorer). */
   const explorerView = ref<'cards' | 'table'>('cards');
@@ -80,30 +76,6 @@
   const inlineTagNameInvalid = computed(() => exceedsTagNameMaxLength(inlineNewTagName.value));
   const canCreateInlineTag = computed(() => !!inlineNewTagName.value.trim() && !inlineTagNameInvalid.value);
 
-  const changeBatchNewNameInvalid = computed(() => exceedsBatchNameMaxLength(changeBatchNewName.value));
-  const canApplyChangeBatchWithNewName = computed(
-    () => !!changeBatchNewName.value.trim() && !changeBatchNewNameInvalid.value,
-  );
-  const canApplyChangeBatch = computed(
-    () =>
-      canApplyChangeBatchWithNewName.value || (!!resolvedChangeBatchTagId.value && !changeBatchNewName.value.trim()),
-  );
-
-  function resolvedBatchTagId(value: string | LaboratoryDataTag | undefined): string | undefined {
-    if (!value) return undefined;
-    if (typeof value === 'string') return value;
-    return value.TagId;
-  }
-
-  const resolvedChangeBatchTagId = computed(() => resolvedBatchTagId(changeBatchSelectedBatchId.value));
-
-  watch(changeBatchNewName, (v) => {
-    if (v.trim()) changeBatchSelectedBatchId.value = undefined;
-  });
-  watch(changeBatchSelectedBatchId, (v) => {
-    if (v) changeBatchNewName.value = '';
-  });
-
   function standardTagIdsForSet(setId: string): string[] {
     const tagIdSet = new Set(standardTags.value.map((t) => t.TagId));
     return (props.sampleIdToTagIds[setId] ?? []).filter((tid) => tagIdSet.has(tid));
@@ -129,6 +101,7 @@
 
   const sampleSections = computed((): SampleSection[] => {
     const nameById = new Map(batchTags.value.map((t) => [t.TagId, t.Name]));
+    const createdAtById = new Map(batchTags.value.map((t) => [t.TagId, t.CreatedAt ?? '']));
     const groups = new Map<string | null, LaboratorySample[]>();
     for (const s of filtered.value) {
       const bid = s.BatchTagId ?? null;
@@ -137,6 +110,10 @@
     }
     const batchEntries = [...groups.entries()].filter(([k]) => k !== null) as [string, LaboratorySample[]][];
     batchEntries.sort((a, b) => {
+      const ca = createdAtById.get(a[0]) ?? '';
+      const cb = createdAtById.get(b[0]) ?? '';
+      const byDate = cb.localeCompare(ca);
+      if (byDate !== 0) return byDate;
       const na = nameById.get(a[0]) ?? a[0];
       const nb = nameById.get(b[0]) ?? b[0];
       return na.localeCompare(nb);
@@ -179,16 +156,6 @@
   function tagById(id: string): LaboratoryDataTag | undefined {
     return props.tags.find((t) => t.TagId === id);
   }
-
-  const changeBatchCurrentlyInLine = computed(() => {
-    const names = new Set<string>();
-    for (const id of props.selectedIds) {
-      const sample = props.samples.find((s) => s.SampleId === id);
-      if (!sample?.BatchTagId) names.add('Unbatched');
-      else names.add(tagById(sample.BatchTagId)?.Name ?? sample.BatchTagId);
-    }
-    return [...names].sort((a, b) => a.localeCompare(b)).join(', ') || '—';
-  });
 
   function batchDisplayName(sample: LaboratorySample): string {
     if (!sample.BatchTagId) return '—';
@@ -373,75 +340,6 @@
         AddTagIds: addTagIds.length ? addTagIds : undefined,
         RemoveTagIds: removeTagIds.length ? removeTagIds : undefined,
       });
-    }
-  }
-
-  async function assignSampleBatchInChunks(
-    sampleIds: string[],
-    body: { ClearBatch?: boolean; BatchTagId?: string; NewBatchName?: string },
-  ): Promise<void> {
-    for (let i = 0; i < sampleIds.length; i += SEQUENCE_SET_IDS_CHUNK) {
-      const chunk = sampleIds.slice(i, i + SEQUENCE_SET_IDS_CHUNK);
-      await $api.dataCollections.assignSampleBatch({
-        LaboratoryId: props.labId,
-        SampleIds: chunk,
-        ...body,
-      });
-    }
-  }
-
-  function openChangeBatchModal(): void {
-    changeBatchSelectedBatchId.value = undefined;
-    changeBatchNewName.value = '';
-    showChangeBatchModal.value = true;
-  }
-
-  function closeChangeBatchModal(): void {
-    showChangeBatchModal.value = false;
-  }
-
-  function clearExistingBatchSelection(): void {
-    changeBatchSelectedBatchId.value = undefined;
-  }
-
-  async function applyChangeBatch(): Promise<void> {
-    if (!props.selectedIds.length) return;
-    const sampleIds = [...props.selectedIds];
-    const nn = changeBatchNewName.value.trim();
-    if (nn && exceedsBatchNameMaxLength(changeBatchNewName.value)) return;
-    uiStore.setRequestPending('dataCollectionsMutate');
-    try {
-      if (nn) {
-        await assignSampleBatchInChunks(sampleIds, { NewBatchName: nn });
-      } else if (resolvedChangeBatchTagId.value) {
-        await assignSampleBatchInChunks(sampleIds, { BatchTagId: resolvedChangeBatchTagId.value });
-      } else {
-        toast.warning('Choose an existing batch or enter a new batch name.');
-        return;
-      }
-      toast.success('Batch updated');
-      closeChangeBatchModal();
-      emit('batch-updated');
-    } catch (e: unknown) {
-      toast.error(e instanceof Error ? e.message : 'Batch update failed');
-    } finally {
-      uiStore.setRequestComplete('dataCollectionsMutate');
-    }
-  }
-
-  async function clearBatchFromModal(): Promise<void> {
-    if (!props.selectedIds.length) return;
-    const sampleIds = [...props.selectedIds];
-    uiStore.setRequestPending('dataCollectionsMutate');
-    try {
-      await assignSampleBatchInChunks(sampleIds, { ClearBatch: true });
-      toast.success('Removed from batch');
-      closeChangeBatchModal();
-      emit('batch-updated');
-    } catch (e: unknown) {
-      toast.error(e instanceof Error ? e.message : 'Batch update failed');
-    } finally {
-      uiStore.setRequestComplete('dataCollectionsMutate');
     }
   }
 
@@ -857,9 +755,6 @@
         <span v-else class="text-muted text-xs">Select samples to add or remove tags in bulk.</span>
         <div v-if="hasSelection" class="ml-auto flex flex-wrap items-center gap-2">
           <UIcon v-if="bulkPanelBusy" name="i-heroicons-arrow-path" class="text-muted h-5 w-5 shrink-0 animate-spin" />
-          <UButton size="sm" variant="outline" :disabled="bulkPanelBusy" @click="openChangeBatchModal">
-            Change batch
-          </UButton>
           <UButton size="sm" variant="outline" :disabled="bulkPanelBusy" @click="openAddBulkPanel">Add Tags</UButton>
           <UButton size="sm" variant="outline" :disabled="bulkPanelBusy" @click="openRemoveBulkPanel">
             Remove Tags
@@ -994,97 +889,4 @@
       </div>
     </div>
   </div>
-
-  <UModal
-    v-model="showChangeBatchModal"
-    :ui="{
-      overlay: {
-        base: 'fixed inset-0 transition-opacity backdrop-blur-[5px]',
-        background: 'bg-gray-800/30',
-      },
-      rounded: 'rounded-3xl',
-      width: 'sm:max-w-lg',
-    }"
-  >
-    <UCard
-      :ui="{
-        base: 'p-8',
-        rounded: 'rounded-3xl',
-        header: { padding: '' },
-      }"
-    >
-      <template #header>
-        <div class="flex flex-col gap-1">
-          <h3 class="text-lg font-semibold text-gray-900">Change batch</h3>
-          <p class="text-muted text-sm">Reassign the selected samples to a different batch.</p>
-        </div>
-      </template>
-
-      <div class="space-y-4">
-        <div class="rounded-lg border border-gray-100 bg-gray-50 px-4 py-3">
-          <dl class="space-y-2.5 text-sm">
-            <div class="flex items-baseline justify-between gap-4">
-              <dt class="text-muted shrink-0">Samples to move</dt>
-              <dd class="font-medium tabular-nums text-gray-900">{{ selectedIds.length }}</dd>
-            </div>
-            <div class="flex items-start justify-between gap-4">
-              <dt class="text-muted shrink-0 pt-0.5">Currently in</dt>
-              <dd class="min-w-0 flex-1 break-words text-right font-medium leading-snug text-gray-900">
-                {{ changeBatchCurrentlyInLine }}
-              </dd>
-            </div>
-          </dl>
-        </div>
-        <div>
-          <div class="mb-1 flex items-center justify-between gap-2">
-            <label class="text-muted block text-xs font-semibold uppercase tracking-wide">Existing batch</label>
-            <button
-              v-if="changeBatchSelectedBatchId"
-              type="button"
-              class="text-primary shrink-0 text-xs font-normal hover:underline disabled:cursor-not-allowed disabled:opacity-50"
-              :disabled="bulkPanelBusy || !!changeBatchNewName.trim()"
-              @click="clearExistingBatchSelection"
-            >
-              Clear selection
-            </button>
-          </div>
-          <USelectMenu
-            v-model="changeBatchSelectedBatchId"
-            :options="batchTags"
-            option-attribute="Name"
-            value-attribute="TagId"
-            placeholder="Select a batch"
-            size="sm"
-            class="w-full"
-            :disabled="bulkPanelBusy || !!changeBatchNewName.trim()"
-          />
-        </div>
-        <div>
-          <label class="text-muted mb-1 block text-xs font-semibold uppercase tracking-wide">Or create new batch</label>
-          <UInput
-            v-model="changeBatchNewName"
-            placeholder="e.g. Nov-2024-FluPanel"
-            size="sm"
-            class="w-full"
-            :color="changeBatchNewNameInvalid ? 'red' : undefined"
-            :disabled="bulkPanelBusy || !!resolvedChangeBatchTagId"
-          />
-          <p v-if="changeBatchNewNameInvalid" class="text-alert-danger-dark mt-1 text-xs">250 characters max</p>
-          <p v-else class="text-muted mt-1.5 text-xs leading-snug">
-            Leave blank to use the existing batch selected above.
-          </p>
-        </div>
-      </div>
-
-      <div class="mt-8 flex flex-wrap justify-end gap-2 border-t border-gray-100 pt-4">
-        <UButton size="sm" variant="ghost" :disabled="bulkPanelBusy" @click="closeChangeBatchModal">Cancel</UButton>
-        <UButton size="sm" variant="outline" :disabled="bulkPanelBusy" @click="clearBatchFromModal">
-          Remove from batch
-        </UButton>
-        <UButton size="sm" :loading="bulkPanelBusy" :disabled="!canApplyChangeBatch" @click="applyChangeBatch">
-          Move samples
-        </UButton>
-      </div>
-    </UCard>
-  </UModal>
 </template>

--- a/packages/front-end/src/app/components/EGSequenceCollectionsListTab.vue
+++ b/packages/front-end/src/app/components/EGSequenceCollectionsListTab.vue
@@ -11,7 +11,6 @@
   const emit = defineEmits<{
     'update:search': [value: string];
     'new-collection': [];
-    import: [];
     'launch-workflow': [collection: LaboratorySequenceCollection];
     'edit-collection': [collection: LaboratorySequenceCollection];
     'delete-collection': [collection: LaboratorySequenceCollection];
@@ -43,7 +42,6 @@
       />
       <div class="flex-1" />
       <UButton variant="outline" @click="emit('new-collection')">+ New Sequence Collection</UButton>
-      <UButton @click="emit('import')">Import data</UButton>
     </div>
 
     <div class="flex-1 overflow-y-auto">

--- a/packages/shared-lib/src/app/utils/HttpError.ts
+++ b/packages/shared-lib/src/app/utils/HttpError.ts
@@ -347,6 +347,7 @@ export class LaboratoryRunNotFoundError extends HttpError {
  *
  * @param sequenceSetId
  * @param messageOpt - optional additional message
+ * @deprecated Use {@link SampleNotFoundError}
  */
 export class SequenceSetNotFoundError extends HttpError {
   constructor(sequenceSetId: string, messageOpt?: string) {
@@ -371,6 +372,7 @@ export class SampleNotFoundError extends HttpError {
  *
  * @param collectionId
  * @param messageOpt - optional additional message
+ * @deprecated Use {@link SequenceCollectionNotFoundError}
  */
 export class DataCollectionNotFoundError extends HttpError {
   constructor(collectionId: string, messageOpt?: string) {


### PR DESCRIPTION
## Title*
Polish data collections UI per review feedback

## Type of Change*
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
Addresses review feedback on the data collections experience. Stack layer **D** on top of #794 (`feat/egv-179-C-dc-analysis-indicators`).

**Import wizard stepper** — Replaced generic “Step 1–4” labels with descriptive titles: Source, Group files, Review samples, Confirm (`EGImportDataWizard.vue`).

**Batch ordering** — Samples tab batch sections sort by batch `CreatedAt` descending (newest first). Unbatched remains first; name is the tie-breaker (`EGSamplesTab.vue`).

**Simplified batch management** — Removed the “Change batch” bulk action, modal, and related reload wiring. Batch assignment during import is unchanged (`EGSamplesTab.vue`, `EGDataCollectionsPage.vue`).

**Schema preset dropdown** — Fixed preset selection in the sequence collection builder with `v-model` on the preset select, edit-mode preset detection, and a “Custom” option when saved columns don’t match a known preset (`EGDataCollectionBuilder.vue`).

**Import button placement** — Removed Import from the Sequence Collections tab; it remains on the Samples tab only (`EGSequenceCollectionsListTab.vue`, `EGDataCollectionsPage.vue`).

**Backend/test fixes (rename fallout)** — Supporting changes so pre-commit hooks pass:
- Added `SampleNotFoundError` and `SequenceCollectionNotFoundError` to shared `HttpError.ts`
- Fixed `skSample` typo in `recordLaboratoryRunUsageForSamples`
- Renamed/updated `laboratory-sample-service.test.ts` and aligned tagging service tests with samples terminology
- Tightened `bulkCreateSamples` copy-job validation and `addSampleIdToFileRow` error handling

## Testing*
- [x] Backend: `pnpm exec projen test` in `packages/back-end` — 56 suites, 395 tests passing
- [x] Pre-commit hooks pass (lint-staged, backend tests, commitlint)
- Manual smoke test recommended:
  - Import wizard shows new step titles and navigation works
  - Newest batch sections appear above older ones on Samples tab
  - No “Change batch” when samples are selected
  - Schema preset dropdown reflects selection when creating/editing a sequence collection
  - Import button only on Samples tab, not Sequence Collections tab

## Impact
- **UX:** Clearer import flow, chronological batch display, less batch-management clutter, working preset dropdown, import entry point consolidated on Samples tab
- **Behaviour:** Users can no longer reassign samples to a different batch after import; batch assignment still happens during import
- **API:** No new endpoints; `assignSampleBatch` remains for the import flow
- **Dependencies:** None

## Additional Information
- Part of the EGV-179 stack: A → B → C → **D**
- Base branch: `feat/egv-179-C-dc-analysis-indicators` (#794), not `development`
- 1 commit; ~165 lines added / ~316 removed across 10 files

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [ ] Code has been commented in particularly hard-to-understand areas.