### PR TITLE
feat: sidebar collapse+expand

### DIFF
--- a/packages/front-end/src/app/components/EGOrgView.vue
+++ b/packages/front-end/src/app/components/EGOrgView.vue
@@ -41,16 +41,16 @@
 
   const showWorkflowAccessTab = computed(() => props.superuser || props.orgAdmin);
 
-  const tabItems = computed(() => {
-    const items: { key: string; label: string }[] = [];
+  const tabItems = computed<{ key: string; label: string; icon: string }[]>(() => {
+    const items: { key: string; label: string; icon: string }[] = [];
     if (props.superuser) {
-      items.push({ key: 'labs', label: 'All Labs' });
+      items.push({ key: 'labs', label: 'All Labs', icon: 'i-heroicons-beaker' });
     }
-    items.push({ key: 'users', label: 'All users' });
+    items.push({ key: 'users', label: 'All users', icon: 'i-heroicons-users' });
     if (showWorkflowAccessTab.value) {
-      items.push({ key: 'workflow-access', label: 'Workflow access' });
+      items.push({ key: 'workflow-access', label: 'Workflow access', icon: 'i-heroicons-key' });
     }
-    items.push({ key: 'details', label: 'Settings' });
+    items.push({ key: 'details', label: 'Settings', icon: 'i-heroicons-cog-6-tooth' });
     return items;
   });
 

--- a/packages/front-end/src/app/components/EGSidebarNav.vue
+++ b/packages/front-end/src/app/components/EGSidebarNav.vue
@@ -31,6 +31,8 @@
     'update:modelValue': [index: number];
   }>();
 
+  const uiStore = useUiStore();
+  const isCollapsed = computed(() => uiStore.sidebarCollapsed);
   const isDark = computed(() => props.variant === 'dark');
 
   // Holds a reference to each tab button so keyboard navigation can move focus
@@ -72,6 +74,10 @@
     focusPanel(index);
   }
 
+  function toggleCollapsed() {
+    uiStore.toggleSidebarCollapsed();
+  }
+
   // WAI-ARIA tabs with automatic activation: arrow keys move between tabs (wrapping),
   // Home/End jump to first/last. Click moves focus into the matching panel.
   function onKeydown(event: KeyboardEvent, index: number) {
@@ -105,15 +111,51 @@
     }
     focusTab(nextIndex);
   }
+
+  const tabButtonClass = (index: number) =>
+    isDark.value
+      ? [props.modelValue === index ? 'sidebar-tab--dark-active font-semibold' : 'sidebar-tab--dark']
+      : [
+          props.modelValue === index
+            ? 'bg-primary-muted text-primary-dark font-semibold'
+            : 'text-body hover:bg-background-light-grey',
+        ];
 </script>
 
 <template>
-  <nav class="sidebar-nav" :class="isDark ? 'sidebar-nav--dark' : 'bg-white'" :aria-label="ariaLabel">
-    <div v-if="calloutTitle" class="sidebar-callout mb-6 flex items-start gap-3 rounded-lg p-3" role="note">
+  <nav
+    class="sidebar-nav"
+    :class="[isDark ? 'sidebar-nav--dark' : 'bg-white', { 'sidebar-nav--collapsed': isCollapsed }]"
+    :aria-label="ariaLabel"
+  >
+    <button
+      type="button"
+      class="sidebar-nav__toggle focus-visible:outline-primary-500 flex h-8 w-8 items-center justify-center rounded-lg transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+      :class="[
+        isDark ? 'text-[#c5c4d0] hover:bg-white/10' : 'text-body hover:bg-background-light-grey',
+        isCollapsed ? 'sidebar-nav__toggle--collapsed' : 'sidebar-nav__toggle--expanded',
+      ]"
+      :aria-label="isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'"
+      :aria-expanded="!isCollapsed"
+      @click="toggleCollapsed"
+    >
+      <UIcon
+        :name="isCollapsed ? 'i-heroicons-chevron-right' : 'i-heroicons-chevron-left'"
+        class="h-5 w-5"
+        aria-hidden="true"
+      />
+    </button>
+
+    <div
+      v-if="calloutTitle"
+      class="sidebar-callout mb-6 flex items-start gap-3 rounded-lg p-3"
+      :class="{ 'sidebar-callout--collapsed justify-center p-2': isCollapsed }"
+      role="note"
+    >
       <span class="sidebar-callout__badge flex h-7 w-7 shrink-0 items-center justify-center rounded-md">
         <UIcon :name="calloutIcon" class="h-4 w-4" aria-hidden="true" />
       </span>
-      <span class="flex flex-col gap-1">
+      <span class="flex flex-col gap-1" :class="{ 'sr-only': isCollapsed }">
         <span class="sidebar-callout__title font-serif text-sm font-semibold">{{ calloutTitle }}</span>
         <span v-if="calloutDescription" class="sidebar-callout__description font-serif text-xs leading-snug">
           {{ calloutDescription }}
