### PR TITLE
feat: enable search on batches

### DIFF
--- a/packages/front-end/src/app/components/EGSampleTagSidebar.vue
+++ b/packages/front-end/src/app/components/EGSampleTagSidebar.vue
@@ -4,6 +4,7 @@
   import EGDialog from '@FE/components/EGDialog.vue';
   import { useToastStore, useUiStore } from '@FE/stores';
   import { ButtonVariantEnum } from '@FE/types/buttons';
+  import { filterSamplesBySearch } from '@FE/utils/data-collections-filters';
   import { exceedsTagNameMaxLength } from '@FE/utils/data-collections-name-validation';
 
   const props = defineProps<{
@@ -39,11 +40,7 @@
 
   const standardTags = computed(() => props.tags.filter((t) => (t.Kind ?? 'standard') === 'standard'));
 
-  const setsMatchingSearch = computed(() => {
-    const q = props.search.trim().toLowerCase();
-    if (!q) return props.samples;
-    return props.samples.filter((s) => s.Name.toLowerCase().includes(q));
-  });
+  const setsMatchingSearch = computed(() => filterSamplesBySearch(props.samples, props.tags, props.search));
 
   function standardTagIdsForSet(setId: string): string[] {
     const tagIdSet = new Set(standardTags.value.map((t) => t.TagId));

--- a/packages/front-end/src/app/components/EGSamplesTab.vue
+++ b/packages/front-end/src/app/components/EGSamplesTab.vue
@@ -8,6 +8,7 @@
   import EGSampleTagSidebar from '@FE/components/EGSampleTagSidebar.vue';
   import { useToastStore, useUiStore } from '@FE/stores';
   import { SAMPLE_LAYOUT_LABELS } from '@FE/utils/data-collections-selection';
+  import { filterSamplesBySearch } from '@FE/utils/data-collections-filters';
   import { exceedsTagNameMaxLength } from '@FE/utils/data-collections-name-validation';
 
   const props = withDefaults(
@@ -99,12 +100,7 @@
     return (props.sampleIdToTagIds[setId] ?? []).filter((tid) => tagIdSet.has(tid));
   }
 
-  const setsMatchingSearch = computed(() => {
-    let rows = props.samples;
-    const q = props.search.trim().toLowerCase();
-    if (q) rows = rows.filter((s) => s.Name.toLowerCase().includes(q));
-    return rows;
-  });
+  const setsMatchingSearch = computed(() => filterSamplesBySearch(props.samples, props.tags, props.search));
 
   const filtered = computed(() => {
     let list = setsMatchingSearch.value;
@@ -535,11 +531,11 @@
           role="toolbar"
           aria-label="Sample explorer tools"
         >
-          <label class="sr-only" for="sequence-set-search">Search samples</label>
+          <label class="sr-only" for="sequence-set-search">Search samples and batches</label>
           <UInput
             id="sequence-set-search"
             :model-value="search"
-            placeholder="Search by sample ID or tag…"
+            placeholder="Search by sample ID or batch…"
             class="max-w-xs"
             size="sm"
             @update:model-value="emit('update:search', String($event ?? ''))"

--- a/packages/front-end/src/app/utils/data-collections-filters.ts
+++ b/packages/front-end/src/app/utils/data-collections-filters.ts
@@ -1,4 +1,8 @@
-import type { LaboratoryRunUsageSummary } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/data-collections';
+import type {
+  LaboratoryDataTag,
+  LaboratoryRunUsageSummary,
+} from '@easy-genomics/shared-lib/src/app/types/easy-genomics/data-collections';
+import type { LaboratorySample } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/samples';
 
 /**
  * Pure helpers backing the Data Collections page scope filters. Extracted from the Vue SFC so
@@ -44,4 +48,22 @@ export function isExpiringSoon(opts: {
   if (soonest === undefined) return false;
   const horizonSeconds = opts.thresholdDays * 86400;
   return soonest - opts.nowEpoch <= horizonSeconds;
+}
+
+/** Samples tab search: sample name substring match, or all samples in a batch whose name matches. */
+export function filterSamplesBySearch(
+  samples: LaboratorySample[],
+  tags: LaboratoryDataTag[],
+  query: string,
+): LaboratorySample[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return samples;
+
+  const matchingBatchIds = new Set(
+    tags.filter((t) => t.Kind === 'batch' && t.Name.toLowerCase().includes(q)).map((t) => t.TagId),
+  );
+
+  return samples.filter(
+    (s) => s.Name.toLowerCase().includes(q) || (s.BatchTagId != null && matchingBatchIds.has(s.BatchTagId)),
+  );
 }

--- a/packages/front-end/test/app/utils/data-collections-filters.test.ts
+++ b/packages/front-end/test/app/utils/data-collections-filters.test.ts
@@ -1,5 +1,13 @@
-import type { LaboratoryRunUsageSummary } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/data-collections';
-import { isExpiringSoon, soonestExpiresAtForUsages } from '../../../src/app/utils/data-collections-filters';
+import type {
+  LaboratoryDataTag,
+  LaboratoryRunUsageSummary,
+} from '@easy-genomics/shared-lib/src/app/types/easy-genomics/data-collections';
+import type { LaboratorySample } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/samples';
+import {
+  filterSamplesBySearch,
+  isExpiringSoon,
+  soonestExpiresAtForUsages,
+} from '../../../src/app/utils/data-collections-filters';
 
 const NOW = 1_777_000_000;
 const DAY = 86_400;
@@ -103,5 +111,81 @@ describe('isExpiringSoon', () => {
         nowEpoch: NOW,
       }),
     ).toBe(true);
+  });
+});
+
+function sample(id: string, name: string, batchTagId?: string): LaboratorySample {
+  return {
+    SampleId: id,
+    Name: name,
+    Layout: 'paired_end',
+    FileCount: 1,
+    BatchTagId: batchTagId,
+  };
+}
+
+function tag(id: string, name: string, kind: LaboratoryDataTag['Kind'] = 'standard'): LaboratoryDataTag {
+  return {
+    TagId: id,
+    Name: name,
+    ColorHex: '#000000',
+    Kind: kind,
+    FileCount: 0,
+  };
+}
+
+describe('filterSamplesBySearch', () => {
+  const batchA = tag('batch-a', 'January Run', 'batch');
+  const batchB = tag('batch-b', 'February Run', 'batch');
+  const standardTag = tag('tag-1', 'January Run', 'standard');
+  const samples = [
+    sample('s1', 'Sample-Alpha', 'batch-a'),
+    sample('s2', 'Sample-Beta', 'batch-a'),
+    sample('s3', 'Sample-Gamma', 'batch-b'),
+    sample('s4', 'Unbatched-One'),
+  ];
+  const tags = [batchA, batchB, standardTag];
+
+  it('returns all samples when query is empty or whitespace', () => {
+    expect(filterSamplesBySearch(samples, tags, '')).toEqual(samples);
+    expect(filterSamplesBySearch(samples, tags, '   ')).toEqual(samples);
+  });
+
+  it('matches sample name substring case-insensitively', () => {
+    expect(filterSamplesBySearch(samples, tags, 'alpha')).toEqual([samples[0]]);
+    expect(filterSamplesBySearch(samples, tags, 'SAMPLE-BETA')).toEqual([samples[1]]);
+  });
+
+  it('returns all samples in a batch when batch name matches', () => {
+    expect(filterSamplesBySearch(samples, tags, 'january')).toEqual([samples[0], samples[1]]);
+  });
+
+  it('includes samples in a matching batch even when their names do not match', () => {
+    const result = filterSamplesBySearch(samples, tags, 'february');
+    expect(result).toEqual([samples[2]]);
+    expect(result.map((s) => s.Name)).toEqual(['Sample-Gamma']);
+  });
+
+  it('matches batch names case-insensitively', () => {
+    expect(filterSamplesBySearch(samples, tags, 'FEBRUARY RUN')).toEqual([samples[2]]);
+  });
+
+  it('only matches unbatched samples on their own name', () => {
+    expect(filterSamplesBySearch(samples, tags, 'unbatched')).toEqual([samples[3]]);
+    expect(filterSamplesBySearch(samples, tags, 'january')).not.toContainEqual(samples[3]);
+  });
+
+  it('does not treat standard tag names as batch matches', () => {
+    const onlyStandard = filterSamplesBySearch([sample('s5', 'Other')], [standardTag], 'january run');
+    expect(onlyStandard).toEqual([]);
+  });
+
+  it('returns union of sample-name and batch-name matches', () => {
+    const result = filterSamplesBySearch(samples, tags, 'gamma');
+    expect(result).toEqual([samples[2]]);
+  });
+
+  it('returns empty when nothing matches', () => {
+    expect(filterSamplesBySearch(samples, tags, 'no-match-here')).toEqual([]);
   });
 });


