### PR TITLE
fix: resolve TDZ crashes, org-redirect reload loop, and run wizard stepper desync

### DIFF
--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -66,13 +66,6 @@
   const addUsersPanelId = 'lab-add-users-panel';
   const usersHeadingId = 'lab-users-heading';
 
-  usePageTitle(() => {
-    const base = labName.value ? labName.value : 'Lab';
-    const tab = tabItems.value[tabIndex.value];
-    if (!tab || tab.key === 'dashboard') return base;
-    return `${tab.label} — ${base}`;
-  });
-
   /** Prevents duplicate redirects when multiple watchers or lifecycle hooks fire. */
   const hasRedirectedForOrgMismatch = ref(false);
 
@@ -168,6 +161,13 @@
     items.push(detailsTab);
 
     return items;
+  });
+
+  usePageTitle(() => {
+    const base = labName.value ? labName.value : 'Lab';
+    const tab = tabItems.value[tabIndex.value];
+    if (!tab || tab.key === 'dashboard') return base;
+    return `${tab.label} — ${base}`;
   });
 
   const activeTabKey = computed(() => tabItems.value[tabIndex.value]?.key || '');
@@ -765,10 +765,6 @@
     }
 
     if (!props.superuser && uiStore.isRequestPending('loadLabData')) {
-      return;
-    }
-
-    if (await redirectIfLabOrgMismatch()) {
       return;
     }
 

--- a/packages/front-end/src/app/pages/labs/[labId]/run-pipeline/[pipelineId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/run-pipeline/[pipelineId].vue
@@ -40,8 +40,6 @@
 
   const labName = computed<string>(() => labsStore.labs[labId].Name);
 
-  usePageTitle(() => (pipeline.value?.name ? `Run pipeline — ${pipeline.value.name}` : 'Run pipeline'));
-
   const seqeraRunTempId = computed<string>(() => $route.query.seqeraRunTempId as string);
 
   const wipSeqeraRun = computed<WipRun | undefined>(() => runStore.wipSeqeraRuns[seqeraRunTempId.value]);
@@ -50,6 +48,8 @@
   const activeStepKey = computed(() => steps.value[selectedStepIndex.value]?.key);
 
   const pipeline = computed<SeqeraPipeline | null>(() => seqeraPipelinesStore.pipelines[pipelineId] || null);
+
+  usePageTitle(() => (pipeline.value?.name ? `Run pipeline — ${pipeline.value.name}` : 'Run pipeline'));
 
   const hasLaunched = ref<boolean>(false);
   const exitConfirmed = ref<boolean>(false);
@@ -208,13 +208,13 @@
 
     runStore.updateWipSeqeraRunParams(seqeraRunTempId.value, paramsToApply);
 
-    applySequenceCollectionsPrepopulation();
+    await applySequenceCollectionsPrepopulation();
 
     uiStore.setRequestComplete('loadSeqeraPipeline');
   }
 
   /** When opened from Data Collections with a pre-built sample sheet, skip to parameter configuration. */