@@ -125,11 +167,31 @@
       <template v-for="(item, index) in items" :key="item.key">
         <div
           v-if="item.dividerBefore"
-          class="my-3 border-t"
-          :class="isDark ? 'border-white/10' : 'border-background-dark-grey'"
+          class="border-t"
+          :class="[isCollapsed ? 'my-2' : 'my-3', isDark ? 'border-white/10' : 'border-background-dark-grey']"
           role="presentation"
         />
+        <UTooltip v-if="isCollapsed" :open-delay="400">
+          <template #text>{{ item.label }}</template>
+          <button
+            :ref="(el) => setTabRef(el, index)"
+            type="button"
+            role="tab"
+            :id="tabId(item.key)"
+            :aria-controls="panelId(item.key)"
+            :aria-selected="modelValue === index"
+            :tabindex="modelValue === index ? 0 : -1"
+            @click="onTabClick(index)"
+            @keydown="onKeydown($event, index)"
+            class="focus-visible:outline-primary-500 flex w-full items-center justify-center rounded-lg px-2 py-2.5 font-serif text-sm transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+            :class="tabButtonClass(index)"
+          >
+            <UIcon v-if="item.icon" :name="item.icon" class="h-5 w-5 shrink-0" aria-hidden="true" />
+            <span class="sr-only">{{ item.label }}</span>
+          </button>
+        </UTooltip>
         <button
+          v-else
           :ref="(el) => setTabRef(el, index)"
           type="button"
           role="tab"
@@ -140,15 +202,7 @@
           @click="onTabClick(index)"
           @keydown="onKeydown($event, index)"
           class="focus-visible:outline-primary-500 flex w-full items-center gap-3 rounded-lg px-4 py-2.5 text-left font-serif text-sm transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
-          :class="
-            isDark
-              ? [modelValue === index ? 'sidebar-tab--dark-active font-semibold' : 'sidebar-tab--dark']
-              : [
-                  modelValue === index
-                    ? 'bg-primary-muted text-primary-dark font-semibold'
-                    : 'text-body hover:bg-background-light-grey',
-                ]
-          "
+          :class="tabButtonClass(index)"
         >
           <UIcon v-if="item.icon" :name="item.icon" class="h-5 w-5 shrink-0" aria-hidden="true" />
           <span>{{ item.label }}</span>
@@ -169,6 +223,29 @@
     min-height: calc(100vh - var(--header-height));
     border-right: 1px solid #e5e5e5;
     border-top: 1px solid #e5e5e5;
+    transition:
+      width 0.2s ease,
+      left 0.2s ease,
+      padding 0.2s ease;
+
+    &--collapsed {
+      left: calc(-1 * var(--sidebar-width-collapsed) - 2rem);
+      width: var(--sidebar-width-collapsed);
+      padding: 1rem 0.5rem;
+    }
+  }
+
+  .sidebar-nav__toggle {
+    &--expanded {
+      position: absolute;
+      top: 0;
+      right: 0;
+      z-index: 1;
+    }
+
+    &--collapsed {
+      margin: 0 auto 1rem;
+    }
   }
 
   // Dark treatment used by the org-admin area to read as a distinct place from the light lab workspace.

--- a/packages/front-end/src/app/layouts/default.vue
+++ b/packages/front-end/src/app/layouts/default.vue
@@ -22,7 +22,13 @@
 <template>
   <EGToasts class="top-[52px]" />
   <EGHeader :is-authed="true" key="routeKey" />
-  <main class="mb-4 mt-6 px-4" :class="{ 'has-sidebar': uiStore.hasSidebar }">
+  <main
+    class="mb-4 mt-6 px-4"
+    :class="{
+      'has-sidebar': uiStore.hasSidebar,
+      'has-sidebar--collapsed': uiStore.hasSidebar && uiStore.sidebarCollapsed,
+    }"
+  >
     <slot v-if="hasInit" />
   </main>
 </template>
@@ -37,6 +43,11 @@
       position: relative;
       margin-left: calc(var(--sidebar-width) + 2rem);
       margin-right: 2rem;
+      transition: margin-left 0.2s ease;
+
+      &.has-sidebar--collapsed {
+        margin-left: calc(var(--sidebar-width-collapsed) + 2rem);
+      }
     }
   }
 </style>

