### PR TITLE
fix: sample sheet unit test error

### DIFF
--- a/packages/shared-lib/src/app/utils/data-collection-sample-sheet.test.ts
+++ b/packages/shared-lib/src/app/utils/data-collection-sample-sheet.test.ts
@@ -135,7 +135,7 @@ describe('buildSampleSheetFromSamples', () => {
       columns,
       [
         {
-          SequenceSetId: '1',
+          SampleId: '1',
           Name: 'SampleA',
           Layout: 'paired_end',
           FileKeys: ['org/lab/a_R1.fastq.gz', 'org/lab/a_R2.fastq.gz'],


### PR DESCRIPTION
## Title
Fix shared-lib sample sheet unit test type error

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
The `@easy-genomics/shared-lib` build was failing with a TypeScript error in `data-collection-sample-sheet.test.ts`:
`error TS2353: Object literal may only specify known properties, and 'SequenceSetId' does not exist in type 'SampleForSampleSheet'.`

The `SampleForSampleSheet` type was updated to use `SampleId` as part of the broader rename from sequence sets to samples, but the `buildSampleSheetFromSamples` test fixture was still using the old `SequenceSetId` property name.

This change updates the test object to use `SampleId`, aligning it with the current type definition.

## Testing
- Ran `pnpm nx run @easy-genomics/shared-lib:build` — compile and tests pass, including `data-collection-sample-sheet.test.ts`.

## Impact
No runtime or behavioural changes. This is a test-only fix that unblocks the shared-lib build.

## Additional Information
The `SampleForSampleSheet` type in `data-collection-sample-sheet.ts` defines `SampleId`, not `SequenceSetId`. No production code changes were required.

## Checklist
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [ ] Code has been commented in particularly hard-to-understand areas.