### PR TITLE
feat: adjust Sample explorer scroll container

### DIFF
--- a/packages/front-end/src/app/components/EGDataCollectionsPage.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsPage.vue
@@ -315,43 +315,10 @@
       uiStore.setRequestComplete('dataCollectionsMutate');
     }
   }
-
-  const rootEl = ref<HTMLElement | null>(null);
-  const rootHeightPx = ref<number | null>(null);
-
-  /** Fill remaining viewport below the lab page header so explorer tabs can scroll internally. */
-  function syncRootHeight(): void {
-    if (!rootEl.value) return;
-    const { top } = rootEl.value.getBoundingClientRect();
-    const bottomMarginPx = 16;
-    const minHeightPx = 28 * 16;
-    rootHeightPx.value = Math.max(window.innerHeight - top - bottomMarginPx, minHeightPx);
-  }
-
-  onMounted(() => {
-    syncRootHeight();
-    window.addEventListener('resize', syncRootHeight);
-  });
-
-  onUnmounted(() => {
-    window.removeEventListener('resize', syncRootHeight);
-  });
-
-  watch(activeTab, () => {
-    nextTick(() => {
-      syncRootHeight();
-      requestAnimationFrame(syncRootHeight);
-    });
-  });
-  watch(view, () => nextTick(syncRootHeight));
 </script>
 
 <template>
-  <div
-    ref="rootEl"
-    class="data-collections-page flex min-h-0 flex-col overflow-hidden"
-    :style="rootHeightPx != null ? { height: `${rootHeightPx}px` } : undefined"
-  >
+  <div class="data-collections-page flex min-h-0 flex-1 flex-col overflow-hidden">
     <EGImportDataWizard
       v-if="view === 'import'"
       class="min-h-0 flex-1"

--- a/packages/front-end/src/app/components/EGDataCollectionsPage.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsPage.vue
@@ -315,12 +315,46 @@
       uiStore.setRequestComplete('dataCollectionsMutate');
     }
   }
+
+  const rootEl = ref<HTMLElement | null>(null);
+  const rootHeightPx = ref<number | null>(null);
+
+  /** Fill remaining viewport below the lab page header so explorer tabs can scroll internally. */
+  function syncRootHeight(): void {
+    if (!rootEl.value) return;
+    const { top } = rootEl.value.getBoundingClientRect();
+    const bottomMarginPx = 16;
+    const minHeightPx = 28 * 16;
+    rootHeightPx.value = Math.max(window.innerHeight - top - bottomMarginPx, minHeightPx);
+  }
+
+  onMounted(() => {
+    syncRootHeight();
+    window.addEventListener('resize', syncRootHeight);
+  });
+
+  onUnmounted(() => {
+    window.removeEventListener('resize', syncRootHeight);
+  });
+
+  watch(activeTab, () => {
+    nextTick(() => {
+      syncRootHeight();
+      requestAnimationFrame(syncRootHeight);
+    });
+  });
+  watch(view, () => nextTick(syncRootHeight));
 </script>
 
 <template>
-  <div class="flex h-full min-h-0 flex-1 flex-col">
+  <div
+    ref="rootEl"
+    class="data-collections-page flex min-h-0 flex-col overflow-hidden"
+    :style="rootHeightPx != null ? { height: `${rootHeightPx}px` } : undefined"
+  >
     <EGImportDataWizard
       v-if="view === 'import'"
+      class="min-h-0 flex-1"
       :lab-id="labId"
       :lab="lab"
       :tags="tags"
@@ -330,6 +364,7 @@
 
     <EGDataCollectionBuilder
       v-else-if="view === 'builder'"
+      class="min-h-0 flex-1"
       :lab-id="labId"
       :lab="lab"
       :samples="samples"
@@ -341,92 +376,95 @@
     />
 
     <template v-else>