--- a/packages/front-end/src/app/stores/ui.ts
+++ b/packages/front-end/src/app/stores/ui.ts
@@ -57,6 +57,7 @@ interface UiStoreState {
   previousPageRoute: string;
   remountAppKey: number;
   hasSidebar: boolean;
+  sidebarCollapsed: boolean;
 }
 
 const initialState = (): UiStoreState => ({
@@ -64,6 +65,7 @@ const initialState = (): UiStoreState => ({
   previousPageRoute: '',
   remountAppKey: 0,
   hasSidebar: false,
+  sidebarCollapsed: false,
 });
 
 const useUiStore = defineStore('uiStore', {
@@ -104,10 +106,18 @@ const useUiStore = defineStore('uiStore', {
     setSidebarVisible(visible: boolean) {
       this.hasSidebar = visible;
     },
+
+    toggleSidebarCollapsed() {
+      this.sidebarCollapsed = !this.sidebarCollapsed;
+    },
+
+    setSidebarCollapsed(collapsed: boolean) {
+      this.sidebarCollapsed = collapsed;
+    },
   },
 
   persist: {
-    pick: ['previousPageRoute'],
+    pick: ['previousPageRoute', 'sidebarCollapsed'],
   },
 });
 

--- a/packages/front-end/src/app/styles/_variables.scss
+++ b/packages/front-end/src/app/styles/_variables.scss
@@ -1,5 +1,6 @@
 :root {
   --max-page-container-width-px: 1332px;
   --sidebar-width: 300px;
+  --sidebar-width-collapsed: 4rem;
   --header-height: 78px;
 }

--- a/packages/shared-lib/src/app/types/easy-genomics/generated.d.ts
+++ b/packages/shared-lib/src/app/types/easy-genomics/generated.d.ts
@@ -249,6 +249,10 @@ export interface paths {
     /** Request Laboratory User */
     post: operations["requestLaboratoryUser"];
   };
+  "/easy-genomics/list-api-docs": {
+    /** List Api Docs */
+    get: operations["listApiDocs"];
+  };
   "/easy-genomics/list-buckets": {
     /** List Buckets */
     get: operations["listBuckets"];
@@ -4315,6 +4319,22 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["LaboratoryUser"];
+        };
+      };
+      400: components["responses"]["BadRequest"];
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalError"];
+    };
+  };
+  /** List Api Docs */
+  listApiDocs: {
+    responses: {
+      /** @description Success */
+      200: {
+        content: {
+          "application/json": unknown;
         };
       };
       400: components["responses"]["BadRequest"];


### PR DESCRIPTION
## Title*
Collapsible sidebar navigation (EGV-181)

## Type of Change*
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
Adds collapse/expand support to the shared `EGSidebarNav` component used across org and lab views, giving users more horizontal space for main content while keeping navigation accessible.

**Sidebar behaviour**
- Toggle button (chevron left/right) collapses the sidebar to an icon-only rail (`4rem` wide) with a smooth width/margin transition.
- Collapsed tabs show icons with `UTooltip` labels on hover and retain the existing ARIA tabs keyboard navigation pattern.
- The org admin callout badge remains visible when collapsed; title/description text is visually hidden but still available to screen readers.

**State management**
- `sidebarCollapsed` is added to the UI Pinia store with `toggleSidebarCollapsed` / `setSidebarCollapsed` actions.
- Collapsed preference is persisted via the existing store `persist` config so it survives page reloads.

**Layout**
- `default.vue` main content margin adjusts between full (`--sidebar-width`) and collapsed (`--sidebar-width-collapsed`) sidebar widths.

**Icons**
- Org admin tab items in `EGOrgView` now include Heroicons (lab view tabs already had icons), which are required for the collapsed icon-only presentation.

Related: EGV-181

## Testing*
Manual testing performed:
- [ ] Toggle sidebar collapse/expand on org admin pages; verify main content reflows smoothly
- [ ] Toggle on lab pages; verify all tab icons and tooltips match labels
- [ ] Confirm collapsed state persists after page refresh
- [ ] Keyboard navigation (arrow keys, Home/End) still works in both expanded and collapsed modes
- [ ] Screen reader: toggle button announces expand/collapse; tab labels remain accessible via `sr-only` text
- [ ] Verify both light (lab) and dark (org admin) sidebar variants

No automated tests were added (UI-only change).

## Impact
- **User-facing:** Sidebar can be collapsed to reclaim ~236px of horizontal space; preference is remembered per browser.
- **Performance:** Negligible — CSS transitions and a persisted boolean in local storage.
- **Dependencies:** None added.
- **Behaviour:** Main content layout margin changes when a sidebar is present; no API or backend changes.

## Additional Information
- The `generated.d.ts` change (`listApiDocs` operation) appears unrelated to sidebar work and may be an incidental type regeneration — worth confirming whether it should be included or reverted before merge.
- Lab view (`EGLabView`) already defined tab icons; only `EGOrgView` needed icon additions in this PR.

## Checklist*
- [ ] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [ ] Code adheres to the coding and style guidelines of the project.
- [ ] Code has been commented in particularly hard-to-understand areas.