### PR TITLE
fix: release v1.4.1

### DIFF
--- a/docs/EASY_GENOMICS_PROD_MIGRATION.md
+++ b/docs/EASY_GENOMICS_PROD_MIGRATION.md
@@ -394,26 +394,45 @@ currently-deployed CloudFormation template for `OLD_STACK`_, without removing th
 metadata Phase 2 needs to detach the tables cleanly (via `DELETE_SKIPPED`) rather than relying on deletion protection's
 hard rejection.
 
-Because the split PR is already merged to `development`, the tip of that branch cannot be used directly for this step —
-`pnpm run build-and-deploy` from that tip will halt at the preflight's "migration pending" check, and even if the
+Because the split PR is already merged to the deployment branch, the tip of that branch cannot be used directly for this
+step — `pnpm run build-and-deploy` from that tip will halt at the preflight's "migration pending" check, and even if the
 preflight were bypassed, deletion protection from Phase 0 would reject the `DeleteTable` calls and force a noisy
 CloudFormation rollback. Instead, build a short-lived "retain bridge" working tree that keeps the old stack topology but
 picks up the new `dynamodb-construct.ts`.
 
 ### 1.1 Assemble the retain-bridge working tree
 
+Both pieces of the bridge — the pre-split stack topology **and** the new `dynamodb-construct.ts` — must come from the
+**same split PR**. Pin everything to that PR's merge commit. Do **not** pull `dynamodb-construct.ts` from the live
+`development`/`main` tip: that branch keeps moving, and the file's `DynamoDBTableDetails` type has drifted from the
+pre-split stacks since the migration was written. A mismatched overlay produces a hard `tsc` failure during
+`pnpm run build`, e.g.:
+
+```text
+src/infra/stacks/easy-genomics-nested-stack.ts:1664:7 - error TS2353: Object literal may only specify known
+properties, and 'timeToLiveAttribute' does not exist in type 'DynamoDBTableDetails'.
+```
+
+(The pre-split `easy-genomics-nested-stack.ts` sets `timeToLiveAttribute`, but an out-of-lineage `dynamodb-construct.ts`
+no longer declares that field on the type.) Pinning both sides to the split merge commit avoids this entirely.
+
 ```bash
-# Identify the last commit on the deployment branch BEFORE the split PR was merged.
-# Concretely: the first parent of the merge commit on `development`.
-#   git log --first-parent development   # find the merge commit
-#   git log --pretty=%P -n 1 <merge-sha> # first SHA printed is the pre-PR parent
-export PRE_PR_SHA=<sha>
+# Identify the split PR's MERGE COMMIT on the branch this environment deploys from
+# (the PR titled "refactor aws cdk stacks to avoid cf limit" — it both creates
+# `easy-genomics-api-stack.ts` and introduces the new `dynamodb-construct.ts`).
+# On `development` it is PR #718; on `main` it shipped as release v1.4.
+#   git log --oneline --merges <deploy-branch>   # locate that PR's merge commit
+export SPLIT_MERGE_SHA=<merge-sha>
+
+# The pre-PR state is the merge commit's FIRST parent.
+export PRE_PR_SHA="$(git rev-parse "${SPLIT_MERGE_SHA}^1")"
 
 # Create a throwaway branch pinned to that pre-PR state.
 git switch -c retain-bridge-${ENV_TYPE}-${ENV_NAME} "$PRE_PR_SHA"
 
-# Pull ONLY the new dynamodb-construct.ts file out of the merged PR.
-git checkout development -- packages/back-end/src/infra/constructs/dynamodb-construct.ts
+# Pull ONLY the new dynamodb-construct.ts out of the SAME split commit (NOT a branch tip),
+# so its `DynamoDBTableDetails` type stays compatible with the pre-split stacks.
+git checkout "$SPLIT_MERGE_SHA" -- packages/back-end/src/infra/constructs/dynamodb-construct.ts
 
 # Sanity-check: the ONLY staged/modified file should be dynamodb-construct.ts.
 git status

--- a/docs/EASY_GENOMICS_PROD_MIGRATION.md
+++ b/docs/EASY_GENOMICS_PROD_MIGRATION.md
@@ -25,8 +25,8 @@ A naive `cdk deploy --all` of the split-stack code against an un-migrated enviro
 currently-deployed template has `DeletionPolicy: Delete` on every easy-genomics table in envs that were created with
 `envType != prod`) and is **broken even where it is non-destructive** (tables with `DeletionPolicy: Retain` orphan
 cleanly, but the new stack then fails to create because the old physical names are still in use). Because we cannot
-reliably promote PRs through environments in a strict order — an unrelated PR to `development` can trigger an
-auto-deploy at any time — the migration model below relies on a pre-deploy guard
+reliably promote PRs through environments in a strict order — an unrelated PR to your deployment branch can trigger an
+auto-deploy at any time (if you wire CI/CD to it) — the migration model below relies on a pre-deploy guard
 ([`packages/back-end/scripts/preflight-deletion-protection.ts`](../packages/back-end/scripts/preflight-deletion-protection.ts))
 that runs **before every `cdk deploy`**. On the first deploy against a given environment the guard automatically arms
 deletion protection + PITR on every easy-genomics table and halts the deploy; on every subsequent deploy it halts the
@@ -169,6 +169,10 @@ a bucket that no longer exists.
   `iam:PassRole`.
 - Local clone of this repo on the commit that is about to be deployed.
 - `aws-cdk` ≥ 2.176.0 (matches `packages/back-end/package.json`).
+- A **deployment branch** — the branch your environments are deployed from. This runbook defaults to `main` (the branch
+  that carries tagged open-source releases), which is what most self-hosted/client deployments track. The upstream
+  project develops on `development` / `staging` instead; if that's you, set `DEPLOY_BRANCH` accordingly below and read
+  every `main` reference as your deployment branch.
 - A short maintenance window for the easy-genomics REST API. HealthOmics, NF-Tower and Cognito stay available
   throughout. Typical duration: 15–30 min in non-prod, 30–45 min in prod depending on data size.
 
@@ -179,6 +183,7 @@ you're migrating:
 export AWS_REGION=us-east-1
 export ENV_NAME=acme               # value of env-name in easy-genomics.yaml
 export ENV_TYPE=dev                # dev | demo | pre-prod | prod
+export DEPLOY_BRANCH=main          # branch your environments deploy from (upstream: development / staging)
 export NAME_PREFIX="${ENV_TYPE}-${ENV_NAME}"
 export OLD_STACK="${NAME_PREFIX}-main-back-end-stack"
 export NEW_STACK="${NAME_PREFIX}-easy-genomics-api-stack"
@@ -209,16 +214,18 @@ any `cdk deploy` of the split-stack code touches that environment.**
 
 This phase is performed **once per environment**. It is idempotent and zero-downtime; rerunning it is always safe. It
 must be completed for every environment the split PR will eventually deploy to (`dev`, `demo`, `pre-prod`, `prod`), but
-the timing — before or after the split PR lands on `development` — is flexible. See the two paths below.
+the timing — before or after the split PR lands on your deployment branch (`main` by default) — is flexible. See the two
+paths below.
 
 ### Why this phase is mandatory
 
-Once the split PR is merged to `development`, any push to that branch (including the split PR itself) triggers
-`cicd-release-quality.yml`, which runs the back-end deploy against the target environment. If deletion protection is not
-already on by the time CloudFormation starts, CFN will happily call `DeleteTable` on every easy-genomics table during
-the nested-stack removal. In an environment created with `envType: dev` / `demo` / `pre-prod`, the currently-deployed
-template has `DeletionPolicy: Delete` on those tables (that was the pre-split default), so the delete call **succeeds**
-and the data is gone.
+Once the split PR is merged to your deployment branch, any push to that branch (including the split PR itself) triggers
+whatever CI/CD you have wired to it (in the upstream project this is `cicd-release-quality.yml` on `development`), which
+runs the back-end deploy against the target environment. If deletion protection is not already on by the time
+CloudFormation starts, CFN will happily call `DeleteTable` on every easy-genomics table during the nested-stack removal.
+In an environment created with `envType: dev` / `demo` / `pre-prod`, the currently-deployed template has
+`DeletionPolicy: Delete` on those tables (that was the pre-split default), so the delete call **succeeds** and the data
+is gone.
 
 Arming deletion protection via the AWS API — out-of-band from CloudFormation — is what prevents this.
 
@@ -347,9 +354,9 @@ during the nested-stack removal. Phase 1 handles that, but only at migration tim
 
 ## What CI does after the split PR merges
 
-As soon as the PR is merged, the existing `cicd-release-quality.yml` pipeline fires on the target branch and runs
-`pnpm run cicd-build-deploy-back-end`. The per-environment behaviour depends on whether Phase 0 arming has already
-happened against that environment.
+As soon as the PR is merged, any deploy pipeline wired to your deployment branch fires (in the upstream project this is
+`cicd-release-quality.yml` on `development`) and runs `pnpm run cicd-build-deploy-back-end`. The per-environment
+behaviour depends on whether Phase 0 arming has already happened against that environment.
 
 ### First post-merge run against an un-armed environment
 
@@ -609,14 +616,14 @@ Most teams should rely on **1.5.2 + 3.5** instead of retention; document whichev
 
 ```bash
 cd <repo-root>