-      <div
-        v-if="!isLabS3Configured"
-        class="mb-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
-      >
-        <p v-if="canEditLabDetails">
-          This lab does not have a
-          <strong>default S3 bucket</strong>
-          configured. Open
-          <strong>Settings</strong>
-          and set
-          <strong>Default S3 bucket directory</strong>
-          to enable data collections features.
-        </p>
-        <p v-else>
-          This lab does not have a default S3 bucket configured. Ask your
-          <strong>organization administrator</strong>
-          to set
-          <strong>Default S3 bucket directory</strong>
-          in lab settings to enable data collections features.
-        </p>
-        <UButton v-if="canEditLabDetails" class="mt-3" size="sm" variant="outline" @click="openLabSettings">
-          Open Settings
-        </UButton>
+      <div class="flex min-h-0 flex-1 flex-col">
+        <div
+          v-if="!isLabS3Configured"
+          class="mb-3 shrink-0 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
+        >
+          <p v-if="canEditLabDetails">
+            This lab does not have a
+            <strong>default S3 bucket</strong>
+            configured. Open
+            <strong>Settings</strong>
+            and set
+            <strong>Default S3 bucket directory</strong>
+            to enable data collections features.
+          </p>
+          <p v-else>
+            This lab does not have a default S3 bucket configured. Ask your
+            <strong>organization administrator</strong>
+            to set
+            <strong>Default S3 bucket directory</strong>
+            in lab settings to enable data collections features.
+          </p>
+          <UButton v-if="canEditLabDetails" class="mt-3" size="sm" variant="outline" @click="openLabSettings">
+            Open Settings
+          </UButton>
+        </div>
+
+        <EGDataCollectionsTabBar
+          v-model:active-tab="activeTab"
+          class="shrink-0"
+          :collection-count="sequenceCollections.length"
+          :sample-count="samples.length"
+          :file-count="unlinkedFiles.length"
+        />
+
+        <EGSequenceCollectionsListTab
+          v-if="activeTab === 'collections'"
+          :collections="sequenceCollections"
+          :loading="loading"
+          :search="collectionSearch"
+          @update:search="collectionSearch = $event"
+          @new-collection="openBuilder()"
+          @launch-workflow="launchWorkflow"
+          @edit-collection="openBuilderForEdit"
+          @delete-collection="openDeleteCollectionDialog"
+        />
+
+        <EGSamplesTab
+          v-else-if="activeTab === 'samples'"
+          :lab-id="labId"
+          :s3-configured="isLabS3Configured"
+          :samples="samples"
+          :tags="tags"
+          :sample-id-to-tag-ids="sampleIdToTagIds"
+          :sample-id-to-run-usages="sampleIdToRunUsages"
+          :loading="loading"
+          :selected-ids="selectedSampleIds"
+          :search="sampleSearch"
+          :tags-filter-untagged="tagsFilterUntagged"
+          :tags-filter-tag-ids="tagsFilterTagIds"
+          @update:selected-ids="selectedSampleIds = $event"
+          @update:search="sampleSearch = $event"
+          @update:tags-filter-untagged="tagsFilterUntagged = $event"
+          @update:tags-filter-tag-ids="tagsFilterTagIds = $event"
+          @import="openImport"
+          @build-collection="openBuilder(selectedSampleIds)"
+          @tags-updated="onSampleTagsUpdated"
+          @tag-created="onSampleTagCreated"
+          @tag-deleted="onSampleTagDeleted"
+        />
+
+        <EGUnlinkedFilesTab
+          v-else
+          :files="unlinkedFiles"
+          :loading="loading"
+          :selected-keys="selectedFileKeys"
+          :search="fileSearch"
+          :s3-configured="isLabS3Configured"
+          :can-edit-lab-details="canEditLabDetails"
+          :s3-bucket="unlinkedMeta.s3Bucket"
+          :resolved-prefix="unlinkedMeta.resolvedPrefix"
+          :last-scan-label="unlinkedMeta.lastScanLabel"
+          @update:selected-keys="selectedFileKeys = $event"
+          @update:search="fileSearch = $event"
+          @rescan="loadUnlinkedFiles"
+          @open-settings="openLabSettings"
+          @build-sample="showBuildSampleModal = true"
+          @group-with-regex="showRegexGroupModal = true"
+        />
       </div>
