### PR TITLE
fix: data collections s3 error handling

### DIFF
--- a/packages/front-end/src/app/components/EGDataCollectionsPage.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsPage.vue
@@ -26,10 +26,10 @@
 
   const emit = defineEmits<{
     'update:explorerTab': [tab: DataCollectionsTab];
+    'open-settings': [];
   }>();
 
   const { $api } = useNuxtApp();
-  const $router = useRouter();
   const labsStore = useLabsStore();
   const userStore = useUserStore();
   const uiStore = useUiStore();
@@ -205,7 +205,7 @@
   );
 
   function openLabSettings(): void {
-    void $router.push(`/labs/${props.labId}?tab=Settings`);
+    emit('open-settings');
   }
 
   function openImport(): void {
@@ -335,18 +335,18 @@
         <p v-if="canEditLabDetails">
           This lab does not have a
           <strong>default S3 bucket</strong>
-          configured. Import, unlinked-file scanning, and runs that use sample files require S3 storage. Open
+          configured. Open
           <strong>Settings</strong>
           and set
           <strong>Default S3 bucket directory</strong>
-          .
+          to enable data collections features.
         </p>
         <p v-else>
           This lab does not have a default S3 bucket configured. Ask your
           <strong>organization administrator</strong>
           to set
           <strong>Default S3 bucket directory</strong>
-          in lab Settings before importing data or scanning files.
+          in lab settings to enable data collections features.
         </p>
         <UButton v-if="canEditLabDetails" class="mt-3" size="sm" variant="outline" @click="openLabSettings">
           Open Settings

--- a/packages/front-end/src/app/components/EGDataCollectionsPage.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsPage.vue
@@ -20,6 +20,7 @@
   import EGRunFromDataCollectionModal from '@FE/components/EGRunFromDataCollectionModal.vue';
   import EGSamplesTab from '@FE/components/EGSamplesTab.vue';
   import EGUnlinkedFilesTab from '@FE/components/EGUnlinkedFilesTab.vue';
+  import { isLaboratoryS3Configured, isMissingLaboratoryS3BucketError } from '@FE/utils/laboratory-s3';
 
   const props = defineProps<{ labId: string }>();
 
@@ -28,13 +29,17 @@
   }>();
 
   const { $api } = useNuxtApp();
+  const $router = useRouter();
   const labsStore = useLabsStore();
+  const userStore = useUserStore();
   const uiStore = useUiStore();
   const toast = useToastStore();
 
   type View = 'main' | 'import' | 'builder';
 
   const lab = computed<Laboratory | null>(() => labsStore.labs[props.labId] ?? null);
+  const isLabS3Configured = computed(() => isLaboratoryS3Configured(lab.value));
+  const canEditLabDetails = computed(() => userStore.canEditLabDetails());
   const view = ref<View>('main');
   const activeTab = ref<DataCollectionsTab>('samples');
 
@@ -134,7 +139,17 @@
     }
   }
 
