### PR TITLE
feat: retry healthomics workflow run

### DIFF
--- a/packages/back-end/src/app/controllers/aws-healthomics/run/create-run-execution.lambda.ts
+++ b/packages/back-end/src/app/controllers/aws-healthomics/run/create-run-execution.lambda.ts
@@ -13,6 +13,7 @@ import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handl
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
 import { LaboratoryWorkflowAccessService } from '@BE/services/easy-genomics/laboratory-workflow-access-service';
 import { createOmicsServiceForLab } from '@BE/services/omics-lab-factory';
+import { OmicsService } from '@BE/services/omics-service';
 import {
   validateLaboratoryManagerAccess,
   validateLaboratoryTechnicianAccess,
@@ -23,6 +24,81 @@ import { resolveSharedWorkflowOwnerId } from '@BE/utils/omics-shared-workflow-ut
 
 const laboratoryService = new LaboratoryService();
 const laboratoryWorkflowAccessService = new LaboratoryWorkflowAccessService();
+
+/**
+ * Derives the S3 bucket to host the laboratory's HealthOmics run cache. Prefers the Laboratory's
+ * configured `S3Bucket`, falling back to the bucket component of the run's output location.
+ */
+function resolveCacheBucket(laboratory: Laboratory, outdir?: string): string | undefined {
+  if (laboratory.S3Bucket) return laboratory.S3Bucket;
+  const match = outdir?.match(/^s3:\/\/([^/]+)\//);
+  return match ? match[1] : undefined;
+}
+
+/**
+ * Ensures the laboratory has an AWS HealthOmics run cache and returns its id.
+ *
+ * The cache is what makes retry/resume possible: when a run started with this cache fails, its
+ * completed task outputs are saved (cacheBehavior CACHE_ON_FAILURE). A later run started with the
+ * same cache resumes from the last completed task whenever the task fingerprint (inputs, params,
+ * script, container) is unchanged, and recomputes only what actually changed. This means:
+ *  - retrying with the same sample data (with or without parameter tweaks) reuses completed work;
+ *  - changing the sample data invalidates the affected tasks, so it effectively runs fresh;
+ *  - runs launched before caching existed have nothing cached, so they run fresh.
+ *
+ * One cache is provisioned per laboratory (lazily, on first run) and its id is persisted on the
+ * Laboratory so all subsequent runs share it. This is best-effort: any failure here is logged and
+ * results in `undefined`, so the run still launches normally (just without resume support).
+ */
+async function ensureLaboratoryRunCache(
+  laboratory: Laboratory,
+  omicsService: OmicsService,
+  outdir: string | undefined,
+  modifiedBy: string,
+): Promise<string | undefined> {
+  try {
+    if (laboratory.HealthOmicsRunCacheId) return laboratory.HealthOmicsRunCacheId;
+
+    const bucket = resolveCacheBucket(laboratory, outdir);
+    if (!bucket) {
+      console.warn(
+        `[create-run-execution] No S3 bucket resolvable for LaboratoryId=${laboratory.LaboratoryId}; skipping run cache provisioning.`,
+      );
+      return undefined;
+    }
+
+    const created = await omicsService.createRunCache({
+      cacheS3Location: `s3://${bucket}/run-cache/`,
+      cacheBehavior: 'CACHE_ON_FAILURE',
+      name: `${process.env.NAME_PREFIX}-${laboratory.LaboratoryId}-run-cache`,
+      description: `Easy Genomics run cache for Laboratory ${laboratory.LaboratoryId}`,
+      // Stable idempotency token keeps concurrent first-runs from creating duplicate caches.
+      requestId: `${laboratory.LaboratoryId}-run-cache`,
+      tags: {
+        LaboratoryId: laboratory.LaboratoryId,
+        OrganizationId: laboratory.OrganizationId,
+        Application: 'easy-genomics',
+      },
+    });
+
+    const cacheId: string | undefined = created.id;
+    if (!cacheId) return undefined;
+
+    // Persist on the Laboratory so every subsequent run reuses the same cache.
+    await laboratoryService.update(
+      { ...laboratory, HealthOmicsRunCacheId: cacheId, ModifiedAt: new Date().toISOString(), ModifiedBy: modifiedBy },
+      laboratory,
+    );
+
+    return cacheId;
+  } catch (error) {
+    console.error(
+      `[create-run-execution] Failed to provision run cache for LaboratoryId=${laboratory.LaboratoryId}:`,
+      error,
+    );
+    return undefined; // Best-effort: never block a run because caching could not be set up.
+  }
+}
 
 /**
  * This POST /aws-healthomics/run/create-run-execution?laboratoryId={LaboratoryId}
@@ -96,6 +172,15 @@ export const handler: Handler = async (
     );
 
     const parameters = JSON.parse(request.parameters!.toString());
+
+    // Ensure the lab has a run cache so failed runs can be resumed on retry (best-effort).
+    const cacheId: string | undefined = await ensureLaboratoryRunCache(
+      laboratory,
+      omicsService,
+      parameters.outdir,
+      omicsUserId,
+    );
+
     // Strip client-supplied workflowOwnerId — always resolve from ACTIVE shares.
     const { workflowVersionName, ...rest } = request;
     const startRunRequestWithoutVersion = { ...rest };
@@ -105,6 +190,9 @@ export const handler: Handler = async (
       ...startRunRequestWithoutVersion,
       ...(workflowVersionName ? { workflowVersionName } : {}),
       ...(workflowOwnerId ? { workflowOwnerId } : {}),
+      // Attaching the cache makes runs resume-capable: completed tasks from a prior failed run with
+      // the same fingerprint are reused, and only changed/failed tasks (and their dependents) re-run.
+      ...(cacheId ? { cacheId, cacheBehavior: 'CACHE_ON_FAILURE' } : {}),
       parameters: {
         ...parameters,
         outdir: '/mnt/workflow/pubdir', // AWS HealthOmics requires explicitly setting 'outdir' = '/mnt/workflow/pubdir' for internal output

--- a/packages/back-end/src/app/services/omics-service.ts
+++ b/packages/back-end/src/app/services/omics-service.ts
@@ -5,9 +5,15 @@ import {
   CancelRunCommand,
   CancelRunCommandInput,
   CancelRunCommandOutput,
+  CreateRunCacheCommand,
+  CreateRunCacheCommandInput,
+  CreateRunCacheCommandOutput,
   GetConfigurationCommand,
   GetConfigurationCommandInput,
   GetConfigurationCommandOutput,
+  GetRunCacheCommand,
+  GetRunCacheCommandInput,
+  GetRunCacheCommandOutput,
   GetRunCommand,
   GetRunCommandInput,
   GetRunCommandOutput,
@@ -40,7 +46,9 @@ import type { AwsCredentialIdentity } from '@aws-sdk/types';
 export enum OmicsCommand {
   CREATE_WORKFLOW = 'create-workflow',
   CANCEL_RUN = 'cancel-run',
+  CREATE_RUN_CACHE = 'create-run-cache',
   GET_CONFIGURATION = 'get-configuration',
+  GET_RUN_CACHE = 'get-run-cache',
   GET_RUN = 'get-run',
   GET_WORKFLOW = 'get-workflow',
   LIST_RUNS = 'list-runs',
@@ -79,12 +87,28 @@ export class OmicsService {
     );
   };
 
+  public createRunCache = async (
+    createRunCacheCommandInput: CreateRunCacheCommandInput,
+  ): Promise<CreateRunCacheCommandOutput> => {
+    return this.omicsRequest<CreateRunCacheCommandInput, CreateRunCacheCommandOutput>(
+      OmicsCommand.CREATE_RUN_CACHE,
+      createRunCacheCommandInput,
+    );
+  };
+
   public getConfiguration = async (
     getConfigurationCommandInput: GetConfigurationCommandInput,
   ): Promise<GetConfigurationCommandOutput> => {
     return this.omicsRequest<GetConfigurationCommandInput, GetConfigurationCommandOutput>(
       OmicsCommand.GET_CONFIGURATION,
       getConfigurationCommandInput,
+    );
+  };
+
+  public getRunCache = async (getRunCacheCommandInput: GetRunCacheCommandInput): Promise<GetRunCacheCommandOutput> => {
+    return this.omicsRequest<GetRunCacheCommandInput, GetRunCacheCommandOutput>(
+      OmicsCommand.GET_RUN_CACHE,
+      getRunCacheCommandInput,
     );
   };
 
@@ -163,8 +187,12 @@ export class OmicsService {
         return new CreateWorkflowCommand(data as CreateWorkflowCommandInput);
       case OmicsCommand.CANCEL_RUN:
         return new CancelRunCommand(data as CancelRunCommandInput);
+      case OmicsCommand.CREATE_RUN_CACHE:
+        return new CreateRunCacheCommand(data as CreateRunCacheCommandInput);
       case OmicsCommand.GET_CONFIGURATION:
         return new GetConfigurationCommand(data as GetConfigurationCommandInput);
+      case OmicsCommand.GET_RUN_CACHE:
+        return new GetRunCacheCommand(data as GetRunCacheCommandInput);
       case OmicsCommand.GET_RUN:
         return new GetRunCommand(data as GetRunCommandInput);
       case OmicsCommand.GET_WORKFLOW:

--- a/packages/back-end/src/infra/stacks/aws-healthomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/aws-healthomics-nested-stack.ts
@@ -361,6 +361,13 @@ export class AwsHealthOmicsNestedStack extends NestedStack {
         actions: ['s3:GetObject'],
         effect: Effect.ALLOW,
       }),
+      // Allow provisioning and reading run caches (call caching / resume support). Run caches are
+      // provisioned per-laboratory and reused across runs so failed runs can be resumed on retry.
+      new PolicyStatement({
+        resources: ['*'],
+        actions: ['omics:CreateRunCache', 'omics:GetRunCache', 'omics:ListRunCaches'],
+        effect: Effect.ALLOW,
+      }),
       // Allow passing the workflow run role to HealthOmics when starting a run
       new PolicyStatement({
         resources: [
@@ -763,7 +770,8 @@ export class AwsHealthOmicsNestedStack extends NestedStack {
           `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table`,
           `arn:aws:dynamodb:${this.props.env.region!}:${this.props.env.account!}:table/${this.props.namePrefix}-laboratory-table/index/*`,
         ],
-        actions: ['dynamodb:Query'],
+        // PutItem: persist the lazily-provisioned HealthOmics run cache id on the Laboratory.
+        actions: ['dynamodb:Query', 'dynamodb:PutItem'],
       }),
       new PolicyStatement({
         resources: [

--- a/packages/front-end/src/app/pages/labs/[labId]/run-workflow/[workflowId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/run-workflow/[workflowId].vue
@@ -55,6 +55,14 @@
 
   const omicsRunTempId = computed<string>(() => $route.query.omicsRunTempId as string);
 
+  /**
+   * When present, this run is being launched as a retry of a previously failed run.
+   * The wizard pre-fills its parameters, inputs, name and workflow version from that
+   * run so the user can re-launch "as is" or after editing any step.
+   */
+  const retryFromRunId = computed<string | undefined>(() => ($route.query.retryFromRunId as string) || undefined);
+  const retrySourceRunName = ref<string | null>(null);
+
   const workflowVersionOptions = ref<{ value: string; label: string }[] | undefined>(undefined);
 
   /** True when the user record still has OmicsWorkflowDefaultParams for this workflow (drives the save-defaults checkbox). */
@@ -201,23 +209,28 @@
     hasOmicsWorkflowSavedParameterDefaults.value =
       typeof rawSavedDefaults === 'object' && Object.keys(rawSavedDefaults).length > 0;
 
-    // initialize wip run in store
-    runStore.updateWipOmicsRun(omicsRunTempId.value, {
-      transactionId: omicsRunTempId.value,
-      paramsRequired: paramsRequired,
-    });
+    if (retryFromRunId.value) {
+      // Retry: seed the wip run from the failed run instead of the user's saved defaults.
+      await prefillFromFailedRun(paramsRequired);
+    } else {
+      // initialize wip run in store
+      runStore.updateWipOmicsRun(omicsRunTempId.value, {
+        transactionId: omicsRunTempId.value,
+        paramsRequired: paramsRequired,
+      });
 
-    const existingWip = runStore.wipOmicsRuns[omicsRunTempId.value];
-    const paramsToApply = { ...workflowDefaultParams };
-    if (existingWip?.params?.input) {
-      paramsToApply.input = existingWip.params.input;
-    }
-    if (existingWip?.params?.outdir) {
-      paramsToApply.outdir = existingWip.params.outdir;
-    }
-    runStore.updateWipOmicsRunParams(omicsRunTempId.value, paramsToApply);
+      const existingWip = runStore.wipOmicsRuns[omicsRunTempId.value];
+      const paramsToApply = { ...workflowDefaultParams };
+      if (existingWip?.params?.input) {
+        paramsToApply.input = existingWip.params.input;
+      }
+      if (existingWip?.params?.outdir) {
+        paramsToApply.outdir = existingWip.params.outdir;
+      }
+      runStore.updateWipOmicsRunParams(omicsRunTempId.value, paramsToApply);
 
-    await applySequenceCollectionsPrepopulation();
+      await applySequenceCollectionsPrepopulation();
+    }
 
     uiStore.setRequestComplete('loadOmicsWorkflow');
   }
@@ -236,6 +249,71 @@
     if (parametersIndex >= 0) {
       selectedStepIndex.value = parametersIndex;
     }
+  }
+
+  /**
+   * Parses an `s3://bucket/key/file.ext` URL into its bucket and containing folder.
+   */
+  function parseS3Location(url?: string): { bucket?: string; path?: string } {
+    const match = url?.match(/^s3:\/\/([^/]+)\/(.+)$/);
+    if (!match) return {};
+    const bucket = match[1];
+    const key = match[2];
+    const lastSlash = key.lastIndexOf('/');
+    return { bucket, path: lastSlash > -1 ? key.substring(0, lastSlash) : '' };
+  }
+
+  /**
+   * Seeds the wip run for a retry from a previously failed LaboratoryRun. The failed run
+   * already stores the full parameter set (`Settings`), sample sheet location and workflow
+   * version, so the input data does not need to be re-uploaded. All steps are enabled so the
+   * user can jump straight to Review ("run as is") or step back to edit parameters/inputs.
+   */
+  async function prefillFromFailedRun(paramsRequired: string[]) {
+    const retryId = retryFromRunId.value!;
+
+    let source = runStore.labRuns[retryId];
+    if (!source) {
+      await runStore.loadLabRunsForLab(labId);
+      source = runStore.labRuns[retryId];
+    }
+    if (!source) {
+      useToastStore().error('Could not load the run to retry.');
+      return;
+    }
+
+    retrySourceRunName.value = source.RunName;
+
+    // `Settings` is stored as a JSON string but the list endpoint returns it already parsed
+    // (ReadLaboratoryRun), so handle both shapes.
+    const rawSettings: unknown = source.Settings;
+    let params: Record<string, unknown> = {};
+    if (typeof rawSettings === 'string' && rawSettings) {
+      try {
+        params = JSON.parse(rawSettings);
+      } catch {
+        params = {};
+      }
+    } else if (rawSettings && typeof rawSettings === 'object') {
+      params = rawSettings as Record<string, unknown>;
+    }
+
+    const { bucket, path } = parseS3Location(source.SampleSheetS3Url);
+
+    runStore.updateWipOmicsRun(omicsRunTempId.value, {
+      transactionId: omicsRunTempId.value,
+      paramsRequired,
+      runName: source.RunName,
+      workflowVersionName: source.WorkflowVersionName,
+      sampleSheetS3Url: source.SampleSheetS3Url,
+      ...(bucket ? { s3Bucket: bucket } : {}),
+      ...(path !== undefined ? { s3Path: path } : {}),
+      params,
+    });
+
+    enableAllSteps();
+    const reviewIndex = steps.value.findIndex((step) => step.key === 'review');
+    selectedStepIndex.value = params.input && reviewIndex !== -1 ? reviewIndex : 0;
   }
 
   function resetParams() {
@@ -357,6 +435,23 @@
   </template>
 
   <template v-else>
+    <div
+      v-if="retryFromRunId && !hasLaunched"
+      class="mb-6 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm"
+    >
+      <UIcon name="i-heroicons-arrow-path" class="mt-0.5 h-5 w-5 flex-shrink-0 text-amber-700" />
+      <div>
+        <p class="font-medium text-amber-900">
+          Retrying failed run{{ retrySourceRunName ? `: ${retrySourceRunName}` : '' }}
+        </p>
+        <p class="text-amber-800">
+          Parameters and input data have been pre-filled from the previous run. Launch as is, or edit any step before
+          launching. Completed steps from the failed run are reused automatically where the sample data and their inputs
+          are unchanged &mdash; changing the sample data re-runs the workflow from the start.
+        </p>
+      </div>
+    </div>
+
     <EGWizardStepTabs
       v-model="selectedStepIndex"
       :items="steps"

--- a/packages/front-end/src/app/pages/labs/[labId]/run/[labRunId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/run/[labRunId].vue
@@ -8,6 +8,7 @@
   import { RunTask, GetRunResponse } from '@aws-sdk/client-omics';
   import { useLabsStore, useRunStore, useUiStore } from '@FE/stores';
   import { ensureLabInActiveOrg } from '@FE/utils/ensure-lab-in-active-org';
+  import { v4 as uuidv4 } from 'uuid';
 
   const $route = useRoute();
   const $router = useRouter();
@@ -163,6 +164,24 @@
     }
   });
 
