### PR TITLE
fix: ignore auth/HO/nftower nested stacks in migration preflight

### DIFF
--- a/packages/back-end/scripts/lib/is-easy-genomics-domain-nested-stack.ts
+++ b/packages/back-end/scripts/lib/is-easy-genomics-domain-nested-stack.ts
@@ -1,0 +1,42 @@
+/**
+ * Identifies the easy-genomics *domain* nested stack that the stack-split
+ * migration detaches from `*-main-back-end-stack`.
+ *
+ * Auth / AWS HealthOmics / NF-Tower nested stacks correctly remain on that
+ * parent after migration. When `envName` is literally `easygenomics`, their
+ * CDK logical IDs look like `easygenomicsauthnestedstack…` and their physical
+ * ARNs embed `…-easygenomics-main-back-end-stack-…`, so a bare
+ * `/easy[-]?genomics/` match false-positives and permanently blocks deploy.
+ */
+
+const SIBLING_NESTED_STACK = /(?:auth|awshealthomics|healthomics|nftower)nested(?:stack)?/i;
+
+/** Domain nested stack: `easy-genomics-nested-stack` or `${env}-easy-genomics-nested-stack`. */
+const DOMAIN_NESTED_STACK = /easygenomics(?:easygenomics)?nested(?:stack)?/i;
+
+function normalizeStackIdentity(value: string): string {
+  return value.toLowerCase().replace(/-/g, '');
+}
+
+/**
+ * Returns true when either the logical id or physical id refers to the
+ * easy-genomics domain nested stack (not Auth / HealthOmics / NF-Tower).
+ */
+export function isEasyGenomicsDomainNestedStack(
+  logicalId: string | undefined,
+  physicalId: string | undefined,
+): boolean {
+  for (const candidate of [logicalId, physicalId]) {
+    if (!candidate) {
+      continue;
+    }
+    const normalized = normalizeStackIdentity(candidate);
+    if (SIBLING_NESTED_STACK.test(normalized)) {
+      continue;
+    }
+    if (DOMAIN_NESTED_STACK.test(normalized)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/packages/back-end/scripts/preflight-deletion-protection.ts
+++ b/packages/back-end/scripts/preflight-deletion-protection.ts
@@ -98,6 +98,7 @@ import {
 } from '@aws-sdk/client-dynamodb';
 import { ConfigurationSettings } from '@easy-genomics/shared-lib/src/app/types/configuration';
 import { loadConfigurations } from '@easy-genomics/shared-lib/src/app/utils/configuration';
+import { isEasyGenomicsDomainNestedStack } from './lib/is-easy-genomics-domain-nested-stack';
 
 const EG_TABLE_SUFFIXES = [
   'organization-table',
@@ -294,12 +295,13 @@ async function armTable(
 }
 
 async function checkMigrationState(client: CloudFormationClient, oldStackName: string): Promise<MigrationState> {
-  // Paginate through the old stack's resources looking for a child stack
-  // whose identity screams "easy-genomics". CDK's nested-stack construct
-  // names mangle to camelCase + a hash in the LogicalResourceId (e.g.
-  // `easygenomicsnestedstack9A1B2C3D`), and the PhysicalResourceId is the
-  // child stack's ARN (which contains the full nested-stack name). Both
-  // are reliable matches, so we accept a hit on either.
+  // Paginate through the old stack's resources looking for the easy-genomics
+  // *domain* nested stack. CDK mangles construct ids to camelCase + a hash in
+  // the LogicalResourceId (e.g. `easygenomicsnestedstack9A1B2C3D`), and the
+  // PhysicalResourceId is the child stack ARN. Matching is delegated to
+  // isEasyGenomicsDomainNestedStack so Auth / HealthOmics / NF-Tower siblings
+  // (which also contain "easygenomics" when envName is that string) are not
+  // treated as migration-pending.
   const collected: StackResourceSummary[] = [];
   let nextToken: string | undefined;
   try {
@@ -321,17 +323,15 @@ async function checkMigrationState(client: CloudFormationClient, oldStackName: s
     return { kind: 'unknown', reason: message };
   }
 
+  // Only the easy-genomics *domain* nested stack (DynamoDB / EG API) must be
+  // gone. Auth / HealthOmics / NF-Tower nested stacks stay on this parent —
+  // and when envName is `easygenomics` their ids also contain that string, so
+  // a bare /easy[-]?genomics/ match false-positives forever. See
+  // isEasyGenomicsDomainNestedStack for the precise matcher.
   const nestedStacks = collected.filter(
     (r) =>
       r.ResourceType === 'AWS::CloudFormation::Stack' &&
-      // Match the logical id (camelCased construct path) or the physical id
-      // (the resolved nested stack ARN/name). Both contain the literal
-      // "easygenomics" / "easy-genomics" when this is the easy-genomics
-      // nested stack. Case-insensitive to be safe against CDK naming
-      // changes.
-      [r.LogicalResourceId, r.PhysicalResourceId].some(
-        (candidate) => candidate !== undefined && /easy[-]?genomics/i.test(candidate),
-      ),
+      isEasyGenomicsDomainNestedStack(r.LogicalResourceId, r.PhysicalResourceId),
   );
 
   if (nestedStacks.length === 0) {

--- a/packages/back-end/test/scripts/is-easy-genomics-domain-nested-stack.test.ts
+++ b/packages/back-end/test/scripts/is-easy-genomics-domain-nested-stack.test.ts
@@ -1,0 +1,59 @@
+import { isEasyGenomicsDomainNestedStack } from '../../scripts/lib/is-easy-genomics-domain-nested-stack';
+
+describe('isEasyGenomicsDomainNestedStack', () => {
+  it('matches the pre-split easy-genomics domain nested stack logical id', () => {
+    expect(isEasyGenomicsDomainNestedStack('easygenomicsnestedstack9A1B2C3D', undefined)).toBe(true);
+  });
+
+  it('matches ${envName}-easy-genomics-nested-stack when envName is easygenomics', () => {
+    expect(
+      isEasyGenomicsDomainNestedStack(
+        'easygenomicseasygenomicsnestedstackNestedStackeasygenomicseasygenomicsnestedstackNestedStackResourceAABBCCDD',
+        undefined,
+      ),
+    ).toBe(true);
+  });
+
+  it('matches domain nested stack physical ARN under main-back-end-stack', () => {
+    expect(
+      isEasyGenomicsDomainNestedStack(
+        undefined,
+        'arn:aws:cloudformation:us-east-1:009845682551:stack/dev-easygenomics-main-back-end-stack-easygenomicsnestedstackNESTED-ABC/uuid',
+      ),
+    ).toBe(true);
+  });
+
+  it('does not match Auth / HealthOmics / NF-Tower siblings when envName is easygenomics', () => {
+    const siblings: Array<[string, string]> = [
+      [
+        'easygenomicsauthnestedstackNestedStackeasygenomicsauthnestedstackNestedStackResource1B02EB4D',
+        'arn:aws:cloudformation:us-east-1:009845682551:stack/dev-easygenomics-main-back-end-stack-easygenomicsauthnestedstackNestedStackeasygenomic-KLFW33P0TUIV/f8607c90-1001-11f0-889d-12ef40d1bc4f',
+      ],
+      [
+        'easygenomicsawshealthomicsnestedstackNestedStackeasygenomicsawshealthomicsnestedstackNestedStackResource4A8D8B5B',
+        'arn:aws:cloudformation:us-east-1:009845682551:stack/dev-easygenomics-main-back-end-stack-easygenomicsawshealthomicsnestedstackNestedStacke-DAB54WP53GFF/3104a140-1002-11f0-889d-12ef40d1bc4f',
+      ],
+      [
+        'easygenomicsnftowernestedstackNestedStackeasygenomicsnftowernestedstackNestedStackResource7CFF7334',
+        'arn:aws:cloudformation:us-east-1:009845682551:stack/dev-easygenomics-main-back-end-stack-easygenomicsnftowernestedstackNestedStackeasygeno-HVQKRXK9S3ER/319d3250-1002-11f0-89e1-0e356142119b',
+      ],
+    ];
+
+    for (const [logicalId, physicalId] of siblings) {
+      expect(isEasyGenomicsDomainNestedStack(logicalId, physicalId)).toBe(false);
+    }
+  });
+
+  it('does not match data-provisioning nested stack', () => {
+    expect(
+      isEasyGenomicsDomainNestedStack(
+        'dataprovisioningnestedstackNestedStackdataprovisioningnestedstackNestedStackResource12345678',
+        'arn:aws:cloudformation:us-east-1:009845682551:stack/dev-easygenomics-main-back-end-stack-dataprovisioningnested-XYZ/uuid',
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false when both ids are missing', () => {
+    expect(isEasyGenomicsDomainNestedStack(undefined, undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Title*
Fix migration preflight false positive when envName is `easygenomics`
## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement
## Description
After the stack-split migration, `*-main-back-end-stack` correctly keeps Auth, AWS HealthOmics, and NF-Tower nested stacks. The deploy preflight treated any nested stack whose logical/physical id matched `/easy[-]?genomics/` as "migration pending."
When `envName` is `easygenomics`, those sibling stacks are named like `easygenomicsauthnestedstack…`, so the check never cleared and `build-and-deploy` stayed blocked even after a successful cutover.
This change introduces `isEasyGenomicsDomainNestedStack`, which only flags the easy-genomics **domain** nested stack (DynamoDB / EG API) and ignores Auth / HealthOmics / NF-Tower siblings.
## Testing*
- Added unit tests in `packages/back-end/test/scripts/is-easy-genomics-domain-nested-stack.test.ts`
- Covered: domain nested stack match (logical + physical), `${envName}-easy-genomics-nested-stack` when envName is `easygenomics`, client sibling stacks (auth/HO/nftower) must not match, data-provisioning must not match
- Ran: `pnpm exec jest test/scripts/is-easy-genomics-domain-nested-stack.test.ts` — all passing
## Impact
- Restores normal `pnpm run build-and-deploy` for environments named `easygenomics` after migration is complete
- No change to migration runbook steps, AWS resources, or CDK stack topology
- Pre-migration environments still halt correctly when the domain nested stack is still on `*-main-back-end-stack`
## Additional Information
Client symptom: post-migration `list-stack-resources` showed only auth / awshealthomics / nftower under `dev-easygenomics-main-back-end-stack`, which is expected, but preflight still printed "PREFLIGHT: migration pending."
## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.