### PR TITLE
fix: run workflow steps error caused activeTabKey

### DIFF
--- a/packages/front-end/src/app/components/EGRunWorkflowFormEditParameters.vue
+++ b/packages/front-end/src/app/components/EGRunWorkflowFormEditParameters.vue
@@ -304,8 +304,10 @@
   }
 
   async function onSubmit() {
+    runStore.updateWipOmicsRunParams(props.omicsRunTempId, localProps.params);
+
     const paramsRequired = wipOmicsRun.value?.paramsRequired || [];
-    const missingParams = paramsRequired.filter((paramName: string) => !wipOmicsRun.value?.params[paramName]);
+    const missingParams = paramsRequired.filter((paramName: string) => !localProps.params[paramName]);
 
     if (missingParams.length > 0) {
       useToastStore().error(`The '${missingParams.shift()}' field is required. Please try again.`);

--- a/packages/front-end/src/app/components/EGWizardStepTabs.vue
+++ b/packages/front-end/src/app/components/EGWizardStepTabs.vue
@@ -96,7 +96,7 @@
       </div>
     </template>
 
-    <template #item="{ item }">
+    <template #item="{ item, index, selected }">
       <div
         role="tabpanel"
         :id="panelId(item.key)"
@@ -104,7 +104,7 @@
         tabindex="0"
         class="outline-none focus:outline-none"
       >
-        <slot name="panel" :item="item" />
+        <slot name="panel" :item="item" :index="index" :selected="selected" />
       </div>
     </template>
   </UTabs>

--- a/packages/front-end/src/app/pages/labs/[labId]/run-pipeline/[pipelineId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/run-pipeline/[pipelineId].vue
@@ -38,6 +38,9 @@
 
   const wipSeqeraRun = computed<WipRun | undefined>(() => runStore.wipSeqeraRuns[seqeraRunTempId.value]);
 
+  /** Only mount the active wizard step panel content (see run-workflow page). */
+  const activeStepKey = computed(() => steps.value[selectedStepIndex.value]?.key);
+
   const pipeline = computed<SeqeraPipeline | null>(() => seqeraPipelinesStore.pipelines[pipelineId] || null);
 
   const hasLaunched = ref<boolean>(false);
@@ -317,10 +320,10 @@
       :has-launched="hasLaunched"
       aria-label="Run Seqera pipeline steps"
     >
-      <template #panel="{ item }">
+      <template #panel="{ selected }">
         <div v-if="!hasLaunched">
           <EGRunFormRunDetails
-            v-if="item.key === 'details'"
+            v-if="activeStepKey === 'details' && selected"
             platform="Seqera Cloud"
             :wip-run-temp-id="seqeraRunTempId"
             :pipeline-or-workflow-name="pipeline?.name"
@@ -330,7 +333,7 @@
           />
 
           <EGRunFormUploadData
-            v-else-if="item.key === 'upload'"
+            v-else-if="activeStepKey === 'upload' && selected"
             :lab-id="labId"
             :pipeline-or-workflow-name="pipeline.name"
             platform="Seqera Cloud"
@@ -341,7 +344,7 @@
           />
 
           <EGRunPipelineFormEditParameters
-            v-else-if="item.key === 'parameters'"
+            v-else-if="activeStepKey === 'parameters' && selected"
             :params="wipSeqeraRun?.params"
             :schema="schema"
             :lab-id="labId"
@@ -352,7 +355,7 @@
           />
 
           <EGRunPipelineFormReview
-            v-else-if="item.key === 'review'"
+            v-else-if="activeStepKey === 'review' && selected"
             :schema="schema"
             :params="wipSeqeraRun?.params"
             :lab-id="labId"

--- a/packages/front-end/src/app/pages/labs/[labId]/run-workflow/[workflowId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/run-workflow/[workflowId].vue
@@ -316,10 +316,10 @@
       :has-launched="hasLaunched"
       aria-label="Run HealthOmics workflow steps"
     >
-      <template #panel="{ item }">
+      <template #panel="{ selected }">
         <div v-if="!hasLaunched">
           <EGRunFormRunDetails
-            v-if="item.key === 'details' && activeStepKey === 'details'"
+            v-if="activeStepKey === 'details' && selected"
             platform="AWS HealthOmics"
             :wip-run-temp-id="omicsRunTempId"
             :pipeline-or-workflow-name="workflow?.name"
@@ -330,7 +330,7 @@
           />
 
           <EGRunFormUploadData
-            v-else-if="item.key === 'upload' && activeStepKey === 'upload'"
+            v-else-if="activeStepKey === 'upload' && selected"
             :lab-id="labId"
             :pipeline-or-workflow-name="workflow.name"
             platform="AWS HealthOmics"
@@ -341,7 +341,7 @@
           />
 
           <EGRunWorkflowFormEditParameters
-            v-else-if="item.key === 'parameters' && activeStepKey === 'parameters'"
+            v-else-if="activeStepKey === 'parameters' && selected"
             :key="`${omicsRunTempId}-${wipOmicsRun?.sampleSheetS3Url ?? ''}`"
             :params="wipOmicsRun?.params ?? {}"
             :schema="schema"
@@ -355,7 +355,7 @@
           />
 
           <EGRunWorkflowFormReview
-            v-else-if="item.key === 'review' && activeStepKey === 'review'"
+            v-else-if="activeStepKey === 'review' && selected"
             :schema="schema"
             :params="wipOmicsRun?.params"
             :lab-id="labId"


### PR DESCRIPTION
## fix: run workflow steps error caused activeTabKey

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
- Fix an intermittent bug where advancing from **Edit Parameters** to **Review Pipeline** selected the Review tab but rendered a blank panel, forcing users to go back and forward again to proceed.
- Root cause: step content was gated on both `activeStepKey` and `item.key`, but Headless UI can briefly show a different panel than `selectedStepIndex` when enabling a previously disabled tab. The visible panel then had no matching component to render.
- Render wizard step content when `activeStepKey` matches **and** the panel is `selected` (passed through from `EGWizardStepTabs`), instead of matching on `item.key`.
- Flush parameter form state to the store before required-field validation on **Save & Continue**, so validation uses the values the user just edited rather than stale store data.
- Apply the same wizard panel fix to the Seqera pipeline run flow for consistency.


## Testing*
Tested manually in local environment.

## Impact
This impacts run workflow forms.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.