+  const isHealthOmics = computed<boolean>(() => labRun.value?.Platform === 'AWS HealthOmics');
+  const isFailed = computed<boolean>(() => labRun.value?.Status?.toUpperCase() === 'FAILED');
+
+  // Retry is HealthOmics-only and relaunches the wizard pre-filled from this run. The workflow id
+  // comes from the GetRun response loaded for failed runs (it isn't stored on the LaboratoryRun).
+  const retryWorkflowId = computed<string | null>(() => omicsRunDetail.value?.workflowId ?? null);
+  const canRetry = computed<boolean>(() => isHealthOmics.value && isFailed.value && !!retryWorkflowId.value);
+
+  function retryRun() {
+    const workflowId = retryWorkflowId.value;
+    if (!workflowId) return;
+
+    $router.push({
+      path: `/labs/${labId}/run-workflow/${workflowId}`,
+      query: { omicsRunTempId: uuidv4(), retryFromRunId: labRunId },
+    });
+  }
+
   const tabItems = computed(() => [
     { key: 'runDetails', label: 'Run Details' },
     { key: 'fileManager', label: 'File Manager' },
@@ -236,6 +255,22 @@
     <template #default="{ item }">
       <!-- Run Details -->
       <div v-if="item.key === 'runDetails'" class="space-y-3">
+        <!-- Retry action for failed HealthOmics runs. Relaunches the wizard pre-filled from this
+             run; unchanged completed tasks are reused via the run cache on retry. -->
+        <section
+          v-if="canRetry"
+          class="stroke-light flex flex-wrap items-center justify-between gap-4 rounded-2xl border border-solid bg-white p-6 max-md:px-5"
+        >
+          <div class="flex flex-col gap-1">
+            <h3 class="text-sm font-medium text-black">Retry this run</h3>
+            <p class="text-muted text-sm">
+              Relaunch pre-filled from this run. Completed steps are reused where the sample data and their inputs are
+              unchanged; changing the sample data re-runs from the start.
+            </p>
+          </div>
+          <EGButton icon="i-heroicons-arrow-path" label="Retry Run" size="sm" @click="retryRun" />
+        </section>
+
         <section
           v-if="labRun"
           class="stroke-light flex flex-col rounded-none rounded-b-2xl border border-solid bg-white p-6 pt-0 max-md:px-5"

--- a/packages/shared-lib/src/app/openapi/easy-genomics-api.yaml
+++ b/packages/shared-lib/src/app/openapi/easy-genomics-api.yaml
@@ -1662,6 +1662,12 @@ components:
           type: boolean
         HasSeqeraLlmApiKey:
           type: boolean
+        HealthOmicsRunCacheId:
+          description: |-
+            AWS HealthOmics run cache id used for call caching ("resume"). Lazily provisioned on the
+            first HealthOmics run and reused for all subsequent runs, so a failed run can be retried and
+            resume from its last completed task instead of recomputing everything. Managed internally.
+          type: string
         CreatedAt:
           type: string
         CreatedBy:
@@ -1749,6 +1755,8 @@ components:
           type: boolean
         HasSeqeraLlmApiKey:
           type: boolean
+        HealthOmicsRunCacheId:
+          type: string
       required:
         - LaboratoryId
         - Name

--- a/packages/shared-lib/src/app/schema/easy-genomics/laboratory.ts
+++ b/packages/shared-lib/src/app/schema/easy-genomics/laboratory.ts
@@ -43,6 +43,12 @@ export const LaboratorySchema = z
      * lookup + LLM on failureReason only).
      */
     HealthOmicsLogEnrichmentEnabled: z.boolean().optional(),
+    /**
+     * AWS HealthOmics run cache id (call caching / "resume"). Lazily provisioned on the first
+     * HealthOmics run and reused for all subsequent runs so failed runs can resume from their
+     * last completed task. Managed internally; not set via the create/update Laboratory APIs.
+     */
+    HealthOmicsRunCacheId: z.string().optional(),
     CreatedAt: z.string().optional(),
     CreatedBy: z.string().optional(),
     ModifiedAt: z.string().optional(),
@@ -120,6 +126,7 @@ export const ReadLaboratorySchema = z
     /** Boolean indicators. The actual keys live in SSM and are never returned. */
     HasHealthOmicsLlmApiKey: z.boolean().optional(),
     HasSeqeraLlmApiKey: z.boolean().optional(),
+    HealthOmicsRunCacheId: z.string().optional(),
     CreatedAt: z.string().optional(),
     CreatedBy: z.string().optional(),
     ModifiedAt: z.string().optional(),

--- a/packages/shared-lib/src/app/types/easy-genomics/generated.d.ts
+++ b/packages/shared-lib/src/app/types/easy-genomics/generated.d.ts
@@ -1095,6 +1095,12 @@ export interface components {
       /** @description Boolean indicators returned by read-laboratory; the actual keys never leave SSM. */
       HasHealthOmicsLlmApiKey?: boolean;
       HasSeqeraLlmApiKey?: boolean;
+      /**
+       * @description AWS HealthOmics run cache id used for call caching ("resume"). Lazily provisioned on the
+       * first HealthOmics run and reused for all subsequent runs, so a failed run can be retried and
+       * resume from its last completed task instead of recomputing everything. Managed internally.
+       */
+      HealthOmicsRunCacheId?: string;
       CreatedAt?: string;
       CreatedBy?: string;
       ModifiedAt?: string;
@@ -1134,6 +1140,7 @@ export interface components {
       /** @description Boolean indicators. The actual keys live in SSM and are never returned. */
       HasHealthOmicsLlmApiKey?: boolean;
       HasSeqeraLlmApiKey?: boolean;
+      HealthOmicsRunCacheId?: string;
     };
     RequestLaboratoryRequest: {
       /** Format: uuid */

--- a/packages/shared-lib/src/app/types/easy-genomics/laboratory.d.ts
+++ b/packages/shared-lib/src/app/types/easy-genomics/laboratory.d.ts
@@ -102,4 +102,11 @@ export interface Laboratory extends BaseAttributes {
   /** Boolean indicators returned by read-laboratory; the actual keys never leave SSM. */
   HasHealthOmicsLlmApiKey?: boolean;
   HasSeqeraLlmApiKey?: boolean;
+
+  /**
+   * AWS HealthOmics run cache id used for call caching ("resume"). Lazily provisioned on the
+   * first HealthOmics run and reused for all subsequent runs, so a failed run can be retried and
+   * resume from its last completed task instead of recomputing everything. Managed internally.
+   */
+  HealthOmicsRunCacheId?: string;
 }


### PR DESCRIPTION
## feat: retry healthomics workflow run

## Type of Change*
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
feat: retry healthomics workflow run
Type of Change*
 New feature
 Bug fix
 Documentation update
 Refactoring
 Hotfix
 Security patch
 UI/UX improvement
Description
Adds retry for failed AWS HealthOmics runs. A "Retry Run" button relaunches the wizard pre-filled from the failed run. Each lab gets a HealthOmics run cache (attached with CACHE_ON_FAILURE), so retries resume from the last completed task instead of re-running everything. Same sample data resumes; changing sample data re-runs; older runs run fresh. Cache setup is best-effort and never blocks a launch.

## Testing*
Manually launched, failed, and retried a HealthOmics run — confirmed resume, plus fresh runs on changed sample data and pre-cache runs. Lint clean; no new typecheck errors.

## Impact
Saves time/cost on retries. Adds one per-lab run cache + run-cache/ S3 prefix and an internal HealthOmicsRunCacheId Laboratory field. No new dependencies.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.