-
-      <EGDataCollectionsTabBar
-        v-model:active-tab="activeTab"
-        :collection-count="sequenceCollections.length"
-        :sample-count="samples.length"
-        :file-count="unlinkedFiles.length"
-      />
-
-      <EGSequenceCollectionsListTab
-        v-if="activeTab === 'collections'"
-        :collections="sequenceCollections"
-        :loading="loading"
-        :search="collectionSearch"
-        @update:search="collectionSearch = $event"
-        @new-collection="openBuilder()"
-        @launch-workflow="launchWorkflow"
-        @edit-collection="openBuilderForEdit"
-        @delete-collection="openDeleteCollectionDialog"
-      />
-
-      <EGSamplesTab
-        v-else-if="activeTab === 'samples'"
-        :lab-id="labId"
-        :s3-configured="isLabS3Configured"
-        :samples="samples"
-        :tags="tags"
-        :sample-id-to-tag-ids="sampleIdToTagIds"
-        :sample-id-to-run-usages="sampleIdToRunUsages"
-        :loading="loading"
-        :selected-ids="selectedSampleIds"
-        :search="sampleSearch"
-        :tags-filter-untagged="tagsFilterUntagged"
-        :tags-filter-tag-ids="tagsFilterTagIds"
-        @update:selected-ids="selectedSampleIds = $event"
-        @update:search="sampleSearch = $event"
-        @update:tags-filter-untagged="tagsFilterUntagged = $event"
-        @update:tags-filter-tag-ids="tagsFilterTagIds = $event"
-        @import="openImport"
-        @build-collection="openBuilder(selectedSampleIds)"
-        @tags-updated="onSampleTagsUpdated"
-        @tag-created="onSampleTagCreated"
-        @tag-deleted="onSampleTagDeleted"
-      />
-
-      <EGUnlinkedFilesTab
-        v-else
-        :files="unlinkedFiles"
-        :loading="loading"
-        :selected-keys="selectedFileKeys"
-        :search="fileSearch"
-        :s3-configured="isLabS3Configured"
-        :can-edit-lab-details="canEditLabDetails"
-        :s3-bucket="unlinkedMeta.s3Bucket"
-        :resolved-prefix="unlinkedMeta.resolvedPrefix"
-        :last-scan-label="unlinkedMeta.lastScanLabel"
-        @update:selected-keys="selectedFileKeys = $event"
-        @update:search="fileSearch = $event"
-        @rescan="loadUnlinkedFiles"
-        @open-settings="openLabSettings"
-        @build-sample="showBuildSampleModal = true"
-        @group-with-regex="showRegexGroupModal = true"
-      />
     </template>
 
     <EGBuildSampleModal

--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -785,46 +785,68 @@
     @update:model-value="handleTabChange"
   />
 
-  <EGPageHeader
+  <div
     v-if="activeTabKey !== 'dashboard'"
-    :title="labName"
-    :description="pageDescription"
-    :back-action="() => (superuser ? $router.push(`/orgs/${orgId || ''}`) : $router.push('/labs'))"
-    :show-back="true"
-    show-org-breadcrumb
-    show-lab-breadcrumb
+    :class="{ 'lab-data-collections-shell flex min-h-0 flex-col': activeTabKey === 'dataCollections' }"
   >
-    <EGButton
-      v-if="!superuser && activeTabKey === 'omicsWorkflows' && canCreateOmicsWorkflows"
-      label="Create Workflow"
-      variant="secondary"
-      @click="$router.push(`/labs/${labId}/create-workflow`)"
-    />
-    <EGButton
-      v-if="!superuser && activeTabKey === 'users'"
-      u-button-type="button"
-      label="Add Lab Users"
-      :disabled="!canAddUsers"
-      :aria-expanded="showAddUserModule"
-      :aria-controls="addUsersPanelId"
-      @click="showAddUserModule = !showAddUserModule"
-    />
-    <div
-      v-if="showAddUserModule && activeTabKey === 'users' && !!orgId"
-      :id="addUsersPanelId"
-      role="region"
-      aria-label="Add users to lab"
-      class="mt-2"
+    <EGPageHeader
+      :class="{ 'shrink-0': activeTabKey === 'dataCollections' }"
+      :title="labName"
+      :description="pageDescription"
+      :back-action="() => (superuser ? $router.push(`/orgs/${orgId || ''}`) : $router.push('/labs'))"
+      :show-back="true"
+      show-org-breadcrumb
+      show-lab-breadcrumb
     >
