### PR TITLE
chore: remove the second lambda permission created for running tests from aws console

### DIFF
--- a/packages/back-end/src/infra/constructs/lambda-construct.ts
+++ b/packages/back-end/src/infra/constructs/lambda-construct.ts
@@ -182,25 +182,26 @@ export class LambdaConstruct extends Construct {
         );
       }
       const pathResource = this.props.restApi.root.resourceForPath(lambdaApiEndpoint);
+      // Disable console test-invoke so CDK does not emit a second `test-invoke-stage`
+      // Lambda::Permission per method. That duplicate doubles this stack's permission count
+      // against CloudFormation's 500-resource-per-stack limit; real traffic uses the
+      // deployment-stage permission, which is unaffected.
+      const lambdaIntegration = new LambdaIntegration(lambdaHandler, { allowTestInvoke: false });
       if (lambdaFunction.command in ALLOWED_LAMBDA_FUNCTION_OPERATIONS_WITH_RESOURCE_ID) {
         const pathResourceWithId: Resource = pathResource.addResource('{id}');
         pathResourceWithId.addMethod(
           ALLOWED_LAMBDA_FUNCTION_OPERATIONS_WITH_RESOURCE_ID[lambdaFunction.command],
-          new LambdaIntegration(lambdaHandler),
+          lambdaIntegration,
           {
             authorizer: this.authorizer,
             ...lambdaMethodOptions,
           },
         );
       } else {
-        pathResource.addMethod(
-          ALLOWED_LAMBDA_FUNCTION_OPERATIONS[lambdaFunction.command],
-          new LambdaIntegration(lambdaHandler),
-          {
-            authorizer: this.authorizer,
-            ...lambdaMethodOptions,
-          },
-        );
+        pathResource.addMethod(ALLOWED_LAMBDA_FUNCTION_OPERATIONS[lambdaFunction.command], lambdaIntegration, {
+          authorizer: this.authorizer,
+          ...lambdaMethodOptions,
+        });
       }
     }
 


### PR DESCRIPTION
## Title*
Disable API Gateway console test-invoke permissions to clear the CloudFormation stack-resource budget

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [x] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
The back-end build fails at synth: the `stack-resource-budget` guardrail hard-fails when a stack crosses **450** CloudFormation resources (CFN's hard limit is 500), and `dev-quality-easy-genomics-api-stack` is at **463/500**.

CDK's `LambdaIntegration` defaults `allowTestInvoke: true`, which emits a *second* `AWS::Lambda::Permission` per Lambda-backed method — one scoped to the deployment stage (used by real traffic) and one scoped to the `test-invoke-stage` pseudo-stage (used only by the "Test" button in the API Gateway console). On the api-stack these duplicates account for roughly half of the ~156 permission resources.

This change sets `allowTestInvoke: false` in `LambdaConstruct`, removing the console-only duplicate permissions. To do it cleanly, the `LambdaIntegration` is now constructed once and reused across both `addMethod` branches (which are mutually exclusive), removing the previously duplicated `new LambdaIntegration(lambdaHandler)` construction.

This is a deliberate **stopgap** to get CI green now; the `SpecRestApi` migration is the durable fix and will make this flag redundant (it grants a single wildcard permission per function and restores console testing).

- File: `packages/back-end/src/infra/constructs/lambda-construct.ts`

## Testing*
All verification run locally against the `dev-demo` config (the only config available locally):

- **`pnpm run synth:silent`** — completes successfully; the `stack-resource-budget` guardrail no longer throws. `dev-demo-easy-genomics-api-stack` reports **398/500** (was over budget before).
- **Synth template inspection** — `AWS::Lambda::Permission` dropped from 162 → **81**, with **0** permissions scoped to `test-invoke-stage` (confirms the flag took effect). No `ApiGateway::Method`/`Resource` changes.
- **`pnpm --filter @easy-genomics/back-end test`** — **57 suites / 405 tests passed**.
- **eslint + prettier** — clean on the changed file.
- No new automated test added: `allowTestInvoke` is awkward to assert directly and the existing `stack-resource-budget.test.ts` already covers the guardrail logic. The change is short-lived (superseded by `SpecRestApi`).

> Note: the actual failing environment is `dev-quality`, which can't be synthed locally. The mechanism is identical — removing per-method test-invoke duplicates — projecting **463 → ~385**, below the 450 fail threshold. CI on the quality env is the final confirmation.

## Impact
- **Runtime / traffic: none.** Real requests use the deployment-stage permission, which is unchanged. No URL, response, auth, or behaviour changes.
- **Deployment: in-place and low-risk across all environments** (incl. customer accounts). On `cdk deploy`, CloudFormation simply deletes the ~78 console-only permissions — no function replacement, no API redeploy, no downtime, no data/export changes. Fully reversible by flipping the flag back.
- **Cost: none** — same APIs, same Lambdas.
- **Only functional loss:** the API Gateway console "Test" button for these methods. Not used in our workflow (we test via Playwright E2E against `quality` and the local dev-server).
- **No new dependencies.**

## Additional Information
- This relieves **only** the `easy-genomics-api-stack` wall. The EG Lambda **nested stack** (~398/500) is untouched (permissions live in the api-stack) and remains the next ceiling — it needs separate relief (`logRetention` / Lambda consolidation) before the data-collections handlers land.
- Margin is intentionally thin: post-change the api-stack sits at ~385–398 (warn threshold is 400). This is expected for a stopgap; `SpecRestApi` takes it to ~123.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly. <!-- N/A — no behaviour/API change to document. -->
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.
