### PR TITLE
fix: s3 IAM policy bug

### DIFF
--- a/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
@@ -1824,7 +1824,6 @@ export class EasyGenomicsNestedStack extends NestedStack {
 
     const sequenceSetDataCollectionRoutes = [
       '/easy-genomics/data-collections/list-samples',
-      '/easy-genomics/data-collections/create-sample',
       '/easy-genomics/data-collections/add-files-to-sample',
       '/easy-genomics/data-collections/remove-files-from-sample',
       '/easy-genomics/data-collections/list-sample-files',
@@ -1839,7 +1838,6 @@ export class EasyGenomicsNestedStack extends NestedStack {
       '/easy-genomics/data-collections/edit-sample-batch',
       '/easy-genomics/data-collections/request-list-sample-tags',
       '/easy-genomics/data-collections/list-samples-by-tag',
-      '/easy-genomics/data-collections/request-unlinked-bucket-objects',
       '/easy-genomics/data-collections/create-bulk-samples',
     ];
     for (const route of sequenceSetDataCollectionRoutes) {
@@ -1854,6 +1852,11 @@ export class EasyGenomicsNestedStack extends NestedStack {
 
     // create-sample may expand regex matches via lab bucket listing
     this.iam.addPolicyStatements('/easy-genomics/data-collections/create-sample', [
+      ...laboratoryReadForSequenceCollections,
+      new PolicyStatement({
+        resources: laboratoryDataTaggingDynamoResources,
+        actions: laboratoryDataTaggingDynamoActions,
+      }),
       new PolicyStatement({
         resources: ['arn:aws:s3:::*'],
         actions: ['s3:ListBucket'],
@@ -1861,8 +1864,13 @@ export class EasyGenomicsNestedStack extends NestedStack {
       }),
     ]);
 
+    // request-unlinked-bucket-objects lists S3 inputs then reads file rows from the tagging table
     this.iam.addPolicyStatements('/easy-genomics/data-collections/request-unlinked-bucket-objects', [
       ...laboratoryReadForSequenceCollections,
+      new PolicyStatement({
+        resources: laboratoryDataTaggingDynamoResources,
+        actions: laboratoryDataTaggingDynamoActions,
+      }),
       new PolicyStatement({
         resources: ['arn:aws:s3:::*'],
         actions: ['s3:ListBucket'],

--- a/packages/back-end/test/infra/stacks/easy-genomics-nested-stack.test.ts
+++ b/packages/back-end/test/infra/stacks/easy-genomics-nested-stack.test.ts
@@ -154,4 +154,46 @@ describe('EasyGenomicsNestedStack environment wiring', () => {
       ]),
     );
   });
+
+  it('adds IAM policy statements for request-unlinked-bucket-objects endpoint', () => {
+    const app = new App();
+    const parentStack = new Stack(app, 'parent-stack');
+    new EasyGenomicsNestedStack(parentStack, 'easy-genomics-test-stack', createProps());
+
+    const iamConstructMock = IamConstruct as unknown as jest.Mock;
+    const iamInstance = iamConstructMock.mock.results[0].value;
+
+    expect(iamInstance.addPolicyStatements).toHaveBeenCalledWith(
+      '/easy-genomics/data-collections/request-unlinked-bucket-objects',
+      expect.arrayContaining([
+        expect.objectContaining({
+          actions: expect.arrayContaining(['dynamodb:GetItem']),
+        }),
+        expect.objectContaining({
+          actions: expect.arrayContaining(['s3:ListBucket']),
+        }),
+      ]),
+    );
+  });
+
+  it('adds IAM policy statements for create-sample endpoint', () => {
+    const app = new App();
+    const parentStack = new Stack(app, 'parent-stack');
+    new EasyGenomicsNestedStack(parentStack, 'easy-genomics-test-stack', createProps());
+
+    const iamConstructMock = IamConstruct as unknown as jest.Mock;
+    const iamInstance = iamConstructMock.mock.results[0].value;
+
+    expect(iamInstance.addPolicyStatements).toHaveBeenCalledWith(
+      '/easy-genomics/data-collections/create-sample',
+      expect.arrayContaining([
+        expect.objectContaining({
+          actions: expect.arrayContaining(['dynamodb:GetItem']),
+        }),
+        expect.objectContaining({
+          actions: expect.arrayContaining(['s3:ListBucket']),
+        }),
+      ]),
+    );
+  });
 });


### PR DESCRIPTION
## Title*
Fix IAM policy overwrite for unlinked-files and create-sample Lambdas

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
After EGV-182 shipped to dev, testers still saw **"Failed to load unlinked files."** on the Data Collections page for labs with S3 configured. The API error was:

> `request-unlinked-bucket-objects` is not authorized to perform `dynamodb:GetItem` on `laboratory-data-tagging-table`

The `request-unlinked-bucket-objects` Lambda lists S3 input files, then calls `getSampleIdsForFileRefs` → `getFileRowSampleIds`, which requires `dynamodb:GetItem` on the tagging table. EGV-182 only addressed frontend handling when a lab has no S3 bucket; it did not change backend IAM.

**Root cause:** `IamConstruct.addPolicyStatements` uses `Map.set`, so a second call for the same route **replaces** the first. Both `request-unlinked-bucket-objects` and `create-sample` were granted DynamoDB tagging-table access in the shared `sequenceSetDataCollectionRoutes` loop, then a later `addPolicyStatements` call overwrote those policies with S3 `ListBucket` only.

**Fix:**
- Remove `create-sample` and `request-unlinked-bucket-objects` from the shared loop.
- Define each route’s IAM policy in a single `addPolicyStatements` call that includes laboratory read, tagging-table DynamoDB actions (including `GetItem`), and S3 `ListBucket`.

Related: EGV-182

## Testing*
- Added infra tests in `easy-genomics-nested-stack.test.ts` asserting both routes receive `dynamodb:GetItem` and `s3:ListBucket` in their final policy statements.
- Ran `npm test -- --testPathPattern=easy-genomics-nested-stack.test` — all 6 tests pass.

**Post-deploy verification (dev-quality):**
- [ ] Open Data Collections for a lab with a default S3 bucket configured.
- [ ] Confirm the Unlinked Files tab loads without the red "Failed to load unlinked files." toast.
- [ ] Confirm creating a sample with regex/S3 expansion still works.

## Impact
- **Requires a back-end CDK deploy** — IAM role changes only take effect after infrastructure deployment.
- No application logic, API contract, or frontend changes in this diff.
- Fixes a latent IAM bug on `create-sample` as well (same overwrite pattern).

## Additional Information
The deployed Lambda role name in the error (`dev-quality-easy-genomics-request-unlinked-bucket-objects`) confirms this is an infrastructure permission issue, not the missing-S3-bucket case handled by EGV-182.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.