-      <EGAddLabUsersModule
-        @added-user-to-lab="handleUserAddedToLab()"
-        :org-id="orgId"
+      <EGButton
+        v-if="!superuser && activeTabKey === 'omicsWorkflows' && canCreateOmicsWorkflows"
+        label="Create Workflow"
+        variant="secondary"
+        @click="$router.push(`/labs/${labId}/create-workflow`)"
+      />
+      <EGButton
+        v-if="!superuser && activeTabKey === 'users'"
+        u-button-type="button"
+        label="Add Lab Users"
+        :disabled="!canAddUsers"
+        :aria-expanded="showAddUserModule"
+        :aria-controls="addUsersPanelId"
+        @click="showAddUserModule = !showAddUserModule"
+      />
+      <div
+        v-if="showAddUserModule && activeTabKey === 'users' && !!orgId"
+        :id="addUsersPanelId"
+        role="region"
+        aria-label="Add users to lab"
+        class="mt-2"
+      >
+        <EGAddLabUsersModule
+          @added-user-to-lab="handleUserAddedToLab()"
+          :org-id="orgId"
+          :lab-id="labId"
+          :lab-name="labName"
+          :lab-users="labUsers"
+        />
+      </div>
+    </EGPageHeader>
+
+    <!-- Data Collections -->
+    <div
+      v-if="activeTabKey === 'dataCollections'"
+      role="tabpanel"
+      id="panel-dataCollections"
+      aria-labelledby="tab-dataCollections"
+      tabindex="0"
+      class="mt-4 flex min-h-0 flex-1 flex-col"
+    >
+      <h2 class="sr-only">Sequence collections</h2>
+      <EGDataCollectionsPage
         :lab-id="labId"
-        :lab-name="labName"
-        :lab-users="labUsers"
+        @update:explorer-tab="dataCollectionsExplorerTab = $event"
+        @open-settings="openLabSettingsFromDataCollections"
       />
     </div>
-  </EGPageHeader>
+  </div>
 
   <!-- Dashboard tab: tabindex enables programmatic focus after tab click; outline suppressed intentionally (focus is moved from the tab, not via Tab). -->
   <div
@@ -836,23 +858,6 @@
     class="outline-none focus:outline-none"
   >
     <EGDashboard :lab-id="labId" />
-  </div>
-
-  <!-- Data Collections -->
-  <div
-    v-if="activeTabKey === 'dataCollections'"
-    role="tabpanel"
-    id="panel-dataCollections"
-    aria-labelledby="tab-dataCollections"
-    tabindex="0"
-    class="mt-4"
-  >
-    <h2 class="sr-only">Sequence collections</h2>
-    <EGDataCollectionsPage
-      :lab-id="labId"
-      @update:explorer-tab="dataCollectionsExplorerTab = $event"
-      @open-settings="openLabSettingsFromDataCollections"
-    />
   </div>
 
   <!-- Runs tab -->
@@ -1125,3 +1130,11 @@
     v-model="isMissingPATModalOpen"
   />
 </template>
+
+<style scoped lang="scss">
+  .lab-data-collections-shell {
+    /* main mt-6 + bottom breathing room (matches prior syncRootHeight margin) */
+    height: calc(100vh - var(--header-height) - 1.5rem - 1rem);
+    min-height: 28rem;
+  }
+</style>

--- a/packages/front-end/src/app/components/EGSamplesTab.vue
+++ b/packages/front-end/src/app/components/EGSamplesTab.vue
@@ -531,7 +531,7 @@
 
       <div class="flex min-h-0 min-w-0 flex-1 flex-col">
         <div
-          class="border-border-muted flex flex-wrap items-center gap-3 border-b px-4 py-3"
+          class="border-border-muted flex shrink-0 flex-wrap items-center gap-3 border-b px-4 py-3"
           role="toolbar"
           aria-label="Sample explorer tools"
         >
