### PR TITLE
fix: suppress spurious error toasts on intentional logout

### DIFF
--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -740,8 +740,9 @@
 
   watch(
     () => userStore.currentOrgId,
-    async () => {
-      if (props.superuser || uiStore.isRequestPending('loadLabData')) {
+    async (orgId) => {
+      // Skip when org is cleared (logout) or a lab load is already in flight.
+      if (!orgId || props.superuser || uiStore.isRequestPending('loadLabData') || uiStore.isLoggingOut) {
         return;
       }
       // Force reload on org switch so we don't trust a stale persisted lab org id.

--- a/packages/front-end/src/app/composables/useAuth.ts
+++ b/packages/front-end/src/app/composables/useAuth.ts
@@ -1,7 +1,7 @@
 import { CognitoUserSession, CognitoRefreshToken } from 'amazon-cognito-identity-js';
 import { Auth } from 'aws-amplify';
 import { VALIDATION_MESSAGES } from '@FE/constants/validation';
-import { useToastStore, useUiStore } from '@FE/stores';
+import { resetStores, useToastStore, useUiStore } from '@FE/stores';
 
 export default function useAuth() {
   async function isAuthed() {
@@ -77,8 +77,15 @@ export default function useAuth() {
     }
   }
 
-  async function signOut() {
+  /**
+   * Clears Cognito session, analytics, and the user store.
+   * Pass `keepLoggingOutFlag: true` when a redirect follows so in-flight lab
+   * requests and auth middleware still suppress spurious error toasts.
+   */
+  async function signOut(options: { keepLoggingOutFlag?: boolean } = {}) {
+    const uiStore = useUiStore();
     try {
+      uiStore.setLoggingOut(true);
       const analytics = useAnalytics();
       analytics.track('signed_out', {});
       analytics.reset();
@@ -86,17 +93,26 @@ export default function useAuth() {
       // by default. Server-side consent is restored on next login via JWT sync.
       useAnalyticsStore().reset();
       await Auth.signOut();
+      // Reset user after Cognito clear. Lab watchers no-op when currentOrgId is
+      // null or isLoggingOut is set, so this is safe while still on a lab page.
       useUserStore().reset();
+      if (!options.keepLoggingOutFlag) {
+        uiStore.setLoggingOut(false);
+      }
     } catch (error) {
+      uiStore.setLoggingOut(false);
       console.error('Error occurred during sign out.', error);
       throw error;
     }
   }
 
   async function signOutAndRedirect() {
-    await signOut();
+    await signOut({ keepLoggingOutFlag: true });
     useToastStore().success('You have been signed out.');
     await navigateTo('/signin');
+    // Lab views are unmounted; wipe remaining stores. isLoggingOut is preserved
+    // across uiStore.reset and cleared on the sign-in page mount.
+    resetStores();
   }
 
   return {

--- a/packages/front-end/src/app/middleware/auth.global.ts
+++ b/packages/front-end/src/app/middleware/auth.global.ts
@@ -49,7 +49,9 @@ export default defineNuxtRouteMiddleware(async (to) => {
       }
     } catch (e) {
       if (to.fullPath !== '/signin') {
-        useToastStore().error('Session error. You have been signed out.');
+        if (!useUiStore().isLoggingOut) {
+          useToastStore().error('Session error. You have been signed out.');
+        }
         return navigateTo('/signin');
       }
     }

--- a/packages/front-end/src/app/pages/signin.vue
+++ b/packages/front-end/src/app/pages/signin.vue
@@ -25,6 +25,7 @@
    */
   onBeforeMount(() => {
     resetStores();
+    useUiStore().setLoggingOut(false);
   });
 
   watchEffect(() => {

--- a/packages/front-end/src/app/stores/labs.ts
+++ b/packages/front-end/src/app/stores/labs.ts
@@ -1,4 +1,5 @@
 import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
+import { Auth } from 'aws-amplify';
 import { defineStore } from 'pinia';
 
 interface LabsStoreState {
@@ -12,6 +13,19 @@ const initialState = (): LabsStoreState => ({
   labs: {},
   labIdsByOrg: {},
 });
+
+async function shouldSuppressLabLoadErrorToast(): Promise<boolean> {
+  if (useUiStore().isLoggingOut) {
+    return true;
+  }
+  try {
+    await Auth.currentAuthenticatedUser();
+    return false;
+  } catch {
+    // No session (logout or expiry) — lab fetch failures are expected.
+    return true;
+  }
+}
 
 const useLabsStore = defineStore('labsStore', {
   state: initialState,
@@ -36,7 +50,9 @@ const useLabsStore = defineStore('labsStore', {
         this.labs[lab.LaboratoryId] = lab;
       } catch (error) {
         console.error('Failed to load lab:', error);
-        useToastStore().error('Failed to load lab details. Please refresh.');
+        if (!(await shouldSuppressLabLoadErrorToast())) {
+          useToastStore().error('Failed to load lab details. Please refresh.');
+        }
       }
     },
 
@@ -53,7 +69,9 @@ const useLabsStore = defineStore('labsStore', {
         }
       } catch (error) {
         console.error('Failed to load labs:', error);
-        useToastStore().error('Failed to load labs. Please refresh.');
+        if (!(await shouldSuppressLabLoadErrorToast())) {
+          useToastStore().error('Failed to load labs. Please refresh.');
+        }
       }
     },
   },

--- a/packages/front-end/src/app/stores/ui.ts
+++ b/packages/front-end/src/app/stores/ui.ts
@@ -58,6 +58,8 @@ interface UiStoreState {
   remountAppKey: number;
   hasSidebar: boolean;
   sidebarCollapsed: boolean;
+  /** True while an intentional logout is in progress; suppresses auth/lab error toasts. */
+  isLoggingOut: boolean;
 }
 
 const initialState = (): UiStoreState => ({
@@ -66,6 +68,7 @@ const initialState = (): UiStoreState => ({
   remountAppKey: 0,
   hasSidebar: false,
   sidebarCollapsed: false,
+  isLoggingOut: false,
 });
 
 const useUiStore = defineStore('uiStore', {
@@ -85,7 +88,14 @@ const useUiStore = defineStore('uiStore', {
 
   actions: {
     reset() {
+      // Preserve across store wipes so in-flight logout requests still skip error toasts.
+      const { isLoggingOut } = this;
       Object.assign(this, initialState());
+      this.isLoggingOut = isLoggingOut;
+    },
+
+    setLoggingOut(loggingOut: boolean): void {
+      this.isLoggingOut = loggingOut;
     },
 
     setRequestPending(val: PendingRequest): void {

--- a/packages/front-end/src/app/utils/ensure-lab-in-active-org.ts
+++ b/packages/front-end/src/app/utils/ensure-lab-in-active-org.ts
@@ -1,5 +1,5 @@
 import { storeToRefs } from 'pinia';
-import { useToastStore } from '@FE/stores';
+import { useToastStore, useUiStore } from '@FE/stores';
 
 export type EnsureLabInActiveOrgOptions = {
   labId: string;
@@ -30,9 +30,15 @@ export async function ensureLabInActiveOrg({
 }: EnsureLabInActiveOrgOptions): Promise<boolean> {
   const userStore = useUserStore();
   const labsStore = useLabsStore();
+  const uiStore = useUiStore();
   const { currentOrgId } = storeToRefs(userStore);
 
   if (superuser || userStore.isSuperuser) {
+    return false;
+  }
+
+  // No active org (e.g. mid-logout): do not fetch or bounce through /labs.
+  if (!currentOrgId.value || uiStore.isLoggingOut) {
     return false;
   }
 
@@ -42,8 +48,10 @@ export async function ensureLabInActiveOrg({
       await labsStore.loadLab(labId);
     } catch (error) {
       console.error('Failed to load laboratory for org validation', error);
-      useToastStore().error('Failed to load laboratory');
-      await navigateTo(redirectTo);
+      if (!uiStore.isLoggingOut) {
+        useToastStore().error('Failed to load laboratory');
+        await navigateTo(redirectTo);
+      }
       return true;
     }
   }
@@ -51,8 +59,10 @@ export async function ensureLabInActiveOrg({
   const lab = labsStore.labs[labId];
   if (!lab) {
     console.error('Laboratory not found after load', { labId });
-    useToastStore().error('Failed to load laboratory');
-    await navigateTo(redirectTo);
+    if (!uiStore.isLoggingOut) {
+      useToastStore().error('Failed to load laboratory');
+      await navigateTo(redirectTo);
+    }
     return true;
   }
 


### PR DESCRIPTION
## Title*
Suppress spurious error toasts on intentional logout

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
Fixes EGV-231: after signing out (especially from a lab page), users saw the expected success toast plus several misleading error toasts (“Failed to load lab details…”, “Failed to load laboratory”, “Session error…”).

Root cause was a race: clearing the user store while lab UI was still mounted re-triggered lab loads without a session, and a bounce through `/labs` hit auth middleware’s session-error toast.

This change:
- Adds an `isLoggingOut` flag on the UI store for the duration of intentional logout
- Guards lab org watchers / `ensureLabInActiveOrg` so they don’t fetch or redirect to `/labs` mid-logout
- Suppresses lab load and session-error toasts when logging out (or when there is no Cognito session)
- Resets remaining stores after navigating to `/signin`, and clears `isLoggingOut` on the sign-in page mount

Unexpected session expiry on a protected route still shows the session error toast.

## Screenshots

### Before

https://github.com/user-attachments/assets/67c3ad7e-c0af-4afb-b057-9d45a8cc103a

### After

https://github.com/user-attachments/assets/d1959812-4482-4fe6-bbdc-98c596f867db

## Testing*
- [ ] Manual: log out from a lab detail page → only “You have been signed out.”; land on `/signin`
- [ ] Manual: log out from `/labs` and `/admin` → same success-only toast behavior
- [ ] Manual: forced session expiry on a protected route → still get “Session error. You have been signed out.” and redirect to `/signin`
- [ ] Existing e2e that asserts “You have been signed out” still passes (`Labs_Lab_Manager.spec.e2e.ts`)
- No new automated unit tests added

## Impact
- Front-end only; no API or schema changes required for the fix
- Improves logout UX by removing false-negative error toasts
- Session-loss messaging for unexpected auth failures is preserved via the `isLoggingOut` gate

## Checklist*
- [x] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.