### PR TITLE
fix: s3 permissions, multiple config checks

### DIFF
--- a/packages/back-end/scripts/build-import-mapping.ts
+++ b/packages/back-end/scripts/build-import-mapping.ts
@@ -66,6 +66,9 @@
  * -----
  *  - `--stack <name>`: override the synthesized stack name to read.
  *    Defaults to `${namePrefix}-easy-genomics-api-stack`.
+ *  - `--env-name <name>`: yaml env-name when easy-genomics.yaml has multiple
+ *    configurations (alternative to ENV_NAME). Do not use --stack for this;
+ *    that flag is reserved for the CDK stack name above.
  *  - `--cdk-out <path>`: override the cloud-assembly directory. Defaults
  *    to `<this package>/cdk.out`.
  *  - `--output <path>`: override the output file path.
@@ -86,11 +89,7 @@
 import { readFileSync, writeFileSync } from 'fs';
 import { join, resolve } from 'path';
 import { ConfigurationSettings } from '@easy-genomics/shared-lib/src/app/types/configuration';
-import {
-  findConfiguration,
-  getStackEnvName,
-  loadConfigurations,
-} from '@easy-genomics/shared-lib/src/app/utils/configuration';
+import { findConfiguration, loadConfigurations } from '@easy-genomics/shared-lib/src/app/utils/configuration';
 
 const EXPECTED_TABLE_SUFFIXES = [
   'organization-table',
@@ -124,6 +123,7 @@ type ImportMapping = Record<string, { TableName: string }>;
 
 type Args = {
   stackName?: string;
+  envName?: string;
   cdkOut?: string;
   output?: string;
   print: boolean;
@@ -136,6 +136,9 @@ function parseArgs(argv: string[]): Args {
     switch (arg) {
       case '--stack':
         args.stackName = argv[++i];
+        break;
+      case '--env-name':
+        args.envName = argv[++i];
         break;
       case '--cdk-out':
         args.cdkOut = argv[++i];
@@ -169,6 +172,8 @@ function printHelp(): void {
       'Options:',
       '  --stack <name>       Stack name to read from cdk.out (defaults',
       '                       to "${namePrefix}-easy-genomics-api-stack").',
+      '  --env-name <name>    Yaml env-name when multiple configurations exist',
+      '                       (alternative to ENV_NAME; not the same as --stack).',
       '  --cdk-out <dir>      Cloud assembly directory (default: cdk.out).',
       '  --output <path>      Where to write the mapping JSON (default:',
       '                       cdk.out/${stack}.import-mapping.json).',
@@ -179,7 +184,7 @@ function printHelp(): void {
   );
 }
 
-function resolveDeployEnv(): DeployEnv {
+function resolveDeployEnv(yamlEnvName?: string): DeployEnv {
   // Mirror `packages/back-end/src/main.ts` and `preflight-deletion-protection.ts`
   // so this script targets exactly the deployment that `cdk synth` just
   // produced. We intentionally re-implement (rather than import) the resolve
@@ -201,16 +206,16 @@ function resolveDeployEnv(): DeployEnv {
     );
   }
 
-  const stackEnvName = getStackEnvName() ?? process.env.ENV_NAME;
-  if (configurations.length > 1 && !stackEnvName) {
+  const selectedEnvName = yamlEnvName ?? process.env.ENV_NAME;
+  if (configurations.length > 1 && !selectedEnvName) {
     throw new Error(
       'build-import-mapping: multiple configurations found in easy-genomics.yaml. ' +
-        'Specify --stack {env-name} or set ENV_NAME.',
+        'Set ENV_NAME or pass --env-name {env-name}. (--stack is the CDK stack name in cdk.out.)',
     );
   }
 
   const configuration =
-    configurations.length > 1 ? findConfiguration(stackEnvName!, configurations) : configurations[0];
+    configurations.length > 1 ? findConfiguration(selectedEnvName!, configurations) : configurations[0];
   const envName = Object.keys(configuration)[0];
   const settings = Object.values(configuration)[0];
   const envType = settings['env-type'];
@@ -265,7 +270,7 @@ function buildMapping(template: CfnTemplate, namePrefix: string): { mapping: Imp
 
 function main(): void {
   const args = parseArgs(process.argv);
-  const env = resolveDeployEnv();
+  const env = resolveDeployEnv(args.envName);
 
   const stackName = args.stackName ?? `${env.namePrefix}-easy-genomics-api-stack`;
   const cdkOut = resolve(args.cdkOut ?? join(__dirname, '..', 'cdk.out'));

--- a/packages/back-end/scripts/build-import-mapping.ts
+++ b/packages/back-end/scripts/build-import-mapping.ts
@@ -89,7 +89,7 @@
 import { readFileSync, writeFileSync } from 'fs';
 import { join, resolve } from 'path';
 import { ConfigurationSettings } from '@easy-genomics/shared-lib/src/app/types/configuration';
-import { findConfiguration, loadConfigurations } from '@easy-genomics/shared-lib/src/app/utils/configuration';
+import { loadConfigurations, resolveConfiguration } from '@easy-genomics/shared-lib/src/app/utils/configuration';
 
 const EXPECTED_TABLE_SUFFIXES = [
   'organization-table',
@@ -200,22 +200,11 @@ function resolveDeployEnv(yamlEnvName?: string): DeployEnv {
 
   const configPath = join(__dirname, '../../../config/easy-genomics.yaml');
   const configurations: { [p: string]: ConfigurationSettings }[] = loadConfigurations(configPath);
-  if (configurations.length === 0) {
-    throw new Error(
-      'build-import-mapping: Easy Genomics Configuration missing / invalid, please update: easy-genomics.yaml',
-    );
-  }
 
+  // For this script the yaml env-name comes from --env-name / ENV_NAME (not --stack, which is
+  // the CDK stack name in cdk.out). resolveConfiguration centralises the 0 / 1 / many handling.
   const selectedEnvName = yamlEnvName ?? process.env.ENV_NAME;
-  if (configurations.length > 1 && !selectedEnvName) {
-    throw new Error(
-      'build-import-mapping: multiple configurations found in easy-genomics.yaml. ' +
-        'Set ENV_NAME or pass --env-name {env-name}. (--stack is the CDK stack name in cdk.out.)',
-    );
-  }
-
-  const configuration =
-    configurations.length > 1 ? findConfiguration(selectedEnvName!, configurations) : configurations[0];
+  const configuration = resolveConfiguration(configurations, selectedEnvName);
   const envName = Object.keys(configuration)[0];
   const settings = Object.values(configuration)[0];
   const envType = settings['env-type'];

--- a/packages/back-end/scripts/build-import-mapping.ts
+++ b/packages/back-end/scripts/build-import-mapping.ts
@@ -86,7 +86,11 @@
 import { readFileSync, writeFileSync } from 'fs';
 import { join, resolve } from 'path';
 import { ConfigurationSettings } from '@easy-genomics/shared-lib/src/app/types/configuration';
-import { loadConfigurations } from '@easy-genomics/shared-lib/src/app/utils/configuration';
+import {
+  findConfiguration,
+  getStackEnvName,
+  loadConfigurations,
+} from '@easy-genomics/shared-lib/src/app/utils/configuration';
 
 const EXPECTED_TABLE_SUFFIXES = [
   'organization-table',
@@ -191,12 +195,22 @@ function resolveDeployEnv(): DeployEnv {
 
   const configPath = join(__dirname, '../../../config/easy-genomics.yaml');
   const configurations: { [p: string]: ConfigurationSettings }[] = loadConfigurations(configPath);
-  if (configurations.length !== 1) {
+  if (configurations.length === 0) {
     throw new Error(
-      `build-import-mapping: expected exactly one configuration collection in easy-genomics.yaml, found ${configurations.length}.`,
+      'build-import-mapping: Easy Genomics Configuration missing / invalid, please update: easy-genomics.yaml',
     );
   }
-  const [configuration] = configurations;
+
+  const stackEnvName = getStackEnvName() ?? process.env.ENV_NAME;
+  if (configurations.length > 1 && !stackEnvName) {
+    throw new Error(
+      'build-import-mapping: multiple configurations found in easy-genomics.yaml. ' +
+        'Specify --stack {env-name} or set ENV_NAME.',
+    );
+  }
+
+  const configuration =
+    configurations.length > 1 ? findConfiguration(stackEnvName!, configurations) : configurations[0];
   const envName = Object.keys(configuration)[0];
   const settings = Object.values(configuration)[0];
   const envType = settings['env-type'];

--- a/packages/back-end/scripts/preflight-deletion-protection.ts
+++ b/packages/back-end/scripts/preflight-deletion-protection.ts
@@ -98,9 +98,9 @@ import {
 } from '@aws-sdk/client-dynamodb';
 import { ConfigurationSettings } from '@easy-genomics/shared-lib/src/app/types/configuration';
 import {
-  findConfiguration,
   getStackEnvName,
   loadConfigurations,
+  resolveConfiguration,
 } from '@easy-genomics/shared-lib/src/app/utils/configuration';
 
 const EG_TABLE_SUFFIXES = [
@@ -175,20 +175,7 @@ function resolveDeployEnv(): DeployEnv {
 
   const configPath = join(__dirname, '../../../config/easy-genomics.yaml');
   const configurations: { [p: string]: ConfigurationSettings }[] = loadConfigurations(configPath);
-  if (configurations.length === 0) {
-    throw new Error('Preflight: Easy Genomics Configuration missing / invalid, please update: easy-genomics.yaml');
-  }
-
-  const stackEnvName = getStackEnvName() ?? process.env.ENV_NAME;
-  if (configurations.length > 1 && !stackEnvName) {
-    throw new Error(
-      'Preflight: multiple configurations found in easy-genomics.yaml. ' +
-        'Specify --stack {env-name} or set ENV_NAME before running deploy.',
-    );
-  }
-
-  const configuration =
-    configurations.length > 1 ? findConfiguration(stackEnvName!, configurations) : configurations[0];
+  const configuration = resolveConfiguration(configurations, getStackEnvName() ?? process.env.ENV_NAME);
   const envName = Object.keys(configuration)[0];
   const settings = Object.values(configuration)[0];
   const envType = settings['env-type'];

--- a/packages/back-end/scripts/preflight-deletion-protection.ts
+++ b/packages/back-end/scripts/preflight-deletion-protection.ts
@@ -97,7 +97,11 @@ import {
   UpdateTableCommand,
 } from '@aws-sdk/client-dynamodb';
 import { ConfigurationSettings } from '@easy-genomics/shared-lib/src/app/types/configuration';
-import { loadConfigurations } from '@easy-genomics/shared-lib/src/app/utils/configuration';
+import {
+  findConfiguration,
+  getStackEnvName,
+  loadConfigurations,
+} from '@easy-genomics/shared-lib/src/app/utils/configuration';
 
 const EG_TABLE_SUFFIXES = [
   'organization-table',
@@ -171,13 +175,20 @@ function resolveDeployEnv(): DeployEnv {
 
   const configPath = join(__dirname, '../../../config/easy-genomics.yaml');
   const configurations: { [p: string]: ConfigurationSettings }[] = loadConfigurations(configPath);
-  if (configurations.length !== 1) {
+  if (configurations.length === 0) {
+    throw new Error('Preflight: Easy Genomics Configuration missing / invalid, please update: easy-genomics.yaml');
+  }
+
+  const stackEnvName = getStackEnvName() ?? process.env.ENV_NAME;
+  if (configurations.length > 1 && !stackEnvName) {
     throw new Error(
-      `Preflight: expected exactly one configuration collection in easy-genomics.yaml, found ${configurations.length}. ` +
-        'Fix the configuration before running `build-and-deploy`.',
+      'Preflight: multiple configurations found in easy-genomics.yaml. ' +
+        'Specify --stack {env-name} or set ENV_NAME before running deploy.',
     );
   }
-  const [configuration] = configurations;
+
+  const configuration =
+    configurations.length > 1 ? findConfiguration(stackEnvName!, configurations) : configurations[0];
   const envName = Object.keys(configuration)[0];
   const settings = Object.values(configuration)[0];
   const envType = settings['env-type'];

--- a/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
@@ -1882,8 +1882,14 @@ export class EasyGenomicsNestedStack extends NestedStack {
         actions: laboratoryDataTaggingDynamoActions,
       }),
       new PolicyStatement({
-        resources: ['arn:aws:s3:::*/*'],
-        actions: ['s3:PutObject', 's3:HeadObject'],
+        resources: ['arn:aws:s3:::*'],
+        actions: [
+          's3:GetBucketLocation',
+          's3:ListBucket', // Required for HeadObject command
+          's3:GetObject', // Required for HeadObject command
+          's3:HeadObject',
+          's3:PutObject',
+        ],
         effect: Effect.ALLOW,
       }),
     ]);

--- a/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
@@ -1621,14 +1621,17 @@ export class EasyGenomicsNestedStack extends NestedStack {
         actions: ['dynamodb:Query'],
       }),
       new PolicyStatement({
+        // Bucket-level action: this handler calls s3:GetBucketLocation on the bucket itself.
         resources: ['arn:aws:s3:::*'],
-        actions: [
-          's3:GetBucketLocation',
-          's3:ListBucket', // Required for HeadObject command
-          's3:GetObject', // Required for HeadObject command
-          's3:HeadObject',
-          's3:PutObject',
-        ],
+        actions: ['s3:GetBucketLocation'],
+        effect: Effect.ALLOW,
+      }),
+      new PolicyStatement({
+        // Object-level actions must target the object ARN (bucket/key), not the bucket ARN.
+        // s3:GetObject authorises the HeadObject existence check (S3 has no s3:HeadObject action);
+        // s3:PutObject writes the generated sample sheet.
+        resources: ['arn:aws:s3:::*/*'],
+        actions: ['s3:GetObject', 's3:PutObject'],
         effect: Effect.ALLOW,
       }),
     ]);
@@ -1882,14 +1885,11 @@ export class EasyGenomicsNestedStack extends NestedStack {
         actions: laboratoryDataTaggingDynamoActions,
       }),
       new PolicyStatement({
-        resources: ['arn:aws:s3:::*'],
-        actions: [
-          's3:GetBucketLocation',
-          's3:ListBucket', // Required for HeadObject command
-          's3:GetObject', // Required for HeadObject command
-          's3:HeadObject',
-          's3:PutObject',
-        ],
+        // Object-level actions must target the object ARN (bucket/key), not the bucket ARN.
+        // s3:GetObject authorises the HeadObject existence check (S3 has no s3:HeadObject action);
+        // s3:PutObject writes the generated sample sheet.
+        resources: ['arn:aws:s3:::*/*'],
+        actions: ['s3:GetObject', 's3:PutObject'],
         effect: Effect.ALLOW,
       }),
     ]);

--- a/packages/back-end/src/main.ts
+++ b/packages/back-end/src/main.ts
@@ -2,9 +2,9 @@ import { randomUUID } from 'crypto';
 import { join } from 'path';
 import { ConfigurationSettings } from '@easy-genomics/shared-lib/src/app/types/configuration';
 import {
-  findConfiguration,
   getStackEnvName,
   loadConfigurations,
+  resolveConfiguration,
 } from '@easy-genomics/shared-lib/src/app/utils/configuration';
 import { TestUserDetails, VpcPeering } from '@easy-genomics/shared-lib/src/infra/types/main-stack';
 import { App, Aspects } from 'aws-cdk-lib';
@@ -154,24 +154,9 @@ if (process.env.CI_CD === 'true') {
   const configurations: { [p: string]: ConfigurationSettings }[] = loadConfigurations(
     join(__dirname, '../../../config/easy-genomics.yaml'),
   );
-  if (configurations.length === 0) {
-    throw new Error('Easy Genomics Configuration missing / invalid, please update: easy-genomics.yaml');
-  }
-
-  const stackEnvName = getStackEnvName() ?? process.env.ENV_NAME;
-  if (configurations.length > 1 && !stackEnvName) {
-    throw new Error(
-      'Multiple configurations found in easy-genomics.yaml, please specify argument: --stack {env-name} or set ENV_NAME',
-    );
-  }
-
-  const configuration =
-    configurations.length > 1 ? findConfiguration(stackEnvName!, configurations) : configurations[0];
-
-  if (configuration) {
-    envName = Object.keys(configuration).shift();
-    configSettings = Object.values(configuration).shift();
-  }
+  const configuration = resolveConfiguration(configurations, getStackEnvName() ?? process.env.ENV_NAME);
+  envName = Object.keys(configuration).shift();
+  configSettings = Object.values(configuration).shift();
 
   if (!envName || !configSettings) {
     throw new Error('Easy Genomics Configuration missing / invalid, please check the easy-genomics.yaml configuration');

--- a/packages/back-end/src/main.ts
+++ b/packages/back-end/src/main.ts
@@ -1,7 +1,11 @@
 import { randomUUID } from 'crypto';
 import { join } from 'path';
 import { ConfigurationSettings } from '@easy-genomics/shared-lib/src/app/types/configuration';
-import { loadConfigurations } from '@easy-genomics/shared-lib/src/app/utils/configuration';
+import {
+  findConfiguration,
+  getStackEnvName,
+  loadConfigurations,
+} from '@easy-genomics/shared-lib/src/app/utils/configuration';
 import { TestUserDetails, VpcPeering } from '@easy-genomics/shared-lib/src/infra/types/main-stack';
 import { App, Aspects } from 'aws-cdk-lib';
 import { AwsSolutionsChecks } from 'cdk-nag';
@@ -152,15 +156,21 @@ if (process.env.CI_CD === 'true') {
   );
   if (configurations.length === 0) {
     throw new Error('Easy Genomics Configuration missing / invalid, please update: easy-genomics.yaml');
-  } else if (configurations.length > 1) {
-    throw new Error('Too many Easy Genomics Configurations found, please update: easy-genomics.yaml');
-  } else {
-    const configuration: { [p: string]: ConfigurationSettings } | undefined = configurations.shift();
+  }
 
-    if (configuration) {
-      envName = Object.keys(configuration).shift();
-      configSettings = Object.values(configuration).shift();
-    }
+  const stackEnvName = getStackEnvName() ?? process.env.ENV_NAME;
+  if (configurations.length > 1 && !stackEnvName) {
+    throw new Error(
+      'Multiple configurations found in easy-genomics.yaml, please specify argument: --stack {env-name} or set ENV_NAME',
+    );
+  }
+
+  const configuration =
+    configurations.length > 1 ? findConfiguration(stackEnvName!, configurations) : configurations[0];
+
+  if (configuration) {
+    envName = Object.keys(configuration).shift();
+    configSettings = Object.values(configuration).shift();
   }
 
   if (!envName || !configSettings) {

--- a/packages/front-end/config/env-config.ts
+++ b/packages/front-end/config/env-config.ts
@@ -1,8 +1,8 @@
 import { join } from 'path';
 import {
-  findConfiguration,
   getStackEnvName,
   loadConfigurations,
+  resolveConfiguration,
 } from '@easy-genomics/shared-lib/src/app/utils/configuration';
 
 interface EnvConfig {
@@ -61,22 +61,8 @@ function getConfigurationSettings(): EnvConfig {
     // Load the configurations from local configuration file
     const configurations = loadConfigurations(join(__dirname, '../../../config/easy-genomics.yaml'));
 
-    if (configurations.length === 0) {
-      throw new Error('Easy Genomics Configuration(s) missing / invalid, please update: easy-genomics.yaml');
-    }
-
-    // Determine the stack environment name
-    const stackEnvName = getStackEnvName();
-
-    if (configurations.length > 1 && !stackEnvName) {
-      throw new Error(
-        'Multiple configurations found in easy-genomics.yaml, please specify argument: --stack {env-name}',
-      );
-    }
-
-    // Find or select the appropriate configuration
-    const configuration =
-      configurations.length > 1 ? findConfiguration(stackEnvName!, configurations) : configurations[0];
+    // Find or select the appropriate configuration for the current environment
+    const configuration = resolveConfiguration(configurations, getStackEnvName() ?? process.env.ENV_NAME);
 
     // Extract and validate the environment configuration
     const envConfig = Object.values(configuration)[0];

--- a/packages/front-end/nuxt-load-configuration-settings.ts
+++ b/packages/front-end/nuxt-load-configuration-settings.ts
@@ -9,9 +9,9 @@ import { ApiGatewayInfo } from '@easy-genomics/shared-lib/src/app/types/api-gate
 import { CognitoIdpInfo } from '@easy-genomics/shared-lib/src/app/types/cognito-idp-info';
 import { ConfigurationSettings } from '@easy-genomics/shared-lib/src/app/types/configuration';
 import {
-  findConfiguration,
   getStackEnvName,
   loadConfigurations,
+  resolveConfiguration,
 } from '@easy-genomics/shared-lib/lib/src/app/utils/configuration';
 import * as fs from 'fs';
 
@@ -119,19 +119,7 @@ void (async () => {
         // `__dirname` here is `packages/front-end`. The repo-level config lives at `config/easy-genomics.yaml`.
         join(__dirname, '../../config/easy-genomics.yaml'),
       );
-      if (configurations.length === 0) {
-        throw new Error('Easy Genomics Configuration missing / invalid, please update: easy-genomics.yaml');
-      }
-
-      const stackEnvName = getStackEnvName() ?? process.env.ENV_NAME;
-      if (configurations.length > 1 && !stackEnvName) {
-        throw new Error(
-          'Multiple configurations found in easy-genomics.yaml, please specify argument: --stack {env-name} or set ENV_NAME',
-        );
-      }
-
-      const configuration =
-        configurations.length > 1 ? findConfiguration(stackEnvName!, configurations) : configurations[0];
+      const configuration = resolveConfiguration(configurations, getStackEnvName() ?? process.env.ENV_NAME);
 
       const envName: string | undefined = Object.keys(configuration).shift();
       const configSettings: ConfigurationSettings | undefined = Object.values(configuration).shift();

--- a/packages/front-end/nuxt-load-configuration-settings.ts
+++ b/packages/front-end/nuxt-load-configuration-settings.ts
@@ -8,7 +8,11 @@ import {
 import { ApiGatewayInfo } from '@easy-genomics/shared-lib/src/app/types/api-gateway-info';
 import { CognitoIdpInfo } from '@easy-genomics/shared-lib/src/app/types/cognito-idp-info';
 import { ConfigurationSettings } from '@easy-genomics/shared-lib/src/app/types/configuration';
-import { loadConfigurations } from '@easy-genomics/shared-lib/lib/src/app/utils/configuration';
+import {
+  findConfiguration,
+  getStackEnvName,
+  loadConfigurations,
+} from '@easy-genomics/shared-lib/lib/src/app/utils/configuration';
 import * as fs from 'fs';
 
 /**
@@ -117,29 +121,33 @@ void (async () => {
       );
       if (configurations.length === 0) {
         throw new Error('Easy Genomics Configuration missing / invalid, please update: easy-genomics.yaml');
-      } else if (configurations.length > 1) {
-        throw new Error('Too many Easy Genomics Configurations found, please update: easy-genomics.yaml');
-      } else {
-        const configuration: { [p: string]: ConfigurationSettings } | undefined = configurations.shift();
-
-        if (configuration) {
-          const envName: string | undefined = Object.keys(configuration).shift();
-          const configSettings: ConfigurationSettings | undefined = Object.values(configuration).shift();
-
-          if (!envName || !configSettings) {
-            throw new Error(
-              'Easy Genomics Configuration missing / invalid, please check the easy-genomics.yaml configuration',
-            );
-          }
-
-          const envType: string = configSettings['env-type']; // dev | pre-prod | prod
-          const awsRegion: string = configSettings['aws-region'];
-          const apiGatewayUrl: string | undefined = process.env.AWS_API_GATEWAY_URL;
-          const easyGenomicsApiUrl: string | undefined = configSettings['aws-easy-genomics-api-url'] ?? undefined;
-
-          await exportNuxtConfigurationSettings(awsRegion, envName, envType, apiGatewayUrl, easyGenomicsApiUrl);
-        }
       }
+
+      const stackEnvName = getStackEnvName() ?? process.env.ENV_NAME;
+      if (configurations.length > 1 && !stackEnvName) {
+        throw new Error(
+          'Multiple configurations found in easy-genomics.yaml, please specify argument: --stack {env-name} or set ENV_NAME',
+        );
+      }
+
+      const configuration =
+        configurations.length > 1 ? findConfiguration(stackEnvName!, configurations) : configurations[0];
+
+      const envName: string | undefined = Object.keys(configuration).shift();
+      const configSettings: ConfigurationSettings | undefined = Object.values(configuration).shift();
+
+      if (!envName || !configSettings) {
+        throw new Error(
+          'Easy Genomics Configuration missing / invalid, please check the easy-genomics.yaml configuration',
+        );
+      }
+
+      const envType: string = configSettings['env-type']; // dev | pre-prod | prod
+      const awsRegion: string = configSettings['aws-region'];
+      const apiGatewayUrl: string | undefined = process.env.AWS_API_GATEWAY_URL;
+      const easyGenomicsApiUrl: string | undefined = configSettings['aws-easy-genomics-api-url'] ?? undefined;
+
+      await exportNuxtConfigurationSettings(awsRegion, envName, envType, apiGatewayUrl, easyGenomicsApiUrl);
     }
   } catch (error) {
     if (isCredentialsError(error)) {

--- a/packages/front-end/src/main.ts
+++ b/packages/front-end/src/main.ts
@@ -1,9 +1,9 @@
 import { join } from 'path';
 import { ConfigurationSettings } from '@easy-genomics/shared-lib/src/app/types/configuration';
 import {
-  findConfiguration,
   getStackEnvName,
   loadConfigurations,
+  resolveConfiguration,
 } from '@easy-genomics/shared-lib/src/app/utils/configuration';
 import { App, Aspects } from 'aws-cdk-lib';
 import { AwsSolutionsChecks } from 'cdk-nag';
@@ -55,28 +55,12 @@ if (process.env.CI_CD === 'true') {
 } else {
   console.log('Loading Front-End easy-genomics.yaml settings...');
 
-  let configSettings: ConfigurationSettings | undefined;
   const configurations: { [p: string]: ConfigurationSettings }[] = loadConfigurations(
     join(__dirname, '../../../config/easy-genomics.yaml'),
   );
-  if (configurations.length === 0) {
-    throw new Error('Easy Genomics Configuration missing / invalid, please update: easy-genomics.yaml');
-  }
-
-  const stackEnvName = getStackEnvName() ?? process.env.ENV_NAME;
-  if (configurations.length > 1 && !stackEnvName) {
-    throw new Error(
-      'Multiple configurations found in easy-genomics.yaml, please specify argument: --stack {env-name} or set ENV_NAME',
-    );
-  }
-
-  const configuration =
-    configurations.length > 1 ? findConfiguration(stackEnvName!, configurations) : configurations[0];
-
-  if (configuration) {
-    envName = Object.keys(configuration).shift();
-    configSettings = Object.values(configuration).shift();
-  }
+  const configuration = resolveConfiguration(configurations, getStackEnvName() ?? process.env.ENV_NAME);
+  envName = Object.keys(configuration).shift();
+  const configSettings: ConfigurationSettings | undefined = Object.values(configuration).shift();
 
   if (!envName || !configSettings) {
     throw new Error('Easy Genomics Configuration missing / invalid, please check the easy-genomics.yaml configuration');

--- a/packages/front-end/src/main.ts
+++ b/packages/front-end/src/main.ts
@@ -1,6 +1,10 @@
 import { join } from 'path';
 import { ConfigurationSettings } from '@easy-genomics/shared-lib/src/app/types/configuration';
-import { loadConfigurations } from '@easy-genomics/shared-lib/src/app/utils/configuration';
+import {
+  findConfiguration,
+  getStackEnvName,
+  loadConfigurations,
+} from '@easy-genomics/shared-lib/src/app/utils/configuration';
 import { App, Aspects } from 'aws-cdk-lib';
 import { AwsSolutionsChecks } from 'cdk-nag';
 import { FrontEndStack } from './infra/stacks/front-end-stack';
@@ -57,15 +61,21 @@ if (process.env.CI_CD === 'true') {
   );
   if (configurations.length === 0) {
     throw new Error('Easy Genomics Configuration missing / invalid, please update: easy-genomics.yaml');
-  } else if (configurations.length > 1) {
-    throw new Error('Too many Easy Genomics Configurations found, please update: easy-genomics.yaml');
-  } else {
-    const configuration: { [p: string]: ConfigurationSettings } | undefined = configurations.shift();
+  }
 
-    if (configuration) {
-      envName = Object.keys(configuration).shift();
-      configSettings = Object.values(configuration).shift();
-    }
+  const stackEnvName = getStackEnvName() ?? process.env.ENV_NAME;
+  if (configurations.length > 1 && !stackEnvName) {
+    throw new Error(
+      'Multiple configurations found in easy-genomics.yaml, please specify argument: --stack {env-name} or set ENV_NAME',
+    );
+  }
+
+  const configuration =
+    configurations.length > 1 ? findConfiguration(stackEnvName!, configurations) : configurations[0];
+
+  if (configuration) {
+    envName = Object.keys(configuration).shift();
+    configSettings = Object.values(configuration).shift();
   }
 
   if (!envName || !configSettings) {

--- a/packages/shared-lib/src/app/utils/configuration.test.ts
+++ b/packages/shared-lib/src/app/utils/configuration.test.ts
@@ -1,0 +1,93 @@
+import { findConfiguration, getStackEnvName, resolveConfiguration } from './configuration';
+import { ConfigurationSettings } from '../types/configuration';
+
+/**
+ * Builds a minimal configuration entry. findConfiguration / resolveConfiguration only
+ * inspect the env-name key, so the settings payload can be an empty stub.
+ */
+function configEntry(envName: string): { [p: string]: ConfigurationSettings } {
+  return { [envName]: {} as ConfigurationSettings };
+}
+
+describe('getStackEnvName', () => {
+  const originalArgv = process.argv;
+
+  afterEach(() => {
+    process.argv = originalArgv;
+  });
+
+  it('returns the value following --stack', () => {
+    process.argv = ['node', 'script.js', '--stack', 'myenv'];
+    expect(getStackEnvName()).toBe('myenv');
+  });
+
+  it('returns the first --stack value when --stack appears among other args', () => {
+    process.argv = ['node', 'script.js', '--other', 'x', '--stack', 'prod-env', '--more', 'y'];
+    expect(getStackEnvName()).toBe('prod-env');
+  });
+
+  it('returns undefined when --stack is absent', () => {
+    process.argv = ['node', 'script.js', '--cdk-out', 'cdk.out'];
+    expect(getStackEnvName()).toBeUndefined();
+  });
+
+  it('returns undefined when --stack is the final argument with no value', () => {
+    process.argv = ['node', 'script.js', '--stack'];
+    expect(getStackEnvName()).toBeUndefined();
+  });
+
+  it('returns undefined when there are no extra arguments', () => {
+    process.argv = ['node', 'script.js'];
+    expect(getStackEnvName()).toBeUndefined();
+  });
+});
+
+describe('findConfiguration', () => {
+  const configurations = [configEntry('dev'), configEntry('prod')];
+
+  it('returns the configuration whose key matches envName', () => {
+    expect(findConfiguration('prod', configurations)).toEqual(configEntry('prod'));
+  });
+
+  it('throws when envName does not match any configuration', () => {
+    expect(() => findConfiguration('staging', configurations)).toThrow(
+      'Easy Genomics Configuration Settings for "staging" stack not found',
+    );
+  });
+
+  it('throws when the configurations list is empty', () => {
+    expect(() => findConfiguration('dev', [])).toThrow(
+      'Easy Genomics Configuration Settings for "dev" stack not found',
+    );
+  });
+});
+
+describe('resolveConfiguration', () => {
+  it('throws when there are no configurations', () => {
+    expect(() => resolveConfiguration([])).toThrow('missing / invalid');
+  });
+
+  it('returns the single configuration without consulting envName', () => {
+    const configurations = [configEntry('only-env')];
+    expect(resolveConfiguration(configurations)).toEqual(configEntry('only-env'));
+    // envName is intentionally ignored for single-config files.
+    expect(resolveConfiguration(configurations, 'does-not-match')).toEqual(configEntry('only-env'));
+  });
+
+  it('returns the matching configuration when multiple exist and envName is supplied', () => {
+    const configurations = [configEntry('dev'), configEntry('prod')];
+    expect(resolveConfiguration(configurations, 'dev')).toEqual(configEntry('dev'));
+  });
+
+  it('throws when multiple configurations exist and envName is missing', () => {
+    const configurations = [configEntry('dev'), configEntry('prod')];
+    expect(() => resolveConfiguration(configurations)).toThrow('a target environment name is required');
+  });
+
+  it('throws when multiple configurations exist and envName does not match', () => {
+    const configurations = [configEntry('dev'), configEntry('prod')];
+    expect(() => resolveConfiguration(configurations, 'staging')).toThrow(
+      'Easy Genomics Configuration Settings for "staging" stack not found',
+    );
+  });
+});

--- a/packages/shared-lib/src/app/utils/configuration.ts
+++ b/packages/shared-lib/src/app/utils/configuration.ts
@@ -67,6 +67,42 @@ export function findConfiguration(
 }
 
 /**
+ * Shared function to resolve the single applicable configuration from the loaded
+ * configurations list. Centralises the selection logic previously duplicated across
+ * the deployment entry-point scripts:
+ *
+ *  - 0 configurations  -> throws (configuration file missing / invalid).
+ *  - 1 configuration   -> returns it directly (envName is ignored).
+ *  - >1 configurations -> requires envName and returns the matching entry
+ *                         (throws if envName is missing, or via findConfiguration
+ *                         if it does not match any configuration).
+ *
+ * @param configurations
+ * @param envName
+ */
+export function resolveConfiguration(
+  configurations: { [p: string]: ConfigurationSettings }[],
+  envName?: string,
+): { [p: string]: ConfigurationSettings } {
+  if (configurations.length === 0) {
+    throw new Error('Easy Genomics Configuration(s) missing / invalid, please update: easy-genomics.yaml');
+  }
+
+  if (configurations.length === 1) {
+    return configurations[0];
+  }
+
+  if (!envName) {
+    throw new Error(
+      'Multiple configurations found in easy-genomics.yaml; a target environment name is required but was not ' +
+        'provided. Set the ENV_NAME environment variable or pass the environment name argument for this command.',
+    );
+  }
+
+  return findConfiguration(envName, configurations);
+}
+
+/**
  * Private function reading specified YAML configuration file.
  * @param filePath
  */


### PR DESCRIPTION
## Title*
Fix S3 IAM for data-collection sample sheet and support multi-env configuration

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Two related fixes for local and multi-environment deployments:

**S3 permissions for `request-sequence-collection-sample-sheet`**

The IAM policy for `/easy-genomics/data-collections/request-sequence-collection-sample-sheet` previously granted only `s3:PutObject` and `s3:HeadObject` on object ARNs (`arn:aws:s3:::*/*`). That was insufficient for the Lambda’s S3 usage (checking object existence and writing sample sheets), which also requires bucket-level actions. The policy is updated to match the pattern already used by `create-file-upload-sample-sheet`: bucket resource `arn:aws:s3:::*` with `s3:GetBucketLocation`, `s3:ListBucket`, `s3:GetObject`, `s3:HeadObject`, and `s3:PutObject`.

**Multi-configuration `easy-genomics.yaml` support**

Several entry points previously failed when `easy-genomics.yaml` contained more than one environment block. They now use the shared `findConfiguration` / `getStackEnvName` helpers to select the correct environment via `--stack {env-name}` or `ENV_NAME`, consistent with the rest of the toolchain. Updated in:

- `packages/back-end/src/main.ts`
- `packages/front-end/src/main.ts`
- `packages/front-end/nuxt-load-configuration-settings.ts`
- `packages/back-end/scripts/build-import-mapping.ts`
- `packages/back-end/scripts/preflight-deletion-protection.ts`

When multiple configurations are present and neither `--stack` nor `ENV_NAME` is set, a clear error is thrown instructing the user to specify the target environment.

## Testing*
- [ ] Deploy back-end and confirm `request-sequence-collection-sample-sheet` succeeds (no `AccessDenied` on S3 HeadObject / ListBucket)
- [ ] With a single env in `easy-genomics.yaml`, verify back-end CDK synth, front-end CDK synth, Nuxt config load, `build-import-mapping`, and preflight deploy scripts all resolve config without `--stack`
- [ ] With multiple envs in `easy-genomics.yaml`, verify the same commands work when passed `--stack {env-name}` or `ENV_NAME={env-name}`
- [ ] Confirm missing/ambiguous config still fails with actionable error messages

## Impact
- **Behaviour:** Data-collection sample sheet generation should work against S3 buckets that require bucket-level permissions for existence checks.
- **Deploy workflow:** Repositories with multiple environment blocks in `easy-genomics.yaml` can deploy and build without reducing the file to a single env; callers must pass `--stack` or set `ENV_NAME` when more than one config exists.
- **IAM scope:** S3 policy for the sample-sheet Lambda is slightly broader (bucket-level read/list in addition to object put/head), aligned with an existing Lambda in the same stack.
- **No new dependencies** or API contract changes.

## Additional Information
Branch: `fix/s3-permissions-dc-samplesheet`  
Base: `development`  
Commit: `11f46419` — fix: s3 permissions, multiple config checks

## Checklist*
- [ ] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [ ] Code adheres to the coding and style guidelines of the project.
- [ ] Code has been commented in particularly hard-to-understand areas.