### PR TITLE
fix: gate org view and authorize list-organization-users-details

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/organization/user/list-organization-users-details.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/organization/user/list-organization-users-details.lambda.ts
@@ -1,13 +1,62 @@
 import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/lib/app/utils/common';
+import { InvalidRequestError, UnauthorizedAccessError } from '@easy-genomics/shared-lib/lib/app/utils/HttpError';
 import { OrganizationUser } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/organization-user';
 import { OrganizationUserDetails } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/organization-user-details';
-import { OrganizationAccess, User } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/user';
-import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
+import {
+  LaboratoryAccessDetails,
+  OrganizationAccess,
+  OrganizationAccessDetails,
+  User,
+} from '@easy-genomics/shared-lib/src/app/types/easy-genomics/user';
+import {
+  APIGatewayProxyEvent,
+  APIGatewayProxyResult,
+  APIGatewayProxyWithCognitoAuthorizerEvent,
+  Handler,
+} from 'aws-lambda';
 import { OrganizationUserService } from '@BE/services/easy-genomics/organization-user-service';
 import { UserService } from '@BE/services/easy-genomics/user-service';
+import { validateOrganizationAdminAccess, validateSystemAdminAccess } from '@BE/utils/auth-utils';
 
 const organizationUserService = new OrganizationUserService();
 const userService = new UserService();
+
+/**
+ * True if the caller is an active Lab Manager for any laboratory in the org.
+ * Lab managers need org user listings when adding users to a lab.
+ */
+function validateAnyLaboratoryManagerAccess(event: APIGatewayProxyEvent, organizationId: string): boolean {
+  try {
+    const orgAccessMetadata: string | undefined = event.requestContext.authorizer?.claims?.OrganizationAccess;
+    if (!orgAccessMetadata) {
+      return false;
+    }
+
+    const organizationAccess: OrganizationAccess = JSON.parse(orgAccessMetadata);
+    const organizationAccessDetails: OrganizationAccessDetails | undefined = organizationAccess[organizationId];
+    if (!organizationAccessDetails?.LaboratoryAccess) {
+      return false;
+    }
+
+    return Object.values(organizationAccessDetails.LaboratoryAccess).some(
+      (lab: LaboratoryAccessDetails) => lab.Status === 'Active' && lab.LabManager === true,
+    );
+  } catch (error) {
+    console.error(error);
+    return false;
+  }
+}
+
+function canListUsersByOrganizationId(
+  event: APIGatewayProxyWithCognitoAuthorizerEvent,
+  organizationId: string,
+): boolean {
+  return (
+    !!validateSystemAdminAccess(event) ||
+    !!validateOrganizationAdminAccess(event, organizationId) ||
+    validateAnyLaboratoryManagerAccess(event, organizationId)
+  );
+}
 
 export const handler: Handler = async (
   event: APIGatewayProxyWithCognitoAuthorizerEvent,
@@ -18,7 +67,7 @@ export const handler: Handler = async (
     const organizationId: string | undefined = event.queryStringParameters?.organizationId;
     const userId: string | undefined = event.queryStringParameters?.userId;
 
-    const organizationUsers: OrganizationUser[] = await listOrganizationUsers(organizationId, userId);
+    const organizationUsers: OrganizationUser[] = await listOrganizationUsers(event, organizationId, userId);
 
     if (organizationUsers.length === 0) {
       return buildResponse(200, JSON.stringify([]), event);
@@ -62,14 +111,37 @@ export const handler: Handler = async (
   }
 };
 
-const listOrganizationUsers = (organizationId?: string, userId?: string): Promise<OrganizationUser[]> => {
+const listOrganizationUsers = async (
+  event: APIGatewayProxyWithCognitoAuthorizerEvent,
+  organizationId?: string,
+  userId?: string,
+): Promise<OrganizationUser[]> => {
   if (organizationId && !userId) {
+    if (!canListUsersByOrganizationId(event, organizationId)) {
+      throw new UnauthorizedAccessError();
+    }
     return organizationUserService.queryByOrganizationId(organizationId);
-  } else if (!organizationId && userId) {
-    return organizationUserService.queryByUserId(userId);
-  } else {
-    throw new Error(
-      'Specify either organizationId or userId query parameter to retrieve the list of organization-users',
-    );
   }
+
+  if (!organizationId && userId) {
+    const currentUserId: string = event.requestContext.authorizer.claims['cognito:username'];
+    const isSystemAdmin = !!validateSystemAdminAccess(event);
+    const isSelf = currentUserId === userId;
+
+    if (isSystemAdmin || isSelf) {
+      return organizationUserService.queryByUserId(userId);
+    }
+
+    // Org admins may only see memberships for orgs they administer
+    const organizationUsers = await organizationUserService.queryByUserId(userId);
+    const authorized = organizationUsers.filter(
+      (orgUser) => !!validateOrganizationAdminAccess(event, orgUser.OrganizationId),
+    );
+    if (authorized.length === 0) {
+      throw new UnauthorizedAccessError();
+    }
+    return authorized;
+  }
+
+  throw new InvalidRequestError();
 };

--- a/packages/front-end/src/app/pages/orgs/[orgId]/index.vue
+++ b/packages/front-end/src/app/pages/orgs/[orgId]/index.vue
@@ -5,14 +5,14 @@
   const userStore = useUserStore();
 
   const orgId = computed(() => $route.params.orgId as string);
+  const canManageOrg = computed(() => userStore.canManageOrg(orgId.value));
 
-  onMounted(() => {
-    if (!userStore.canManageOrg(orgId.value)) {
-      $router.push({ path: '/' });
-    }
-  });
+  // Sync + v-if: prevents EGOrgView from mounting (and fetching members) before redirect
+  if (!canManageOrg.value) {
+    $router.push({ path: '/' });
+  }
 </script>
 
 <template>
-  <EGOrgView :org-id="orgId" :org-admin="userStore.isOrgAdminForOrg(orgId)" />
+  <EGOrgView v-if="canManageOrg" :org-id="orgId" :org-admin="userStore.isOrgAdminForOrg(orgId)" />
 </template>


### PR DESCRIPTION
## fix: gate org view and authorize list-organization-users-details

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

- Gate <EGOrgView> with v-if so unauthorized users never mount the org page or fetch members before redirect.
- Enforce auth on list-organization-users-details (org admin / lab manager / system admin; userId queries filtered accordingly)

## Testing*
Tested manually on development.


## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.