### PR TITLE
fix: stale lab data race condition s3 bug

### DIFF
--- a/packages/front-end/src/app/components/EGDataCollectionsPage.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsPage.vue
@@ -20,7 +20,7 @@
   import EGRunFromDataCollectionModal from '@FE/components/EGRunFromDataCollectionModal.vue';
   import EGSamplesTab from '@FE/components/EGSamplesTab.vue';
   import EGUnlinkedFilesTab from '@FE/components/EGUnlinkedFilesTab.vue';
-  import { isLaboratoryS3Configured, isMissingLaboratoryS3BucketError } from '@FE/utils/laboratory-s3';
+  import { isLaboratoryS3Configured, shouldIgnoreUnlinkedBucketObjectsError } from '@FE/utils/laboratory-s3';
 
   const props = defineProps<{ labId: string }>();
 
@@ -144,7 +144,13 @@
     unlinkedMeta.value = { s3Bucket: '', resolvedPrefix: '', lastScanLabel: '' };
   }
 
+  async function ensureLabDetailsLoaded(): Promise<void> {
+    await labsStore.loadLab(props.labId);
+  }
+
   async function loadUnlinkedFiles(): Promise<void> {
+    await ensureLabDetailsLoaded();
+
     if (!isLabS3Configured.value) {
       clearUnlinkedFiles();
       return;
@@ -163,7 +169,7 @@
         lastScanLabel: `Last scan ${new Date().toLocaleTimeString()}`,
       };
     } catch (e: unknown) {
-      if (isMissingLaboratoryS3BucketError(e)) {
+      if (shouldIgnoreUnlinkedBucketObjectsError(e, lab.value)) {
         clearUnlinkedFiles();
         return;
       }
@@ -174,7 +180,14 @@
   }
 
   async function refreshAll(): Promise<void> {
-    await Promise.all([loadTags(), loadSamples(), loadSequenceCollections(), loadUnlinkedFiles()]);
+    await ensureLabDetailsLoaded();
+    const tasks = [loadTags(), loadSamples(), loadSequenceCollections()];
+    if (isLabS3Configured.value) {
+      tasks.push(loadUnlinkedFiles());
+    } else {
+      clearUnlinkedFiles();
+    }
+    await Promise.all(tasks);
   }
 
   async function onSampleTagsUpdated(): Promise<void> {

--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -701,6 +701,7 @@
     () => {
       hasRefreshedLabForNullToken.value = false;
       lastProcessedLabRef.value = null;
+      void loadLabData();
     },
   );
 

--- a/packages/front-end/src/app/utils/laboratory-s3.ts
+++ b/packages/front-end/src/app/utils/laboratory-s3.ts
@@ -1,6 +1,7 @@
 import type { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
 
 const MISSING_S3_BUCKET_MESSAGE = 'no S3 bucket configured';
+const BUCKET_DOES_NOT_EXIST_MESSAGE = 'specified bucket does not exist';
 
 export function isLaboratoryS3Configured(lab: Laboratory | null | undefined): boolean {
   return !!lab?.S3Bucket?.trim();
@@ -9,4 +10,16 @@ export function isLaboratoryS3Configured(lab: Laboratory | null | undefined): bo
 export function isMissingLaboratoryS3BucketError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return message.includes(MISSING_S3_BUCKET_MESSAGE);
+}
+
+/** Suppress unlinked-bucket scan errors when the lab has no usable S3 bucket configured. */
+export function shouldIgnoreUnlinkedBucketObjectsError(error: unknown, lab: Laboratory | null | undefined): boolean {
+  if (isMissingLaboratoryS3BucketError(error)) {
+    return true;
+  }
+  if (!isLaboratoryS3Configured(lab)) {
+    const message = error instanceof Error ? error.message : String(error);
+    return message.toLowerCase().includes(BUCKET_DOES_NOT_EXIST_MESSAGE);
+  }
+  return false;
 }

--- a/packages/front-end/test/app/utils/laboratory-s3.test.ts
+++ b/packages/front-end/test/app/utils/laboratory-s3.test.ts
@@ -1,4 +1,8 @@
-import { isLaboratoryS3Configured, isMissingLaboratoryS3BucketError } from '../../../src/app/utils/laboratory-s3';
+import {
+  isLaboratoryS3Configured,
+  isMissingLaboratoryS3BucketError,
+  shouldIgnoreUnlinkedBucketObjectsError,
+} from '../../../src/app/utils/laboratory-s3';
 
 describe('isLaboratoryS3Configured', () => {
   it('returns false when lab is null or undefined', () => {
@@ -29,5 +33,27 @@ describe('isMissingLaboratoryS3BucketError', () => {
   it('returns false for unrelated errors', () => {
     expect(isMissingLaboratoryS3BucketError(new Error('Failed to load unlinked files.'))).toBe(false);
     expect(isMissingLaboratoryS3BucketError('network error')).toBe(false);
+  });
+});
+
+describe('shouldIgnoreUnlinkedBucketObjectsError', () => {
+  it('ignores missing-bucket API errors', () => {
+    expect(shouldIgnoreUnlinkedBucketObjectsError(new Error('Laboratory has no S3 bucket configured'), null)).toBe(
+      true,
+    );
+  });
+
+  it('ignores bucket-not-found errors when the lab has no S3 bucket configured', () => {
+    const lab = { S3Bucket: '' } as never;
+    expect(
+      shouldIgnoreUnlinkedBucketObjectsError(new Error('Request error: The specified bucket does not exist'), lab),
+    ).toBe(true);
+  });
+
+  it('does not ignore bucket-not-found errors when the lab has an S3 bucket configured', () => {
+    const lab = { S3Bucket: 'my-bucket' } as never;
+    expect(
+      shouldIgnoreUnlinkedBucketObjectsError(new Error('Request error: The specified bucket does not exist'), lab),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Title
Fix data collections S3 scan firing when lab bucket is not configured

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
On the Data Collections page, navigating to a lab without a default S3 bucket configured could still trigger `POST /data-collections/request-unlinked-bucket-objects`, resulting in a 400 error (`EG-100`: "The specified bucket does not exist") and an error toast.

The root cause was a race with stale lab data in the persisted Pinia store: the page could read an outdated `S3Bucket` value before fresh lab details were loaded, pass the S3-configured guard, and fire the unlinked-bucket scan request even though the lab had no bucket set.

This PR:
- Loads fresh lab details before any S3-dependent logic on the Data Collections page (`ensureLabDetailsLoaded`)
- Skips `loadUnlinkedFiles()` entirely in `refreshAll()` when no S3 bucket is configured
- Refreshes lab data when navigating between labs in `EGLabView` (previously only loaded on initial mount)
- Adds `shouldIgnoreUnlinkedBucketObjectsError()` to silently handle in-flight scan failures after the bucket has been cleared (covers both "no S3 bucket configured" and "specified bucket does not exist" responses)

## Testing
- Added unit tests for `shouldIgnoreUnlinkedBucketObjectsError` in `packages/front-end/test/app/utils/laboratory-s3.test.ts`
- Ran `npx jest test/app/utils/laboratory-s3.test.ts` — all 8 tests pass
- Manual verification recommended:
  - Open a lab with no default S3 bucket configured and navigate to Data Collections
  - Confirm the configuration banner appears and no `request-unlinked-bucket-objects` request is made
  - Navigate between labs (one with and one without a bucket) and confirm no spurious S3 errors

## Impact
- **Behaviour:** Users on labs without an S3 bucket no longer see spurious API errors on the Data Collections page
- **Performance:** One additional `loadLab` call per Data Collections refresh and when switching labs; acceptable trade-off for correctness
- **Dependencies:** None

## Additional Information
Builds on the earlier S3 guard work in `EGDataCollectionsPage` (`isLaboratoryS3Configured`); this change ensures the guard evaluates against fresh server state rather than potentially stale persisted store data.

## Checklist
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.