-git switch development
+git switch "$DEPLOY_BRANCH"
 git branch -D retain-bridge-${ENV_TYPE}-${ENV_NAME}   # throw away the bridge branch
 pnpm install --frozen-lockfile
 cd packages/back-end
 pnpm run build
 ```
 
-Phases 2–5 all run from `development` (the merged split code).
+Phases 2–5 all run from your deployment branch (`main` by default — the merged split code).
 
 ---
 
@@ -638,7 +645,7 @@ NF-Tower routes stay live because they're served from a different API Gateway in
 
 ```bash
 cd <repo-root>
-git switch development
+git switch "$DEPLOY_BRANCH"
 git pull --ff-only
 pnpm install --frozen-lockfile
 cd packages/back-end


### PR DESCRIPTION
## Title
Fix prod migration runbook: pin retain-bridge to split merge commit and generalize deploy branch

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring
- [x] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Updates `docs/EASY_GENOMICS_PROD_MIGRATION.md` to fix two gaps in the CDK stack-split migration runbook:

1. **Retain-bridge pinning** — Phase 1.1 previously checked out `dynamodb-construct.ts` from the live `development` tip while the working tree was pinned to the pre-split commit. That branch keeps moving, and `DynamoDBTableDetails` has drifted since the migration was written (e.g. `timeToLiveAttribute` on the pre-split nested stack vs. the current type), causing hard `tsc` failures during `pnpm run build`. The runbook now pins both the pre-split stack topology and `dynamodb-construct.ts` to the **same split PR merge commit** (`SPLIT_MERGE_SHA`), with `PRE_PR_SHA` derived as that commit's first parent.

2. **Deployment branch generalization** — The runbook hardcoded `development` as the deployment branch. Many self-hosted/client deployments track `main` (tagged open-source releases) instead. Introduces `DEPLOY_BRANCH` (default `main`) in prerequisites and shell snippets, and reframes CI/CD references as "whatever pipeline is wired to your deployment branch" while noting upstream uses `development` / `staging`.

## Testing
- Documentation-only change; no code or automated tests affected.
- Verified commit SHAs and branch references against the described split PR (#718 on `development`, v1.4 on `main`).

## Impact
- Operators following the runbook on `main`-based deployments get correct branch instructions and avoid a documented foot-gun that blocks the retain-bridge build.
- No runtime, API, or infrastructure behavior changes.

## Additional Information
Two commits on this branch:
- `docs: pin retain-bridge dynamodb-construct to split merge commit`
- `docs: fix refs to dev branch, add DEPLOY_BRANCH var to migration`

## Checklist
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.