@@ -580,7 +580,7 @@
           </div>
         </div>
 
-        <div class="border-border-muted flex flex-wrap items-center gap-2 border-b bg-gray-50 px-4 py-2">
+        <div class="border-border-muted flex shrink-0 flex-wrap items-center gap-2 border-b bg-gray-50 px-4 py-2">
           <span class="text-xs font-semibold leading-snug text-gray-900" aria-live="polite" aria-atomic="true">
             {{ filtered.length }} sample{{ filtered.length === 1 ? '' : 's' }}
           </span>
@@ -914,7 +914,7 @@
     <div
       v-if="bulkPanelOpen"
       ref="bulkPanelContentEl"
-      class="border-border-muted relative border-t bg-white px-4 pb-4 pt-3"
+      class="border-border-muted relative max-h-[min(40vh,24rem)] shrink-0 overflow-y-auto border-t bg-white px-4 pb-4 pt-3"
       role="region"
       aria-label="Bulk tag editor"
     >

--- a/packages/front-end/src/app/components/EGSidebarNav.vue
+++ b/packages/front-end/src/app/components/EGSidebarNav.vue
@@ -215,7 +215,7 @@
 <style scoped lang="scss">
   .sidebar-nav {
     position: absolute;
-    left: calc(-1 * var(--sidebar-width) - 2rem);
+    left: calc(-1 * var(--sidebar-width) - var(--sidebar-content-gap));
     top: -1.5rem;
     bottom: 0;
     width: var(--sidebar-width);
@@ -229,7 +229,7 @@
       padding 0.2s ease;
 
     &--collapsed {
-      left: calc(-1 * var(--sidebar-width-collapsed) - 2rem);
+      left: calc(-1 * var(--sidebar-width-collapsed) - var(--sidebar-content-gap));
       width: var(--sidebar-width-collapsed);
       padding: 1rem 0.5rem;
     }

--- a/packages/front-end/src/app/layouts/default.vue
+++ b/packages/front-end/src/app/layouts/default.vue
@@ -4,6 +4,8 @@
   const { setCurrentUserDataFromToken } = useUser();
   const hasInit = ref(false);
   const uiStore = useUiStore();
+  const route = useRoute();
+  const isFullWidthContent = computed(() => Boolean(route.meta.fullWidthContent));
 
   /**
    * @description Initialize the app for authed users; set the current user's organization with
@@ -27,6 +29,7 @@
     :class="{
       'has-sidebar': uiStore.hasSidebar,
       'has-sidebar--collapsed': uiStore.hasSidebar && uiStore.sidebarCollapsed,
+      'is-full-width-content': isFullWidthContent,
     }"
   >
     <slot v-if="hasInit" />
@@ -39,14 +42,26 @@
     margin-left: max(1rem, calc((100% - var(--max-page-container-width-px)) / 3));
     margin-right: auto;
 
+    &.is-full-width-content {
+      max-width: none;
+      width: calc(100% - 2 * var(--sidebar-content-gap));
+      margin-left: var(--sidebar-content-gap);
+      margin-right: var(--sidebar-content-gap);
+    }
+
     &.has-sidebar {
       position: relative;
-      margin-left: calc(var(--sidebar-width) + 2rem);
-      margin-right: 2rem;
-      transition: margin-left 0.2s ease;
+      max-width: none;
+      width: calc(100% - var(--sidebar-width) - 2 * var(--sidebar-content-gap));
+      margin-left: calc(var(--sidebar-width) + var(--sidebar-content-gap));
+      margin-right: var(--sidebar-content-gap);
+      transition:
+        margin-left 0.2s ease,
+        width 0.2s ease;
 
       &.has-sidebar--collapsed {
-        margin-left: calc(var(--sidebar-width-collapsed) + 2rem);
+        width: calc(100% - var(--sidebar-width-collapsed) - 2 * var(--sidebar-content-gap));
+        margin-left: calc(var(--sidebar-width-collapsed) + var(--sidebar-content-gap));
       }
     }
   }

--- a/packages/front-end/src/app/pages/labs/index.vue
+++ b/packages/front-end/src/app/pages/labs/index.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+  definePageMeta({ fullWidthContent: true });
+
   const $router = useRouter();
 
   const userStore = useUserStore();

--- a/packages/front-end/src/app/pages/orgs/index.vue
+++ b/packages/front-end/src/app/pages/orgs/index.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+  definePageMeta({ fullWidthContent: true });
+
   const $router = useRouter();
 
   if (!useUserStore().canManageAnyOrgs()) {

--- a/packages/front-end/src/app/styles/_variables.scss
+++ b/packages/front-end/src/app/styles/_variables.scss
@@ -2,5 +2,6 @@
   --max-page-container-width-px: 1332px;
   --sidebar-width: 300px;
   --sidebar-width-collapsed: 4rem;
+  --sidebar-content-gap: 1rem;
   --header-height: 78px;
 }


### PR DESCRIPTION
## Title
Re-implement scroll container for data collections samples explorer (EGV-203)

## Type of Change*
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
Restores proper internal scrolling for the data collections samples explorer so the sample list scrolls within the tab panel instead of growing the page and pushing content off-screen.

**Data collections page (`EGDataCollectionsPage.vue`)**
- Adds a viewport-aware root container that measures its position and sets an explicit height to fill the remaining space below the lab page header.
- Recalculates height on mount, window resize, tab switches, and view changes (explorer vs import/builder).
- Restructures the explorer layout as a flex column with `overflow-hidden` on the root and `shrink-0` on the S3 warning banner and tab bar so tab content receives a bounded height for internal scrolling.

**Samples tab (`EGSamplesTab.vue`)**
- Marks the toolbar and filter bar as `shrink-0` so they stay fixed while the sample list scrolls.
- Caps the bulk tag editor panel at `min(40vh, 24rem)` with `overflow-y-auto` so a large selection does not consume the full viewport.

**Layout / full-width content**
- Introduces `--sidebar-content-gap` (1rem) and uses it consistently in the default layout and sidebar positioning (replacing hardcoded `2rem` offsets).
- Adds a `fullWidthContent` route meta flag so pages with sidebars can use the full available width instead of the centered max-width container.
- Applies `fullWidthContent` to the labs and orgs index pages so main content fills the screen width alongside the sidebar.

Related: EGV-203

## Testing*
- [ ] Open a lab → Data Collections → Samples tab with enough samples to overflow the viewport; confirm the sample list scrolls inside the tab while the tab bar and toolbars stay fixed.
- [ ] Switch between Collections / Samples / Unlinked Files tabs and confirm height recalculates correctly (no clipped or double scrollbars).
- [ ] Open import and collection builder views and confirm they still fill the available space.
- [ ] Select multiple samples and open the bulk tag editor; confirm the panel scrolls internally when content exceeds the max height.
- [ ] Resize the browser window and confirm the explorer container resizes with the viewport.
- [ ] Visit Labs and Orgs index pages with the sidebar expanded and collapsed; confirm content uses full width with consistent gap spacing.
- [ ] Spot-check other sidebar pages to ensure layout is unchanged where `fullWidthContent` is not set.

No automated tests added (front-end layout change only).

## Impact
- **Behaviour:** Data collections explorer tabs now scroll internally; page-level scrolling for long sample lists should no longer occur on that view.
- **Layout:** Labs and orgs index pages render full-width when a sidebar is present; other pages keep the existing centered max-width layout.
- **Performance:** Minimal — one `resize` listener on the data collections page root, removed on unmount.
- **Dependencies:** None.

## Additional Information
Two commits on this branch:
1. `feat: re-implement scroll container on samples explorer`
2. `fix: main content fill screen width`

The full-width layout changes support the scroll container work by giving the data collections explorer (and similar lab pages) the horizontal space they need; the new `--sidebar-content-gap` variable keeps sidebar offset and content margin aligned.

## Checklist*
- [ ] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [ ] Code adheres to the coding and style guidelines of the project.
- [ ] Code has been commented in particularly hard-to-understand areas.