### PR TITLE
fix(ci): set working-directory for playwright install step to packages/front-end

### DIFF
--- a/.github/workflows/cicd-release-quality-uat.yml
+++ b/.github/workflows/cicd-release-quality-uat.yml
@@ -285,6 +285,7 @@ jobs:
           key: playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
       - name: Install Playwright Chromium
         run: npx playwright install chromium
+        working-directory: packages/front-end
       - name: Run E2E Tests
         run: pnpm run test-e2e
         continue-on-error: true

--- a/.github/workflows/cicd-release-quality.yml
+++ b/.github/workflows/cicd-release-quality.yml
@@ -285,6 +285,7 @@ jobs:
           key: playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
       - name: Install Playwright Chromium
         run: npx playwright install chromium
+        working-directory: packages/front-end
       - name: Run E2E Tests
         run: pnpm run test-e2e
         continue-on-error: true

--- a/projenrc/github-actions-cicd-release.ts
+++ b/projenrc/github-actions-cicd-release.ts
@@ -100,6 +100,7 @@ export class GithubActionsCICDRelease extends Component {
           },
           {
             name: 'Install Playwright Chromium',
+            workingDirectory: 'packages/front-end',
             run: 'npx playwright install chromium',
           },
           {


### PR DESCRIPTION
## Title
fix(ci): set working-directory for Playwright install step to packages/front-end

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [x] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
The `Install Playwright Chromium` CI step was failing with `playwright: not found` (exit code 127) because `npx playwright install chromium` was running from the workspace root, where the `playwright` binary is not available.

pnpm does not hoist workspace-package binaries to the root `node_modules/.bin`. Since `playwright` is declared as a dependency of `packages/front-end` only, its binary lives in `packages/front-end/node_modules/.bin`. The fix adds `working-directory: packages/front-end` to the install step, matching the existing `working-directory` already set on the `Run E2E Tests` step.

The change is made in `projenrc/github-actions-cicd-release.ts` (the projen construct that generates the workflows) and propagated to the generated `cicd-release-quality.yml` and `cicd-release-quality-uat.yml` files.

## Testing
- Pre-commit hook ran the full back-end test suite (491/491 pass).
- Verified the generated YAML now includes `working-directory: packages/front-end` on both the install and run E2E steps.

## Impact
Unblocks the `Install Playwright Chromium` step so the E2E job can proceed. No changes to application code, dependencies, or pipeline logic.

## Additional Information
`cicd-release-sandbox.yml` does not include an E2E job (`e2e: false`) so it is unaffected.

## Checklist
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [ ] Code has been commented in particularly hard-to-understand areas.