-  function applySequenceCollectionsPrepopulation(): void {
+  async function applySequenceCollectionsPrepopulation(): Promise<void> {
     if ($route.query.from !== 'data-collections') return;
 
     const wip = runStore.wipSeqeraRuns[seqeraRunTempId.value];
@@ -222,6 +222,7 @@
 
     setStepEnabled('upload', true);
     setStepEnabled('parameters', true);
+    await nextTick();
     const parametersIndex = steps.value.findIndex((step) => step.key === 'parameters');
     if (parametersIndex >= 0) {
       selectedStepIndex.value = parametersIndex;
@@ -282,9 +283,13 @@
     }
   }
 
-  function nextStep(val: string) {
+  async function nextStep(val: string) {
     const completedStep = steps.value[selectedStepIndex.value]?.key || '';
     setStepEnabled(val, true);
+    // Wait for the enabled tab's `disabled` attribute to reach the DOM before moving the
+    // selected index — HeadlessUI's TabGroup resolves the target tab from the live DOM state,
+    // and moving the index in the same tick makes it fall back to the nearest still-enabled tab.
+    await nextTick();
     selectedStepIndex.value = clampIndex(selectedStepIndex.value + 1);
 
     // Analytics: run wizard step completed.

--- a/packages/front-end/src/app/pages/labs/[labId]/run-workflow/[workflowId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/run-workflow/[workflowId].vue
@@ -50,8 +50,6 @@
 
   const labName = computed<string>(() => labsStore.labs[labId].Name);
 
-  usePageTitle(() => (workflow.value?.name ? `Run workflow — ${workflow.value.name}` : 'Run workflow'));
-
   /** Must match EGRunFormRunDetails default sentinel for Omics workflow version */
   const OMICS_DEFAULT_WORKFLOW_VERSION = '__omics_default_version__';
 
@@ -68,6 +66,8 @@
   const activeStepKey = computed(() => steps.value[selectedStepIndex.value]?.key);
 
   const workflow = computed<ReadWorkflow | null>(() => omicsWorkflowsStore.workflows[workflowId] || null);
+
+  usePageTitle(() => (workflow.value?.name ? `Run workflow — ${workflow.value.name}` : 'Run workflow'));
 
   const schema = computed<Record<string, WorkflowParameter> | null>(() => workflow.value?.parameterTemplate ?? null);
 
@@ -212,13 +212,13 @@
     }
     runStore.updateWipOmicsRunParams(omicsRunTempId.value, paramsToApply);
 
-    applySequenceCollectionsPrepopulation();
+    await applySequenceCollectionsPrepopulation();
 
     uiStore.setRequestComplete('loadOmicsWorkflow');
   }
 
   /** When opened from Data Collections with a pre-built sample sheet, skip to parameter configuration. */
-  function applySequenceCollectionsPrepopulation(): void {
+  async function applySequenceCollectionsPrepopulation(): Promise<void> {
     if ($route.query.from !== 'data-collections') return;
 
     const wip = runStore.wipOmicsRuns[omicsRunTempId.value];
@@ -226,6 +226,7 @@
 
     setStepEnabled('upload', true);
     setStepEnabled('parameters', true);
+    await nextTick();
     const parametersIndex = steps.value.findIndex((step) => step.key === 'parameters');
     if (parametersIndex >= 0) {
       selectedStepIndex.value = parametersIndex;
@@ -278,9 +279,13 @@
     }
   }
 
-  function nextStep(val: string) {
+  async function nextStep(val: string) {
     const completedStep = steps.value[selectedStepIndex.value]?.key || '';
     setStepEnabled(val, true);
+    // Wait for the enabled tab's `disabled` attribute to reach the DOM before moving the
+    // selected index — HeadlessUI's TabGroup resolves the target tab from the live DOM state,
+    // and moving the index in the same tick makes it fall back to the nearest still-enabled tab.
+    await nextTick();
     selectedStepIndex.value = clampIndex(selectedStepIndex.value + 1);
 
     // Analytics: run wizard step completed.


### PR DESCRIPTION
## Title*
[EGV-221] Fix Lab view TDZ crashes, org-redirect reload loop, and run wizard stepper desync

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Three separate pre-existing bugs found while investigating reports of console errors and a reload loop on the Lab view, and stepper glitches on the Run Workflow / Run Pipeline pages:

1. **TDZ `ReferenceError` on Lab view and run-wizard pages** (`EGLabView.vue`, `run-workflow/[workflowId].vue`, `run-pipeline/[pipelineId].vue`) — `usePageTitle()` read a `computed` (`tabItems`, `workflow`, `pipeline`) before it was declared later in the same `<script setup>` block. Nuxt's `useHead` evaluates the title getter during component setup, before script execution reaches the later `const` declaration, hitting the JS temporal-dead-zone. Fixed by moving each `usePageTitle()` call after the computed it depends on. Audited all 13 `usePageTitle` call sites in the codebase — no other instances of this pattern exist.

2. **Infinite reload loop on the Lab view** (`EGLabView.vue`) — `watch(lab, ...)` called `redirectIfLabOrgMismatch()`, which unconditionally refetches the lab via `ensureLabInActiveOrg()` (added in PR #774 for org-switch handling) and overwrites the store entry with a new object reference on every call. That refetch changed the very `lab` ref the watcher observes, re-triggering the same watcher indefinitely. Confirmed via local-server request logs (`read-laboratory` fired 14× in 15s, dragging `list-laboratory-runs`, `list-pipelines`, `list-workflows` along each cycle). Fixed by removing the redundant call — org-mismatch validation is already covered by `onBeforeMount` (initial load) and the dedicated `watch(() => userStore.currentOrgId, ...)` (org switch).

3. **Run wizard stepper visual desync** (`run-workflow/[workflowId].vue`, `run-pipeline/[pipelineId].vue`) — the step tabs sometimes highlighted the wrong step (falling back to step 1) while the correct step's content rendered, requiring a manual back/forward click to resync. Root-caused in `@headlessui/vue`'s `TabGroup` source: it resolves the tab to highlight by reading the *live DOM* `disabled` attribute when its controlled `selectedIndex` prop changes. `nextStep()` enabled the next tab and advanced `selectedIndex` in the same tick, so HeadlessUI read the target tab as still disabled (DOM not yet patched) and fell back to the nearest enabled tab. Fixed by awaiting `nextTick()` between enabling the step and advancing the index, in both wizards (identical duplicated logic, same bug).

## Testing*
- No automated tests exist for these Vue components/pages, and none were added.
- Bugs 1 and 2 were reproduced from user-supplied browser console screenshots and a local-server request log (`ui-error.log`) before the fix.
- Bug 3 was root-caused by reading the `@headlessui/vue` v1.7.23 `TabGroup` source directly (not by running the app).
- **Not yet re-verified end-to-end in a running browser by either the user or me** (no browser access in this session). Last status from the user after the bug-2 fix was that the loop still appeared to occur; a hard refresh + fresh log capture was requested but not yet completed. **To verify:** hard-refresh a Lab page and confirm no console errors and the network tab settles; step through the HealthOmics and Seqera run wizards and confirm the highlighted tab always matches the rendered step content.

## Impact
- Front-end only (`packages/front-end`); no backend, schema, or infra changes.
- No new dependencies.
- Bug 2's fix reduces network request volume on the Lab view (removes an unbounded refetch loop); no other behavior changes beyond the three fixes described.

## Additional Information
Bug 2 (reload loop) has not received final confirmation from the user that it's fully resolved after a hard refresh — worth a close look in review/QA before merging.

## Checklist*
- [ ] No new errors or warnings have been introduced. *(not verified — no browser/build check run in this session)*
- [ ] All tests pass successfully and new tests added as necessary. *(N/A — no automated test coverage exists for these components; none added)*
- [ ] Documentation has been updated accordingly. *(N/A — no user-facing docs affected)*
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.