### PR DESCRIPTION
## Title*
Enable batch name search on Data Collections Samples tab

## Type of Change*
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
The Samples tab search on the Data Collections page previously filtered only on sample `Name`. Users could not find samples by batch, even though samples are grouped visually by batch in the UI.

This change extends search to also match batch tag names (`Kind === 'batch'`). When a query matches a batch name, all samples in that batch are shown. When it matches a sample name, only that sample is shown (existing behavior). Search remains case-insensitive and uses substring matching.

Implementation details:
- Added `filterSamplesBySearch()` to `packages/front-end/src/app/utils/data-collections-filters.ts` as a pure, unit-testable helper (same pattern as existing filters in that file).
- Wired the helper into `EGSamplesTab.vue` and `EGSampleTagSidebar.vue` so the main sample list and left-rail tag chip counts stay in sync.
- Updated search input copy: placeholder is now "Search by sample ID or batch…" and the screen-reader label mentions batches.

No backend or API changes — samples and tags are already loaded client-side on the page.

## Testing*
- Added 9 unit tests for `filterSamplesBySearch` in `packages/front-end/test/app/utils/data-collections-filters.test.ts`, covering:
  - Empty/whitespace query
  - Sample name substring match (case-insensitive)
  - Batch name match returning all samples in the batch
  - Case-insensitive batch matching
  - Unbatched samples matching only on their own name
  - Standard tags not treated as batch matches
  - No-match empty result
- Ran `pnpm exec jest test/app/utils/data-collections-filters.test.ts` — all 19 tests pass.

Manual verification recommended:
- Search a sample ID → only matching sample(s) appear
- Search a batch name → entire batch section appears with all member samples
- Confirm left-rail tag chip counts update when batch search narrows the set
- Clear search → full list restored

## Impact
- **Behavior:** Users can now discover samples by batch name from the existing search bar.
- **Performance:** Negligible — same client-side filter pattern as before, with a small additional pass over batch tags per keystroke.
- **Dependencies:** None added.
- **Scope:** Front-end only; no OpenAPI, CDK, or database changes.

## Additional Information
The previous placeholder said "Search by sample ID or tag…" but standard tag name search was never implemented. This PR updates the placeholder to reflect what is actually searchable (sample ID and batch).

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.