+  function clearUnlinkedFiles(): void {
+    unlinkedFiles.value = [];
+    unlinkedMeta.value = { s3Bucket: '', resolvedPrefix: '', lastScanLabel: '' };
+  }
+
   async function loadUnlinkedFiles(): Promise<void> {
+    if (!isLabS3Configured.value) {
+      clearUnlinkedFiles();
+      return;
+    }
+
     uiStore.setRequestPending('dataCollectionsList');
     try {
       const res = await $api.dataCollections.requestUnlinkedBucketObjects({
@@ -147,7 +162,11 @@
         resolvedPrefix: res.ResolvedPrefix,
         lastScanLabel: `Last scan ${new Date().toLocaleTimeString()}`,
       };
-    } catch {
+    } catch (e: unknown) {
+      if (isMissingLaboratoryS3BucketError(e)) {
+        clearUnlinkedFiles();
+        return;
+      }
       toast.error('Failed to load unlinked files.');
     } finally {
       uiStore.setRequestComplete('dataCollectionsList');
@@ -177,7 +196,20 @@
     () => void refreshAll(),
   );
 
+  watch(
+    () => lab.value?.S3Bucket,
+    () => {
+      if (isLabS3Configured.value) void loadUnlinkedFiles();
+      else clearUnlinkedFiles();
+    },
+  );
+
+  function openLabSettings(): void {
+    void $router.push(`/labs/${props.labId}?tab=Settings`);
+  }
+
   function openImport(): void {
+    if (!isLabS3Configured.value) return;
     view.value = 'import';
   }
 
@@ -296,6 +328,31 @@
     />
 
     <template v-else>
+      <div
+        v-if="!isLabS3Configured"
+        class="mb-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
+      >
+        <p v-if="canEditLabDetails">
+          This lab does not have a
+          <strong>default S3 bucket</strong>
+          configured. Import, unlinked-file scanning, and runs that use sample files require S3 storage. Open
+          <strong>Settings</strong>
+          and set
+          <strong>Default S3 bucket directory</strong>
+          .
+        </p>
+        <p v-else>
+          This lab does not have a default S3 bucket configured. Ask your
+          <strong>organization administrator</strong>
+          to set
+          <strong>Default S3 bucket directory</strong>
+          in lab Settings before importing data or scanning files.
+        </p>
+        <UButton v-if="canEditLabDetails" class="mt-3" size="sm" variant="outline" @click="openLabSettings">
+          Open Settings
+        </UButton>
+      </div>
+
       <EGDataCollectionsTabBar
         v-model:active-tab="activeTab"
         :collection-count="sequenceCollections.length"
@@ -318,6 +375,7 @@
       <EGSamplesTab
         v-else-if="activeTab === 'samples'"
         :lab-id="labId"
+        :s3-configured="isLabS3Configured"
         :samples="samples"
         :tags="tags"
         :sample-id-to-tag-ids="sampleIdToTagIds"
@@ -344,12 +402,15 @@
         :loading="loading"
         :selected-keys="selectedFileKeys"
         :search="fileSearch"
+        :s3-configured="isLabS3Configured"
+        :can-edit-lab-details="canEditLabDetails"
         :s3-bucket="unlinkedMeta.s3Bucket"
         :resolved-prefix="unlinkedMeta.resolvedPrefix"
         :last-scan-label="unlinkedMeta.lastScanLabel"
         @update:selected-keys="selectedFileKeys = $event"
         @update:search="fileSearch = $event"
         @rescan="loadUnlinkedFiles"
+        @open-settings="openLabSettings"
         @build-sample="showBuildSampleModal = true"
         @group-with-regex="showRegexGroupModal = true"
       />

--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -204,6 +204,11 @@
     tabIndex.value = newIndex;
   }
 
+  function openLabSettingsFromDataCollections(): void {
+    const settingsIndex = tabItems.value.findIndex((tab) => tab.key === 'details');
+    if (settingsIndex !== -1) handleTabChange(settingsIndex);
+  }
+
   // Lab Runs Tab
 
   type LaboratoryRunTableItem = LaboratoryRun & { lastUpdated: string; searchIndex: string };
@@ -822,7 +827,11 @@
     class="mt-4"
   >
     <h2 class="sr-only">Sequence collections</h2>
-    <EGDataCollectionsPage :lab-id="labId" @update:explorer-tab="dataCollectionsExplorerTab = $event" />
+    <EGDataCollectionsPage
+      :lab-id="labId"
+      @update:explorer-tab="dataCollectionsExplorerTab = $event"
+      @open-settings="openLabSettingsFromDataCollections"
+    />
   </div>
 
   <!-- Runs tab -->

--- a/packages/front-end/src/app/components/EGSamplesTab.vue
+++ b/packages/front-end/src/app/components/EGSamplesTab.vue
@@ -10,18 +10,24 @@
   import { SAMPLE_LAYOUT_LABELS } from '@FE/utils/data-collections-selection';
   import { exceedsTagNameMaxLength } from '@FE/utils/data-collections-name-validation';
 
-  const props = defineProps<{
-    labId: string;
-    samples: LaboratorySample[];
-    tags: LaboratoryDataTag[];
-    sampleIdToTagIds: Record<string, string[]>;
-    sampleIdToRunUsages: Record<string, LaboratoryRunUsageSummary[]>;
-    loading: boolean;
-    selectedIds: string[];
-    search: string;
-    tagsFilterUntagged: boolean;
-    tagsFilterTagIds: string[];
-  }>();
+  const props = withDefaults(
+    defineProps<{
+      labId: string;
+      samples: LaboratorySample[];
+      tags: LaboratoryDataTag[];
+      sampleIdToTagIds: Record<string, string[]>;
+      sampleIdToRunUsages: Record<string, LaboratoryRunUsageSummary[]>;
+      loading: boolean;
+      selectedIds: string[];
+      search: string;
+      tagsFilterUntagged: boolean;
+      tagsFilterTagIds: string[];
+      s3Configured?: boolean;
+    }>(),
+    {
+      s3Configured: true,
+    },
+  );
 
   const emit = defineEmits<{
     'update:selectedIds': [ids: string[]];
@@ -449,7 +455,16 @@
             />
           </div>
           <div class="ml-auto shrink-0">
-            <UButton size="sm" @click="emit('import')">Import data</UButton>
+            <UButton
+              size="sm"
+              :disabled="!s3Configured"
+              :title="
+                s3Configured ? undefined : 'Configure the lab default S3 bucket in Settings before importing data.'
+              "
+              @click="emit('import')"
+            >
+              Import data
+            </UButton>
           </div>
         </div>
 

--- a/packages/front-end/src/app/components/EGUnlinkedFilesTab.vue
+++ b/packages/front-end/src/app/components/EGUnlinkedFilesTab.vue
@@ -7,15 +7,23 @@
     type DataCollectionFileTypeFilter,
   } from '@FE/utils/data-collections-file-type';
 
-  const props = defineProps<{
-    files: Array<{ Key: string; Size?: number; LastModified?: string }>;
-    loading: boolean;
-    selectedKeys: string[];
-    search: string;
-    s3Bucket: string;
-    resolvedPrefix: string;
-    lastScanLabel: string;
-  }>();
+  const props = withDefaults(
+    defineProps<{
+      files: Array<{ Key: string; Size?: number; LastModified?: string }>;
+      loading: boolean;
+      selectedKeys: string[];
+      search: string;
+      s3Bucket: string;
+      resolvedPrefix: string;
+      lastScanLabel: string;
+      s3Configured?: boolean;
+      canEditLabDetails?: boolean;
+    }>(),
+    {
+      s3Configured: true,
+      canEditLabDetails: false,
+    },
+  );
 
   const emit = defineEmits<{
     'update:selectedKeys': [keys: string[]];
@@ -23,6 +31,7 @@
     rescan: [];
     'build-sample': [];
     'group-with-regex': [];
+    'open-settings': [];
   }>();
 
   const fileTypeFilter = ref<DataCollectionFileTypeFilter>({ fastq: true, fasta: false, other: false });
@@ -75,76 +84,98 @@
       />
       <EGDataCollectionsFileTypeFilter v-model="fileTypeFilter" :counts="fileTypeCounts" />
       <div class="flex-1" />
-      <UButton variant="outline" :loading="loading" @click="emit('rescan')">Rescan bucket</UButton>
+      <UButton variant="outline" :loading="loading" :disabled="!s3Configured" @click="emit('rescan')">
+        Rescan bucket
+      </UButton>
     </div>
 
-    <div class="border-b bg-gray-50 px-4 py-2 text-xs text-gray-500">
-      Scanned from
-      <span class="font-mono text-gray-800">s3://{{ s3Bucket }}/{{ resolvedPrefix }}</span>
-      ·
-      <strong>{{ files.length }}</strong>
-      unlinked files
-      <span v-if="lastScanLabel">· {{ lastScanLabel }}</span>
+    <div v-if="!s3Configured" class="flex flex-1 flex-col items-center justify-center gap-3 p-8 text-center">
+      <p class="max-w-lg text-sm text-gray-600">
+        <template v-if="canEditLabDetails">
+          Configure a
+          <strong>default S3 bucket</strong>
+          in lab Settings to scan unlinked files in storage.
+        </template>
+        <template v-else>
+          Ask your organization administrator to configure the lab's
+          <strong>default S3 bucket</strong>
+          in Settings before files can be scanned.
+        </template>
+      </p>
+      <UButton v-if="canEditLabDetails" size="sm" variant="outline" @click="emit('open-settings')">
+        Open Settings
+      </UButton>
     </div>
 
-    <div class="flex-1 overflow-y-auto">
-      <table class="w-full text-sm">
-        <thead class="sticky top-0 bg-gray-50">
-          <tr>
-            <th class="w-10 p-3" />
-            <th class="p-3 text-left text-xs uppercase text-gray-400">File</th>
-            <th class="p-3 text-left text-xs uppercase text-gray-400">Type</th>
-            <th class="p-3 text-left text-xs uppercase text-gray-400">Size</th>
-            <th class="p-3 text-left text-xs uppercase text-gray-400">Last modified</th>
-            <th class="p-3 text-left text-xs uppercase text-gray-400">Status</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr v-if="loading">
-            <td colspan="6" class="p-6 text-center text-gray-400">Scanning…</td>
-          </tr>
-          <tr v-else-if="!filtered.length">
-            <td colspan="6" class="p-6 text-center text-gray-400">No unlinked files match the current filters.</td>
-          </tr>
-          <tr
-            v-for="f in filtered"
-            :key="f.Key"
-            class="border-t border-gray-100 hover:bg-gray-50"
-            :class="{ 'bg-primary-50': selectedKeys.includes(f.Key) }"
-          >
-            <td class="p-3">
-              <input type="checkbox" :checked="selectedKeys.includes(f.Key)" @change="toggle(f.Key)" />
-            </td>
-            <td class="p-3 font-mono text-xs">{{ f.Key.split('/').pop() }}</td>
-            <td class="p-3 text-xs uppercase text-gray-500">{{ dataCollectionFileKind(f.Key) }}</td>
-            <td class="p-3 text-xs">{{ formatSize(f.Size) }}</td>
-            <td class="p-3 text-xs text-gray-400">
-              {{ f.LastModified ? new Date(f.LastModified).toLocaleString() : '—' }}
-            </td>
-            <td class="p-3">
-              <span class="rounded-full bg-amber-100 px-2 py-0.5 text-xs text-amber-800">unlinked</span>
-            </td>
-          </tr>
-          <tr v-if="hiddenCount > 0">
-            <td colspan="6" class="p-3 text-center text-xs italic text-gray-400">
-              {{ hiddenCount }} file(s) hidden by type filter
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-
-    <div v-if="selectedKeys.length" class="flex items-center justify-between border-t border-gray-200 bg-white p-3">
-      <span class="text-sm text-gray-500">
-        <strong>{{ selectedKeys.length }}</strong>
-        selected
-      </span>
-      <div class="flex gap-2">
-        <UButton variant="outline" :disabled="selectedKeys.length < 2" @click="emit('group-with-regex')">
-          Group with regex
-        </UButton>
-        <UButton @click="emit('build-sample')">Build sample</UButton>
+    <template v-else>
+      <div class="border-b bg-gray-50 px-4 py-2 text-xs text-gray-500">
+        Scanned from
+        <span class="font-mono text-gray-800">s3://{{ s3Bucket }}/{{ resolvedPrefix }}</span>
+        ·
+        <strong>{{ files.length }}</strong>
+        unlinked files
+        <span v-if="lastScanLabel">· {{ lastScanLabel }}</span>
       </div>
-    </div>
+
+      <div class="flex-1 overflow-y-auto">
+        <table class="w-full text-sm">
+          <thead class="sticky top-0 bg-gray-50">
+            <tr>
+              <th class="w-10 p-3" />
+              <th class="p-3 text-left text-xs uppercase text-gray-400">File</th>
+              <th class="p-3 text-left text-xs uppercase text-gray-400">Type</th>
+              <th class="p-3 text-left text-xs uppercase text-gray-400">Size</th>
+              <th class="p-3 text-left text-xs uppercase text-gray-400">Last modified</th>
+              <th class="p-3 text-left text-xs uppercase text-gray-400">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-if="loading">
+              <td colspan="6" class="p-6 text-center text-gray-400">Scanning…</td>
+            </tr>
+            <tr v-else-if="!filtered.length">
+              <td colspan="6" class="p-6 text-center text-gray-400">No unlinked files match the current filters.</td>
+            </tr>
+            <tr
+              v-for="f in filtered"
+              :key="f.Key"
+              class="border-t border-gray-100 hover:bg-gray-50"
+              :class="{ 'bg-primary-50': selectedKeys.includes(f.Key) }"
+            >
+              <td class="p-3">
+                <input type="checkbox" :checked="selectedKeys.includes(f.Key)" @change="toggle(f.Key)" />
+              </td>
+              <td class="p-3 font-mono text-xs">{{ f.Key.split('/').pop() }}</td>
+              <td class="p-3 text-xs uppercase text-gray-500">{{ dataCollectionFileKind(f.Key) }}</td>
+              <td class="p-3 text-xs">{{ formatSize(f.Size) }}</td>
+              <td class="p-3 text-xs text-gray-400">
+                {{ f.LastModified ? new Date(f.LastModified).toLocaleString() : '—' }}
+              </td>
+              <td class="p-3">
+                <span class="rounded-full bg-amber-100 px-2 py-0.5 text-xs text-amber-800">unlinked</span>
+              </td>
+            </tr>
+            <tr v-if="hiddenCount > 0">
+              <td colspan="6" class="p-3 text-center text-xs italic text-gray-400">
+                {{ hiddenCount }} file(s) hidden by type filter
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div v-if="selectedKeys.length" class="flex items-center justify-between border-t border-gray-200 bg-white p-3">
+        <span class="text-sm text-gray-500">
+          <strong>{{ selectedKeys.length }}</strong>
+          selected
+        </span>
+        <div class="flex gap-2">
+          <UButton variant="outline" :disabled="selectedKeys.length < 2" @click="emit('group-with-regex')">
+            Group with regex
+          </UButton>
+          <UButton @click="emit('build-sample')">Build sample</UButton>
+        </div>
+      </div>
+    </template>
   </div>
 </template>

--- a/packages/front-end/src/app/utils/laboratory-s3.ts
+++ b/packages/front-end/src/app/utils/laboratory-s3.ts
@@ -1,0 +1,12 @@
+import type { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
+
+const MISSING_S3_BUCKET_MESSAGE = 'no S3 bucket configured';
+
+export function isLaboratoryS3Configured(lab: Laboratory | null | undefined): boolean {
+  return !!lab?.S3Bucket?.trim();
+}
+
+export function isMissingLaboratoryS3BucketError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes(MISSING_S3_BUCKET_MESSAGE);
+}

--- a/packages/front-end/test/app/utils/laboratory-s3.test.ts
+++ b/packages/front-end/test/app/utils/laboratory-s3.test.ts
@@ -1,0 +1,33 @@
+import { isLaboratoryS3Configured, isMissingLaboratoryS3BucketError } from '../../../src/app/utils/laboratory-s3';
+
+describe('isLaboratoryS3Configured', () => {
+  it('returns false when lab is null or undefined', () => {
+    expect(isLaboratoryS3Configured(null)).toBe(false);
+    expect(isLaboratoryS3Configured(undefined)).toBe(false);
+  });
+
+  it('returns false when S3Bucket is missing, empty, or whitespace', () => {
+    expect(isLaboratoryS3Configured({} as never)).toBe(false);
+    expect(isLaboratoryS3Configured({ S3Bucket: '' } as never)).toBe(false);
+    expect(isLaboratoryS3Configured({ S3Bucket: '   ' } as never)).toBe(false);
+  });
+
+  it('returns true when S3Bucket has a value', () => {
+    expect(isLaboratoryS3Configured({ S3Bucket: 'my-bucket' } as never)).toBe(true);
+    expect(isLaboratoryS3Configured({ S3Bucket: '  my-bucket  ' } as never)).toBe(true);
+  });
+});
+
+describe('isMissingLaboratoryS3BucketError', () => {
+  it('matches direct and HttpFactory-wrapped API errors', () => {
+    expect(isMissingLaboratoryS3BucketError(new Error('Laboratory has no S3 bucket configured'))).toBe(true);
+    expect(isMissingLaboratoryS3BucketError(new Error('Request error: Laboratory has no S3 bucket configured'))).toBe(
+      true,
+    );
+  });
+
+  it('returns false for unrelated errors', () => {
+    expect(isMissingLaboratoryS3BucketError(new Error('Failed to load unlinked files.'))).toBe(false);
+    expect(isMissingLaboratoryS3BucketError('network error')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Title*
Handle missing lab S3 bucket on Data Collections page

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
Data Collections assumed every lab had a default S3 bucket configured. When `S3Bucket` was unset, the page still called the unlinked-files API, surfaced a generic error toast, and left import/rescan actions enabled — a confusing experience with no path to fix the problem.

This PR adds front-end guards and guidance for labs without a default S3 bucket:

- New `laboratory-s3` helpers (`isLaboratoryS3Configured`, `isMissingLaboratoryS3BucketError`) centralize S3 configuration checks and API error detection.
- **EGDataCollectionsPage** shows an amber banner explaining that a default S3 bucket is required, with role-appropriate copy (editors vs. non-editors) and an **Open Settings** shortcut for users who can edit lab details.
- Unlinked-file loading is skipped when S3 is not configured; missing-bucket API errors are handled silently instead of showing a failure toast.
- A watcher on `lab.S3Bucket` reloads or clears unlinked files when settings change.
- **EGSamplesTab** disables **Import data** when S3 is not configured (with tooltip).
- **EGUnlinkedFilesTab** disables **Rescan bucket**, shows an empty-state message, and offers **Open Settings** for editors.
- **EGLabView** wires the `open-settings` event from Data Collections to the lab **Settings** tab.

Related: EGV-182

## Testing*
- Added unit tests for `laboratory-s3` helpers (`packages/front-end/test/app/utils/laboratory-s3.test.ts`) — 5 tests, all passing.
- Manual verification recommended:
  - Open Data Collections for a lab with no default S3 bucket → banner appears; import/rescan disabled; no error toast.
  - As a lab editor, click **Open Settings** → navigates to lab Settings tab.
  - As a non-editor, confirm admin-oriented messaging with no settings button.
  - Configure a default S3 bucket in Settings → unlinked files load; import/rescan become available.
  - Confirm unrelated API failures still show the existing error toast.

## Impact
- Front-end only; no API or back-end changes in this branch.
- Data Collections features that depend on S3 (import, bucket scan) are gated until a default bucket is configured.
- Behaviour change: missing S3 bucket no longer produces a generic "Failed to load unlinked files" toast.
- No new dependencies.

## Additional Information
- `s3Configured` props on child tabs default to `true` so existing callers outside Data Collections are unaffected.
- `isMissingLaboratoryS3BucketError` matches the back-end message fragment `"no S3 bucket configured"` (including HttpFactory-wrapped errors).

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.