### PR TITLE
refactor: cut easy-genomics nested stack from 459 to 235 CFN resources

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/file/process-folder-download-job.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/file/process-folder-download-job.lambda.ts
@@ -6,6 +6,7 @@ import archiver from 'archiver';
 import { APIGatewayProxyResult, Handler } from 'aws-lambda';
 import { SQSEvent } from 'aws-lambda/trigger/sqs';
 import { S3Service } from '@BE/services/s3-service';
+import { parseSqsJsonBody } from '@BE/utils/sqs-json-body';
 
 const s3Service = new S3Service();
 const MULTIPART_PART_SIZE_BYTES = 8 * 1024 * 1024; // 8MB
@@ -53,11 +54,8 @@ const writeStatus = async (input: {
   });
 };
 
-const parseSnsWrappedMessage = (body: string): FolderDownloadJobMessage => {
-  const parsedBody = JSON.parse(body);
-  const messageBody = parsedBody?.Message ? parsedBody.Message : body;
-  return JSON.parse(messageBody) as FolderDownloadJobMessage;
-};
+const parseSnsWrappedMessage = (body: string): FolderDownloadJobMessage =>
+  parseSqsJsonBody<FolderDownloadJobMessage>(body);
 
 const uploadZipMultipart = async (job: FolderDownloadJobMessage, zipStream: PassThrough): Promise<void> => {
   const s3Client: S3Client = s3Service.getClient();

--- a/packages/back-end/src/app/controllers/easy-genomics/file/request-folder-download-job.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/file/request-folder-download-job.lambda.ts
@@ -12,7 +12,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { LaboratoryS3AccessService } from '@BE/services/easy-genomics/laboratory-s3-access-service';
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
 import { S3Service } from '@BE/services/s3-service';
-import { SnsService } from '@BE/services/sns-service';
+import { SqsService } from '@BE/services/sqs-service';
 import {
   validateLaboratoryManagerAccess,
   validateLaboratoryTechnicianAccess,
@@ -23,7 +23,7 @@ import { assertLaboratoryHasS3BucketAccess } from '@BE/utils/laboratory-s3-acces
 
 const laboratoryService = new LaboratoryService();
 const s3Service = new S3Service();
-const snsService = new SnsService();
+const sqsService = new SqsService();
 const s3AccessService = new LaboratoryS3AccessService();
 
 const DOWNLOAD_JOBS_PREFIX = '.downloads/jobs';
@@ -230,9 +230,9 @@ export const handler: Handler = async (
       }),
     });
 
-    const topicArn = process.env.SNS_FOLDER_DOWNLOAD_TOPIC || '';
-    if (!topicArn) {
-      throw new Error('Missing SNS_FOLDER_DOWNLOAD_TOPIC environment variable');
+    const queueUrl = process.env.SQS_FOLDER_DOWNLOAD_QUEUE_URL || '';
+    if (!queueUrl) {
+      throw new Error('Missing SQS_FOLDER_DOWNLOAD_QUEUE_URL environment variable');
     }
 
     const message: FolderDownloadJobMessage = {
@@ -245,11 +245,11 @@ export const handler: Handler = async (
       StatusKey: statusKey,
     };
 
-    await snsService.publish({
-      TopicArn: topicArn,
+    await sqsService.sendMessage({
+      QueueUrl: queueUrl,
       MessageGroupId: laboratory.LaboratoryId,
       MessageDeduplicationId: `${jobId}-${Date.now()}`,
-      Message: JSON.stringify(message),
+      MessageBody: JSON.stringify(message),
     });
 
     const response: FolderDownloadJobResponse = {

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/delete-laboratory.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/delete-laboratory.lambda.ts
@@ -13,14 +13,14 @@ import { v4 as uuidv4 } from 'uuid';
 import { LaboratoryRunService } from '@BE/services/easy-genomics/laboratory-run-service';
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
 import { LaboratoryUserService } from '@BE/services/easy-genomics/laboratory-user-service';
-import { SnsService } from '@BE/services/sns-service';
+import { SqsService } from '@BE/services/sqs-service';
 import { SsmService } from '@BE/services/ssm-service';
 import { validateOrganizationAdminAccess } from '@BE/utils/auth-utils';
 
 const laboratoryService = new LaboratoryService();
 const laboratoryUserService = new LaboratoryUserService();
 const laboratoryRunService = new LaboratoryRunService();
-const snsService = new SnsService();
+const sqsService = new SqsService();
 const ssmService = new SsmService();
 
 export const handler: Handler = async (
@@ -86,9 +86,9 @@ async function publishDeleteLaboratoryUsers(laboratoryId: string): Promise<void>
         Type: 'LaboratoryUser',
         Record: laboratoryUser,
       };
-      return snsService.publish({
-        TopicArn: process.env.SNS_LABORATORY_DELETION_TOPIC,
-        Message: JSON.stringify(record),
+      return sqsService.sendMessage({
+        QueueUrl: process.env.SQS_LABORATORY_DELETION_QUEUE_URL,
+        MessageBody: JSON.stringify(record),
         MessageGroupId: `delete-laboratory-${laboratoryId}`,
         MessageDeduplicationId: uuidv4(),
       });
@@ -110,9 +110,9 @@ async function publishDeleteLaboratoryRuns(laboratoryId: string): Promise<void> 
         Type: 'LaboratoryRun',
         Record: laboratoryRun,
       };
-      return snsService.publish({
-        TopicArn: process.env.SNS_LABORATORY_DELETION_TOPIC,
-        Message: JSON.stringify(record),
+      return sqsService.sendMessage({
+        QueueUrl: process.env.SQS_LABORATORY_DELETION_QUEUE_URL,
+        MessageBody: JSON.stringify(record),
         MessageGroupId: `delete-laboratory-${laboratoryId}`,
         MessageDeduplicationId: uuidv4(),
       });

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/process-delete-laboratory.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/process-delete-laboratory.lambda.ts
@@ -11,6 +11,7 @@ import { SQSEvent } from 'aws-lambda/trigger/sqs';
 import { LaboratoryRunService } from '@BE/services/easy-genomics/laboratory-run-service';
 import { PlatformUserService } from '@BE/services/easy-genomics/platform-user-service';
 import { UserService } from '@BE/services/easy-genomics/user-service';
+import { parseSqsJsonBody } from '@BE/utils/sqs-json-body';
 
 const platformUserService = new PlatformUserService();
 const laboratoryRunService = new LaboratoryRunService();
@@ -21,8 +22,7 @@ export const handler: Handler = async (event: SQSEvent): Promise<APIGatewayProxy
   try {
     const sqsRecords: SQSRecord[] = event.Records;
     for (const sqsRecord of sqsRecords) {
-      const body = JSON.parse(sqsRecord.body);
-      const snsEvent: SnsProcessingEvent = <SnsProcessingEvent>JSON.parse(body.Message);
+      const snsEvent: SnsProcessingEvent = parseSqsJsonBody<SnsProcessingEvent>(sqsRecord.body);
 
       switch (snsEvent.Type) {
         case 'LaboratoryUser':

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/create-laboratory-run.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/create-laboratory-run.lambda.ts
@@ -19,7 +19,7 @@ import { LaboratoryRunService } from '@BE/services/easy-genomics/laboratory-run-
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
 import { RunCostEstimationService } from '@BE/services/easy-genomics/run-cost-estimation-service';
 import { buildRunInputProfile } from '@BE/services/easy-genomics/run-input-profile-service';
-import { SnsService } from '@BE/services/sns-service';
+import { SqsService } from '@BE/services/sqs-service';
 import {
   validateLaboratoryManagerAccess,
   validateLaboratoryTechnicianAccess,
@@ -36,7 +36,7 @@ const laboratoryRunService = new LaboratoryRunService();
 const laboratoryService = new LaboratoryService();
 const dataTaggingService = new LaboratoryDataTaggingService();
 const runCostEstimationService = new RunCostEstimationService();
-const snsService = new SnsService();
+const sqsService = new SqsService();
 
 /**
  * Best-effort input profile + pre-run estimate. Runs after laboratoryRunService.add()
@@ -164,9 +164,9 @@ export const handler: Handler = async (
         Type: 'LaboratoryRun',
         Record: laboratoryRun,
       };
-      await snsService.publish({
-        TopicArn: process.env.SNS_LABORATORY_RUN_UPDATE_TOPIC,
-        Message: JSON.stringify(record),
+      await sqsService.sendMessage({
+        QueueUrl: process.env.SQS_LABORATORY_RUN_UPDATE_QUEUE_URL,
+        MessageBody: JSON.stringify(record),
         MessageGroupId: `update-laboratory-run-${laboratoryRun.RunId}`,
         MessageDeduplicationId: uuidv4(),
       });

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/process-classify-laboratory-run-failure.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/process-classify-laboratory-run-failure.lambda.ts
@@ -20,6 +20,7 @@ import { ClassificationInput } from '@BE/services/llm-classification/llm-classif
 import { LLMClassificationService, ProviderConfig } from '@BE/services/llm-classification/llm-classification-service';
 import { fetchRedactedLogExcerpt } from '@BE/services/llm-classification/run-log-fetcher';
 import { SsmService } from '@BE/services/ssm-service';
+import { parseSqsJsonBody } from '@BE/utils/sqs-json-body';
 
 const laboratoryRunService = new LaboratoryRunService();
 const laboratoryService = new LaboratoryService();
@@ -32,8 +33,7 @@ export const handler: Handler = async (event: SQSEvent): Promise<APIGatewayProxy
   try {
     const sqsRecords: SQSRecord[] = event.Records;
     for (const sqsRecord of sqsRecords) {
-      const body = JSON.parse(sqsRecord.body);
-      const snsEvent: SnsProcessingEvent = <SnsProcessingEvent>JSON.parse(body.Message);
+      const snsEvent: SnsProcessingEvent = parseSqsJsonBody<SnsProcessingEvent>(sqsRecord.body);
 
       if (snsEvent.Type !== 'LaboratoryRun') {
         console.error(`Unsupported SNS Processing Event Type: ${snsEvent.Type}`);

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.ts
@@ -20,7 +20,7 @@ import { LaboratoryRunService } from '@BE/services/easy-genomics/laboratory-run-
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
 import { captureRunCostOutcome } from '@BE/services/easy-genomics/run-cost-capture-service';
 import { createOmicsServiceForLab } from '@BE/services/omics-lab-factory';
-import { SnsService } from '@BE/services/sns-service';
+import { SqsService } from '@BE/services/sqs-service';
 import { SsmService } from '@BE/services/ssm-service';
 import {
   calculateExpiresAtEpochSeconds,
@@ -32,11 +32,12 @@ import {
 import { aggregateTaskProgress, OmicsTaskProgress } from '@BE/utils/omics-run-progress-utils';
 import { getNextFlowApiQueryParameters, httpRequest, REST_API_METHOD } from '@BE/utils/rest-api-utils';
 import { aggregateSeqeraProgress } from '@BE/utils/seqera-run-progress-utils';
+import { parseSqsJsonBody } from '@BE/utils/sqs-json-body';
 
 const laboratoryService = new LaboratoryService();
 const laboratoryRunService = new LaboratoryRunService();
 const laboratoryDataTaggingService = new LaboratoryDataTaggingService();
-const snsService = new SnsService();
+const sqsService = new SqsService();
 const ssmService = new SsmService();
 
 /**
@@ -53,28 +54,28 @@ async function safeCaptureRunCost(run: LaboratoryRun): Promise<LaboratoryRun['Ru
 }
 
 /**
- * Best-effort SNS publish that hands off a freshly-failed run to the
+ * Best-effort SQS publish that hands off a freshly-failed run to the
  * classification pipeline. Failures here are swallowed because classification
  * is a downstream enhancement — the status-check pipeline must never break if
- * the topic is misconfigured or SNS is temporarily unavailable.
+ * the queue is misconfigured or SQS is temporarily unavailable.
  */
 async function safePublishForClassification(run: LaboratoryRun): Promise<void> {
-  const topicArn = process.env.SNS_LABORATORY_RUN_FAILURE_CLASSIFICATION_TOPIC;
-  if (!topicArn) return;
+  const queueUrl = process.env.SQS_LABORATORY_RUN_FAILURE_CLASSIFICATION_QUEUE_URL;
+  if (!queueUrl) return;
   try {
     const record: SnsProcessingEvent = {
       Operation: 'UPDATE',
       Type: 'LaboratoryRun',
       Record: run,
     };
-    await snsService.publish({
-      TopicArn: topicArn,
-      Message: JSON.stringify(record),
+    await sqsService.sendMessage({
+      QueueUrl: queueUrl,
+      MessageBody: JSON.stringify(record),
       MessageGroupId: `classify-laboratory-run-${run.RunId}`,
       MessageDeduplicationId: uuidv4(),
     });
   } catch (err) {
-    console.warn('Failed to publish FAILED run to classification topic (continuing):', err);
+    console.warn('Failed to publish FAILED run to classification queue (continuing):', err);
   }
 }
 
@@ -109,8 +110,7 @@ export const handler: Handler = async (event: SQSEvent): Promise<APIGatewayProxy
   try {
     const sqsRecords: SQSRecord[] = event.Records;
     for (const sqsRecord of sqsRecords) {
-      const body = JSON.parse(sqsRecord.body);
-      const snsEvent: SnsProcessingEvent = <SnsProcessingEvent>JSON.parse(body.Message);
+      const snsEvent: SnsProcessingEvent = parseSqsJsonBody<SnsProcessingEvent>(sqsRecord.body);
 
       switch (snsEvent.Type) {
         case 'LaboratoryRun':

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/request-laboratory-run-status-check.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/request-laboratory-run-status-check.lambda.ts
@@ -10,7 +10,7 @@ import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handl
 import { v4 as uuidv4 } from 'uuid';
 import { LaboratoryRunService } from '@BE/services/easy-genomics/laboratory-run-service';
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
-import { SnsService } from '@BE/services/sns-service';
+import { SqsService } from '@BE/services/sqs-service';
 import {
   validateLaboratoryManagerAccess,
   validateLaboratoryTechnicianAccess,
@@ -19,7 +19,7 @@ import {
 
 const laboratoryRunService = new LaboratoryRunService();
 const laboratoryService = new LaboratoryService();
-const snsService = new SnsService();
+const sqsService = new SqsService();
 
 const TERMINAL_STATUSES = ['FAILED', 'SUCCEEDED', 'CANCELLED', 'COMPLETED', 'DELETED'];
 
@@ -89,9 +89,9 @@ export const handler: Handler = async (
         Type: 'LaboratoryRun',
         Record: run,
       };
-      return snsService.publish({
-        TopicArn: process.env.SNS_LABORATORY_RUN_UPDATE_TOPIC,
-        Message: JSON.stringify(record),
+      return sqsService.sendMessage({
+        QueueUrl: process.env.SQS_LABORATORY_RUN_UPDATE_QUEUE_URL,
+        MessageBody: JSON.stringify(record),
         MessageGroupId: `update-laboratory-run-${run.RunId}`,
         MessageDeduplicationId: uuidv4(),
       });

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/update-laboratory-run.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/update-laboratory-run.lambda.ts
@@ -16,7 +16,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { LaboratoryDataTaggingService } from '@BE/services/easy-genomics/laboratory-data-tagging-service';
 import { LaboratoryRunService } from '@BE/services/easy-genomics/laboratory-run-service';
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
-import { SnsService } from '@BE/services/sns-service';
+import { SqsService } from '@BE/services/sqs-service';
 import {
   validateLaboratoryManagerAccess,
   validateLaboratoryTechnicianAccess,
@@ -30,7 +30,7 @@ import {
   shouldExpireWithRetentionMonths,
 } from '@BE/utils/laboratory-run-ttl-utils';
 
-const snsService = new SnsService();
+const sqsService = new SqsService();
 
 const laboratoryRunService = new LaboratoryRunService();
 const laboratoryService = new LaboratoryService();
@@ -128,9 +128,9 @@ export const handler: Handler = async (
       Type: 'LaboratoryRun',
       Record: response,
     };
-    await snsService.publish({
-      TopicArn: process.env.SNS_LABORATORY_RUN_UPDATE_TOPIC,
-      Message: JSON.stringify(record),
+    await sqsService.sendMessage({
+      QueueUrl: process.env.SQS_LABORATORY_RUN_UPDATE_QUEUE_URL,
+      MessageBody: JSON.stringify(record),
       MessageGroupId: `update-laboratory-run-${response.RunId}`,
       MessageDeduplicationId: uuidv4(),
     });

--- a/packages/back-end/src/app/controllers/easy-genomics/organization/delete-organization.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/organization/delete-organization.lambda.ts
@@ -1,5 +1,9 @@
 import { buildErrorResponse, buildResponse } from '@easy-genomics/shared-lib/lib/app/utils/common';
-import { OrganizationDeleteFailedError, RequiredIdNotFoundError, UnauthorizedAccessError } from '@easy-genomics/shared-lib/lib/app/utils/HttpError';
+import {
+  OrganizationDeleteFailedError,
+  RequiredIdNotFoundError,
+  UnauthorizedAccessError,
+} from '@easy-genomics/shared-lib/lib/app/utils/HttpError';
 import { Laboratory } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory';
 import { Organization } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/organization';
 import { OrganizationUser } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/organization-user';
@@ -9,13 +13,13 @@ import { v4 as uuidv4 } from 'uuid';
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
 import { OrganizationService } from '@BE/services/easy-genomics/organization-service';
 import { OrganizationUserService } from '@BE/services/easy-genomics/organization-user-service';
-import { SnsService } from '@BE/services/sns-service';
+import { SqsService } from '@BE/services/sqs-service';
 import { validateSystemAdminAccess } from '@BE/utils/auth-utils';
 
 const organizationService = new OrganizationService();
 const organizationUserService = new OrganizationUserService();
 const laboratoryService = new LaboratoryService();
-const snsService = new SnsService();
+const sqsService = new SqsService();
 
 export const handler: Handler = async (
   event: APIGatewayProxyWithCognitoAuthorizerEvent,
@@ -62,9 +66,9 @@ async function publishDeleteOrganizationUsers(organizationId: string): Promise<v
         Type: 'OrganizationUser',
         Record: organizationUser,
       };
-      return snsService.publish({
-        TopicArn: process.env.SNS_ORGANIZATION_DELETION_TOPIC,
-        Message: JSON.stringify(record),
+      return sqsService.sendMessage({
+        QueueUrl: process.env.SQS_ORGANIZATION_DELETION_QUEUE_URL,
+        MessageBody: JSON.stringify(record),
         MessageGroupId: `delete-organization-${organizationId}`,
         MessageDeduplicationId: uuidv4(),
       });
@@ -86,9 +90,9 @@ async function publishDeleteOrganizationLabs(organizationId: string): Promise<vo
         Type: 'Laboratory',
         Record: laboratory,
       };
-      return snsService.publish({
-        TopicArn: process.env.SNS_ORGANIZATION_DELETION_TOPIC,
-        Message: JSON.stringify(record),
+      return sqsService.sendMessage({
+        QueueUrl: process.env.SQS_ORGANIZATION_DELETION_QUEUE_URL,
+        MessageBody: JSON.stringify(record),
         MessageGroupId: `delete-organization-${organizationId}`,
         MessageDeduplicationId: uuidv4(),
       });

--- a/packages/back-end/src/app/controllers/easy-genomics/organization/process-delete-organization.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/organization/process-delete-organization.lambda.ts
@@ -11,6 +11,7 @@ import { SQSEvent } from 'aws-lambda/trigger/sqs';
 import { LaboratoryService } from '@BE/services/easy-genomics/laboratory-service';
 import { PlatformUserService } from '@BE/services/easy-genomics/platform-user-service';
 import { UserService } from '@BE/services/easy-genomics/user-service';
+import { parseSqsJsonBody } from '@BE/utils/sqs-json-body';
 
 const laboratoryService = new LaboratoryService();
 const platformUserService = new PlatformUserService();
@@ -21,8 +22,7 @@ export const handler: Handler = async (event: SQSEvent): Promise<APIGatewayProxy
   try {
     const sqsRecords: SQSRecord[] = event.Records;
     for (const sqsRecord of sqsRecords) {
-      const body = JSON.parse(sqsRecord.body);
-      const snsEvent: SnsProcessingEvent = <SnsProcessingEvent>JSON.parse(body.Message);
+      const snsEvent: SnsProcessingEvent = parseSqsJsonBody<SnsProcessingEvent>(sqsRecord.body);
 
       switch (snsEvent.Type) {
         case 'LaboratoryUser':

--- a/packages/back-end/src/app/controllers/easy-genomics/user/create-bulk-user-invitation-requests.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/user/create-bulk-user-invitation-requests.lambda.ts
@@ -10,11 +10,11 @@ import { SnsProcessingEvent } from '@easy-genomics/shared-lib/src/app/types/easy
 import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent, Handler } from 'aws-lambda';
 import { v4 as uuidv4 } from 'uuid';
 import { OrganizationService } from '@BE/services/easy-genomics/organization-service';
-import { SnsService } from '@BE/services/sns-service';
+import { SqsService } from '@BE/services/sqs-service';
 import { validateOrganizationAdminAccess, validateSystemAdminAccess } from '@BE/utils/auth-utils';
 
 const organizationService = new OrganizationService();
-const snsService = new SnsService();
+const sqsService = new SqsService();
 
 export const handler: Handler = async (
   event: APIGatewayProxyWithCognitoAuthorizerEvent,
@@ -49,9 +49,9 @@ export const handler: Handler = async (
             CreatedBy: currentUserId,
           },
         };
-        return snsService.publish({
-          TopicArn: process.env.SNS_USER_INVITE_TOPIC,
-          Message: JSON.stringify(record),
+        return sqsService.sendMessage({
+          QueueUrl: process.env.SQS_USER_INVITE_QUEUE_URL,
+          MessageBody: JSON.stringify(record),
           MessageGroupId: `create-user-invite-${organization.OrganizationId}`,
           MessageDeduplicationId: uuidv4(),
         });

--- a/packages/back-end/src/app/controllers/easy-genomics/user/delete-user-request.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/user/delete-user-request.lambda.ts
@@ -15,12 +15,12 @@ import { CognitoIdpService } from '@BE/services/cognito-idp-service';
 import { LaboratoryUserService } from '@BE/services/easy-genomics/laboratory-user-service';
 import { OrganizationUserService } from '@BE/services/easy-genomics/organization-user-service';
 import { UserService } from '@BE/services/easy-genomics/user-service';
-import { SnsService } from '@BE/services/sns-service';
+import { SqsService } from '@BE/services/sqs-service';
 import { validateSystemAdminAccess } from '@BE/utils/auth-utils';
 
 const cognitoIdpService = new CognitoIdpService({ userPoolId: process.env.COGNITO_USER_POOL_ID });
 const userService: UserService = new UserService();
-const snsService: SnsService = new SnsService();
+const sqsService: SqsService = new SqsService();
 const laboratoryUserService: LaboratoryUserService = new LaboratoryUserService();
 const organizationUserService: OrganizationUserService = new OrganizationUserService();
 
@@ -80,9 +80,9 @@ async function publishDeleteLaboratoryUsers(userId: string): Promise<void> {
         Type: 'LaboratoryUser',
         Record: laboratoryUser,
       };
-      return snsService.publish({
-        TopicArn: process.env.SNS_USER_DELETION_TOPIC,
-        Message: JSON.stringify(record),
+      return sqsService.sendMessage({
+        QueueUrl: process.env.SQS_USER_DELETION_QUEUE_URL,
+        MessageBody: JSON.stringify(record),
         MessageGroupId: `delete-user-${userId}`,
         MessageDeduplicationId: uuidv4(),
       });
@@ -104,9 +104,9 @@ async function publishDeleteOrganizationUsers(userId: string): Promise<void> {
         Type: 'OrganizationUser',
         Record: organizationUser,
       };
-      return snsService.publish({
-        TopicArn: process.env.SNS_USER_DELETION_TOPIC,
-        Message: JSON.stringify(record),
+      return sqsService.sendMessage({
+        QueueUrl: process.env.SQS_USER_DELETION_QUEUE_URL,
+        MessageBody: JSON.stringify(record),
         MessageGroupId: `delete-user-${userId}`,
         MessageDeduplicationId: uuidv4(),
       });

--- a/packages/back-end/src/app/controllers/easy-genomics/user/process-create-user-invites.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/user/process-create-user-invites.lambda.ts
@@ -11,6 +11,7 @@ import { SQSEvent } from 'aws-lambda/trigger/sqs';
 import { OrganizationService } from '@BE/services/easy-genomics/organization-service';
 import { UserInviteService } from '@BE/services/easy-genomics/user-invite-service';
 import { UserService } from '@BE/services/easy-genomics/user-service';
+import { parseSqsJsonBody } from '@BE/utils/sqs-json-body';
 
 const userInviteService = new UserInviteService();
 const organizationService = new OrganizationService();
@@ -21,8 +22,7 @@ export const handler: Handler = async (event: SQSEvent): Promise<APIGatewayProxy
   try {
     const sqsRecords: SQSRecord[] = event.Records;
     for (const sqsRecord of sqsRecords) {
-      const body = JSON.parse(sqsRecord.body);
-      const snsEvent: SnsProcessingEvent = <SnsProcessingEvent>JSON.parse(body.Message);
+      const snsEvent: SnsProcessingEvent = parseSqsJsonBody<SnsProcessingEvent>(sqsRecord.body);
 
       switch (snsEvent.Type) {
         case 'UserInvite':

--- a/packages/back-end/src/app/controllers/easy-genomics/user/process-delete-user.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/user/process-delete-user.lambda.ts
@@ -9,6 +9,7 @@ import { APIGatewayProxyResult, Handler, SQSRecord } from 'aws-lambda';
 import { SQSEvent } from 'aws-lambda/trigger/sqs';
 import { LaboratoryUserService } from '@BE/services/easy-genomics/laboratory-user-service';
 import { OrganizationUserService } from '@BE/services/easy-genomics/organization-user-service';
+import { parseSqsJsonBody } from '@BE/utils/sqs-json-body';
 
 const laboratoryUserService = new LaboratoryUserService();
 const organizationUserService = new OrganizationUserService();
@@ -18,8 +19,7 @@ export const handler: Handler = async (event: SQSEvent): Promise<APIGatewayProxy
   try {
     const sqsRecords: SQSRecord[] = event.Records;
     for (const sqsRecord of sqsRecords) {
-      const body = JSON.parse(sqsRecord.body);
-      const snsEvent: SnsProcessingEvent = <SnsProcessingEvent>JSON.parse(body.Message);
+      const snsEvent: SnsProcessingEvent = parseSqsJsonBody<SnsProcessingEvent>(sqsRecord.body);
 
       switch (snsEvent.Type) {
         case 'LaboratoryUser':

--- a/packages/back-end/src/app/services/sqs-service.ts
+++ b/packages/back-end/src/app/services/sqs-service.ts
@@ -2,52 +2,62 @@ import {
   ReceiveMessageCommand,
   ReceiveMessageCommandInput,
   ReceiveMessageCommandOutput,
+  SendMessageCommand,
+  SendMessageCommandInput,
+  SendMessageCommandOutput,
   SQSClient,
   SQSServiceException,
 } from '@aws-sdk/client-sqs';
 
 export enum SqsCommand {
   RECEIVE_MESSAGE = 'receive-message',
+  SEND_MESSAGE = 'send-message',
 }
 
 export class SqsService {
-  private readonly sqsClient;
+  private readonly clientsByRegion = new Map<string, SQSClient>();
+  private readonly fallbackRegion = process.env.AWS_REGION ?? process.env.REGION;
 
-  public constructor() {
-    this.sqsClient = new SQSClient();
+  /**
+   * SQS SendMessage must target the queue's region. Queue URLs embed the
+   * region (`https://sqs.<region>.amazonaws.com/...`); fall back to the
+   * Lambda's configured region when the URL cannot be parsed.
+   */
+  private clientForQueueUrl(queueUrl: string | undefined): SQSClient {
+    const m = queueUrl?.match(/sqs\.([a-z0-9-]+)\.amazonaws\.com/);
+    const region = m?.[1] ?? this.fallbackRegion;
+    if (!region) {
+      return new SQSClient();
+    }
+    let client = this.clientsByRegion.get(region);
+    if (!client) {
+      client = new SQSClient({ region });
+      this.clientsByRegion.set(region, client);
+    }
+    return client;
   }
 
-  public sendMessage = async (
-    receiveMessageCommandInput: ReceiveMessageCommandInput,
-  ): Promise<ReceiveMessageCommandOutput> => {
-    return this.sqsRequest<ReceiveMessageCommandInput, ReceiveMessageCommandOutput>(
-      SqsCommand.RECEIVE_MESSAGE,
-      receiveMessageCommandInput,
-    );
+  public sendMessage = async (input: SendMessageCommandInput): Promise<SendMessageCommandOutput> => {
+    try {
+      const client = this.clientForQueueUrl(input.QueueUrl);
+      return await client.send(new SendMessageCommand(input));
+    } catch (error: any) {
+      console.error('[sqs-service : sendMessage] exception encountered:', error);
+      throw this.handleError(error);
+    }
   };
 
-  private sqsRequest = async <RequestType, ResponseType>(
-    command: SqsCommand,
-    data?: RequestType,
-  ): Promise<ResponseType> => {
+  public receiveMessage = async (input: ReceiveMessageCommandInput): Promise<ReceiveMessageCommandOutput> => {
     try {
-      return await this.sqsClient.send(this.getSqsCommand(command, data));
+      const client = this.clientForQueueUrl(input.QueueUrl);
+      return await client.send(new ReceiveMessageCommand(input));
     } catch (error: any) {
-      console.error(`[sqs-service : sqsRequest] command: ${command} exception encountered:`, error);
+      console.error('[sqs-service : receiveMessage] exception encountered:', error);
       throw this.handleError(error);
     }
   };
 
   private handleError = (error: any): SQSServiceException => {
-    return error as SQSServiceException; // Base Exception
-  };
-
-  private getSqsCommand = <SqsCommandInput>(command: SqsCommand, data: SqsCommandInput): any => {
-    switch (command) {
-      case SqsCommand.RECEIVE_MESSAGE:
-        return new ReceiveMessageCommand(data);
-      default:
-        throw new Error(`Unsupported SQS Management Command '${command}'`);
-    }
+    return error as SQSServiceException;
   };
 }

--- a/packages/back-end/src/app/utils/sqs-json-body.ts
+++ b/packages/back-end/src/app/utils/sqs-json-body.ts
@@ -1,0 +1,17 @@
+/**
+ * Parse an SQS record body that may be either:
+ *  - a raw JSON payload published directly to the queue, or
+ *  - an SNS→SQS notification envelope (`{ Message: "<json string>" }`) left
+ *    over from the previous SNS fan-in topology.
+ *
+ * Publishing now goes straight to the FIFO queues (no SNS hop), but keeping
+ * both shapes means in-flight SNS-wrapped messages still process cleanly
+ * during a rolling deploy.
+ */
+export function parseSqsJsonBody<T>(body: string): T {
+  const parsed = JSON.parse(body);
+  if (parsed && typeof parsed === 'object' && typeof parsed.Message === 'string') {
+    return JSON.parse(parsed.Message) as T;
+  }
+  return parsed as T;
+}

--- a/packages/back-end/src/infra/constructs/lambda-construct.ts
+++ b/packages/back-end/src/infra/constructs/lambda-construct.ts
@@ -2,9 +2,8 @@ import * as fs from 'fs';
 import path from 'path';
 import { AssociativeArray, HttpRequest } from '@easy-genomics/shared-lib/src/app/utils/common';
 import { aws_lambda, aws_lambda_nodejs, Duration } from 'aws-cdk-lib';
-import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { ManagedPolicy, PolicyDocument, PolicyStatement, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { IEventSource, IFunction, Runtime } from 'aws-cdk-lib/aws-lambda';
-import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
 import { CommonApiNestedStackProps } from '../types/back-end-stack';
 
@@ -18,6 +17,12 @@ export const LAMBDA_FUNCTION_ROOT_DIR = 'src/app/controllers'; // DO NOT CHANGE
 // using this map. It deliberately does NOT extend any single domain's
 // nested-stack props, so no domain can accidentally inherit another domain's
 // API ownership just by sharing Cognito/VPC dependencies.
+//
+// Per-handler IAM is folded into the Role as an inline policy (instead of a
+// separate AWS::IAM::Policy) so each handler costs 2 CFN resources instead of
+// 3. Log retention is NOT created here — callers provision it in a sibling
+// nested stack via `logGroupNames` to keep Custom::LogRetention out of the
+// route-heavy domain templates.
 export interface LambdaConstructProps extends CommonApiNestedStackProps {
   lambdaFunctionsDir: string;
   lambdaFunctionsNamespace: string;
@@ -67,6 +72,12 @@ const ALLOWED_LAMBDA_FUNCTION_OPERATIONS: AssociativeArray<HttpRequest> = {
 export class LambdaConstruct extends Construct {
   private props: LambdaConstructProps;
   readonly lambdaFunctions: Map<string, IFunction> = new Map();
+  /**
+   * Deterministic `/aws/lambda/<functionName>` log group names for every
+   * handler registered by this construct. Used by `LogRetentionNestedStack`
+   * so Custom::LogRetention resources live in a separate template.
+   */
+  readonly logGroupNames: string[] = [];
 
   constructor(scope: Construct, id: string, props: LambdaConstructProps) {
     super(scope, id);
@@ -101,32 +112,14 @@ export class LambdaConstruct extends Construct {
     const lambdaTimeoutSeconds = this.props.lambdaFunctionsResources[lambdaApiEndpoint]?.timeoutSeconds || 30;
     const lambdaMemorySizeMb = this.props.lambdaFunctionsResources[lambdaApiEndpoint]?.memorySizeMb || 1024;
     const lambdaNodeModules = this.props.lambdaFunctionsResources[lambdaApiEndpoint]?.nodeModules;
+    const hasEventSources = (this.props.lambdaFunctionsResources[lambdaApiEndpoint]?.events?.length ?? 0) > 0;
 
-    const lambdaHandler: IFunction = new aws_lambda_nodejs.NodejsFunction(this, `${lambdaId}`, {
-      runtime: Runtime.NODEJS_20_X,
-      timeout: Duration.seconds(lambdaTimeoutSeconds),
-      memorySize: lambdaMemorySizeMb,
-      functionName: `${this.props.lambdaFunctionsNamespace}-${lambdaName}`.slice(0, 64),
-      entry: `${lambdaFunction.path}`,
-      handler: 'handler',
-      tracing: aws_lambda.Tracing.ACTIVE,
-      bundling: {
-        loader: { '.hbs': 'text' },
-        externalModules: ['@aws-sdk/*'],
-        nodeModules: lambdaNodeModules,
-      },
-      logRetention: RetentionDays.ONE_DAY,
-      logRetentionRetryOptions: {
-        // Attempt to avoid LogRetention creation failure due to throttling
-        maxRetries: 10, // AWS default is 3
-      },
-      environment: {
-        ...commonProcessEnv, // Common process.env settings
-        ...lambdaProcessEnv, // Specific process.env settings
-      },
-    });
+    const functionName = `${this.props.lambdaFunctionsNamespace}-${lambdaName}`.slice(0, 64);
+    this.logGroupNames.push(`/aws/lambda/${functionName}`);
 
-    // Attach relevant IAM policies to Lambda Function matching specific API Endpoint
+    // Attach relevant IAM policies to Lambda Function matching specific API Endpoint.
+    // Folded into the Role as an inline policy so we do not emit a separate
+    // AWS::IAM::Policy resource per handler (CloudFormation stack budget).
     const iamPolicyStatements: PolicyStatement[] | undefined = this.props.iamPolicyStatements?.get(lambdaApiEndpoint);
     if (iamPolicyStatements) {
       if (process.env.CI_CD === 'true') {
@@ -134,12 +127,52 @@ export class LambdaConstruct extends Construct {
           `Attaching IAM Policy to REST API Endpoint: ${lambdaApiEndpoint}\n${JSON.stringify(iamPolicyStatements, null, 2)}`,
         );
       }
-      iamPolicyStatements.forEach((iamPolicyStatement: PolicyStatement) => {
-        lambdaHandler.addToRolePolicy(iamPolicyStatement);
-      });
     } else {
       console.warn(`WARNING: ${lambdaApiEndpoint} does not have any IAM Policies attached`);
     }
+
+    const role = new Role(this, `${lambdaId}-role`, {
+      assumedBy: new ServicePrincipal('lambda.amazonaws.com'),
+      managedPolicies: [
+        // Required when supplying a custom role — Function skips its default managed policies.
+        ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole'),
+        // Replaces the inline xray:Put* statement Tracing.ACTIVE would otherwise add via
+        // addToRolePolicy (which would recreate a DefaultPolicy AWS::IAM::Policy resource).
+        ManagedPolicy.fromAwsManagedPolicyName('AWSXRayDaemonWriteAccess'),
+      ],
+      inlinePolicies:
+        iamPolicyStatements && iamPolicyStatements.length > 0
+          ? {
+              handler: new PolicyDocument({ statements: iamPolicyStatements }),
+            }
+          : undefined,
+    });
+
+    // Handlers with event sources need a mutable role so SqsEventSource /
+    // DynamoEventSource grants (sqs:ReceiveMessage, dynamodb:GetRecords, …)
+    // can land on a DefaultPolicy. Everything else uses withoutPolicyUpdates()
+    // so Tracing.ACTIVE's addToRolePolicy call is a silent no-op.
+    const functionRole = hasEventSources ? role : role.withoutPolicyUpdates();
+
+    const lambdaHandler: IFunction = new aws_lambda_nodejs.NodejsFunction(this, `${lambdaId}`, {
+      runtime: Runtime.NODEJS_20_X,
+      timeout: Duration.seconds(lambdaTimeoutSeconds),
+      memorySize: lambdaMemorySizeMb,
+      functionName,
+      entry: `${lambdaFunction.path}`,
+      handler: 'handler',
+      tracing: aws_lambda.Tracing.ACTIVE,
+      role: functionRole,
+      bundling: {
+        loader: { '.hbs': 'text' },
+        externalModules: ['@aws-sdk/*'],
+        nodeModules: lambdaNodeModules,
+      },
+      environment: {
+        ...commonProcessEnv, // Common process.env settings
+        ...lambdaProcessEnv, // Specific process.env settings
+      },
+    });
 
     if (lambdaFunction.command === 'process') {
       // Register Event Source Listeners/Triggers for the respective Lambda function

--- a/packages/back-end/src/infra/constructs/sqs-construct.ts
+++ b/packages/back-end/src/infra/constructs/sqs-construct.ts
@@ -5,7 +5,8 @@ import { Queue, QueueProps } from 'aws-cdk-lib/aws-sqs';
 import { Construct } from 'constructs';
 
 export interface QueueDetails extends QueueProps {
-  snsTopics: Topic[];
+  /** Optional SNS topics to subscribe this queue to. Prefer direct SQS publish. */
+  snsTopics?: Topic[];
 }
 
 export interface Queues {
@@ -33,16 +34,17 @@ export class SqsConstruct extends Construct {
 
   private createQueue = (name: string, queueDetails: QueueDetails) => {
     const removalPolicy = this.props.envType !== 'prod' ? RemovalPolicy.DESTROY : undefined; // Only for Non-Prod
+    const { snsTopics, ...queueProps } = queueDetails;
 
     const queue = new Queue(this, `${this.props.namePrefix}-${name}`, {
-      ...queueDetails,
+      ...queueProps,
       queueName:
         queueDetails.fifo === true ? `${this.props.namePrefix}-${name}.fifo` : `${this.props.namePrefix}-${name}`,
       removalPolicy: removalPolicy,
     });
 
-    // Subscribe SQS Queue to supplied SNS Topic(s)
-    queueDetails.snsTopics.forEach((topic: Topic) => {
+    // Subscribe SQS Queue to supplied SNS Topic(s), if any
+    snsTopics?.forEach((topic: Topic) => {
       topic.addSubscription(new SqsSubscription(queue));
     });
 

--- a/packages/back-end/src/infra/stacks/back-end-stack.ts
+++ b/packages/back-end/src/infra/stacks/back-end-stack.ts
@@ -9,6 +9,7 @@ import { NagSuppressions } from 'cdk-nag';
 import { Construct } from 'constructs';
 import { AuthNestedStack } from './auth-nested-stack';
 import { AwsHealthOmicsNestedStack } from './aws-healthomics-nested-stack';
+import { LogRetentionNestedStack } from './log-retention-nested-stack';
 import { NFTowerNestedStack } from './nf-tower-nested-stack';
 import { AnalyticsConstruct } from '../constructs/analytics/analytics-construct';
 import { SpecRestApiConstruct } from '../constructs/spec-rest-api-construct';
@@ -109,6 +110,17 @@ export class BackEndStack extends Stack {
       `${this.props.envName}-nf-tower-nested-stack`,
       nfTowerNestedStackProps,
     );
+
+    // Custom::LogRetention for auth / HealthOmics / NF-Tower Lambdas — kept in
+    // a sibling nested stack so LambdaConstruct no longer emits them into each
+    // domain template (same pattern as EasyGenomicsApiStack).
+    new LogRetentionNestedStack(this, `${this.props.envName}-platform-log-retention-nested-stack`, {
+      logGroupNames: [
+        ...authNestedStack.lambda.logGroupNames,
+        ...awsHealthOmicsNestedStack.lambda.logGroupNames,
+        ...nfTowerNestedStack.lambda.logGroupNames,
+      ],
+    });
 
     // Shared API Gateway for the remaining (smaller) back-end domains, deployed
     // from easy-genomics-api.yaml via SpecRestApi. Built after the nested stacks

--- a/packages/back-end/src/infra/stacks/easy-genomics-api-stack.ts
+++ b/packages/back-end/src/infra/stacks/easy-genomics-api-stack.ts
@@ -4,6 +4,7 @@ import { NagSuppressions } from 'cdk-nag';
 import { Construct } from 'constructs';
 import { DataProvisioningNestedStack } from './data-provisioning-nested-stack';
 import { EasyGenomicsNestedStack } from './easy-genomics-nested-stack';
+import { LogRetentionNestedStack } from './log-retention-nested-stack';
 import { baseLSIAttributes, DynamoConstruct } from '../constructs/dynamodb-construct';
 import { SpecRestApiConstruct } from '../constructs/spec-rest-api-construct';
 import {
@@ -87,6 +88,14 @@ export class EasyGenomicsApiStack extends Stack {
       easyGenomicsNestedStackProps,
     );
 
+    // Custom::LogRetention for every easy-genomics Lambda lives here (its own
+    // template) so the route-heavy EasyGenomicsNestedStack stays under the
+    // CloudFormation 500-resource limit. functionName is deterministic, so no
+    // cross-stack reference to the Lambda functions is required.
+    new LogRetentionNestedStack(this, `${this.props.envName}-easy-genomics-log-retention-nested-stack`, {
+      logGroupNames: this.easyGenomicsNestedStack.lambda.logGroupNames,
+    });
+
     // Dedicated API Gateway for the Easy Genomics domain, deployed directly from
     // easy-genomics-api.yaml via SpecRestApi. Keeping the API at this stack level
     // means its resources land in this template (not `BackEndStack`); reusing the
@@ -141,22 +150,24 @@ export class EasyGenomicsApiStack extends Stack {
     // authorizer, add a single RestApi-scoped suppression here.
 
     // Lambda execution roles that require broader S3 access (signed URLs,
-    // bucket listing, multi-object downloads, etc.).
+    // bucket listing, multi-object downloads, etc.). Paths target the explicit
+    // `${lambdaId}-role` construct (inline policies live on the Role itself;
+    // there is no longer a ServiceRole/DefaultPolicy AWS::IAM::Policy resource).
     NagSuppressions.addResourceSuppressionsByPath(
       this,
       [
-        `${stackPath}/${nestedId}/${easyGenomicsId}/${easyGenomicsId}-request-file-download-url/ServiceRole/DefaultPolicy/Resource`,
-        `${stackPath}/${nestedId}/${easyGenomicsId}/${easyGenomicsId}-request-list-bucket-objects/ServiceRole/DefaultPolicy/Resource`,
-        `${stackPath}/${nestedId}/${easyGenomicsId}/${easyGenomicsId}-request-top-level-bucket-objects/ServiceRole/DefaultPolicy/Resource`,
-        `${stackPath}/${nestedId}/${easyGenomicsId}/${easyGenomicsId}-request-laboratory-bucket-objects/ServiceRole/DefaultPolicy/Resource`,
-        `${stackPath}/${nestedId}/${easyGenomicsId}/${easyGenomicsId}-request-search-bucket-objects/ServiceRole/DefaultPolicy/Resource`,
-        `${stackPath}/${nestedId}/${easyGenomicsId}/${easyGenomicsId}-request-folder-download-job/ServiceRole/DefaultPolicy/Resource`,
-        `${stackPath}/${nestedId}/${easyGenomicsId}/${easyGenomicsId}-request-folder-download-job-status/ServiceRole/DefaultPolicy/Resource`,
-        `${stackPath}/${nestedId}/${easyGenomicsId}/${easyGenomicsId}-process-folder-download-job/ServiceRole/DefaultPolicy/Resource`,
-        `${stackPath}/${nestedId}/${easyGenomicsId}/${easyGenomicsId}-update-laboratory/ServiceRole/DefaultPolicy/Resource`,
-        `${stackPath}/${nestedId}/${easyGenomicsId}/${easyGenomicsId}-list-buckets/ServiceRole/DefaultPolicy/Resource`,
-        `${stackPath}/${nestedId}/${easyGenomicsId}/${easyGenomicsId}-create-file-upload-request/ServiceRole/DefaultPolicy/Resource`,
-        `${stackPath}/${nestedId}/${easyGenomicsId}/${easyGenomicsId}-create-file-upload-sample-sheet/ServiceRole/DefaultPolicy/Resource`,
+        `${stackPath}/${nestedId}/${easyGenomicsId}/${easyGenomicsId}-request-file-download-url-role/Resource`,
+        `${stackPath}/${nestedId}/${easyGenomicsId}/${easyGenomicsId}-request-list-bucket-objects-role/Resource`,
+        `${stackPath}/${nestedId}/${easyGenomicsId}/${easyGenomicsId}-request-top-level-bucket-objects-role/Resource`,
+        `${stackPath}/${nestedId}/${easyGenomicsId}/${easyGenomicsId}-request-laboratory-bucket-objects-role/Resource`,
+        `${stackPath}/${nestedId}/${easyGenomicsId}/${easyGenomicsId}-request-search-bucket-objects-role/Resource`,
+        `${stackPath}/${nestedId}/${easyGenomicsId}/${easyGenomicsId}-request-folder-download-job-role/Resource`,
+        `${stackPath}/${nestedId}/${easyGenomicsId}/${easyGenomicsId}-request-folder-download-job-status-role/Resource`,
+        `${stackPath}/${nestedId}/${easyGenomicsId}/${easyGenomicsId}-process-folder-download-job-role/Resource`,
+        `${stackPath}/${nestedId}/${easyGenomicsId}/${easyGenomicsId}-update-laboratory-role/Resource`,
+        `${stackPath}/${nestedId}/${easyGenomicsId}/${easyGenomicsId}-list-buckets-role/Resource`,
+        `${stackPath}/${nestedId}/${easyGenomicsId}/${easyGenomicsId}-create-file-upload-request-role/Resource`,
+        `${stackPath}/${nestedId}/${easyGenomicsId}/${easyGenomicsId}-create-file-upload-sample-sheet-role/Resource`,
       ],
       [
         {
@@ -168,10 +179,14 @@ export class EasyGenomicsApiStack extends Stack {
     );
 
     // Lab Runs processor needs access to read any omics run to fetch status.
+    // This handler has an SQS event source, so it still gets a mutable role with
+    // a DefaultPolicy for the event-source grants — suppress both the Role
+    // (inline handler policy) and the DefaultPolicy (event-source grants).
     NagSuppressions.addResourceSuppressionsByPath(
       this,
       [
-        `${stackPath}/${nestedId}/${easyGenomicsId}/${easyGenomicsId}-process-update-laboratory-run/ServiceRole/DefaultPolicy/Resource`,
+        `${stackPath}/${nestedId}/${easyGenomicsId}/${easyGenomicsId}-process-update-laboratory-run-role/Resource`,
+        `${stackPath}/${nestedId}/${easyGenomicsId}/${easyGenomicsId}-process-update-laboratory-run-role/DefaultPolicy/Resource`,
       ],
       [
         {

--- a/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
@@ -1,22 +1,20 @@
 import { Duration, NestedStack } from 'aws-cdk-lib';
 import { Schedule, Rule } from 'aws-cdk-lib/aws-events';
 import { LambdaFunction } from 'aws-cdk-lib/aws-events-targets';
-import { Effect, PolicyStatement, StarPrincipal } from 'aws-cdk-lib/aws-iam';
+import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { StartingPosition } from 'aws-cdk-lib/aws-lambda';
 import { DynamoEventSource, SqsDlq, SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
-import { Topic } from 'aws-cdk-lib/aws-sns';
 import { Queue } from 'aws-cdk-lib/aws-sqs';
 import { NagSuppressions } from 'cdk-nag';
 import { Construct } from 'constructs';
 import { IamConstruct, IamConstructProps } from '../constructs/iam-construct';
 import { LambdaConstruct } from '../constructs/lambda-construct';
 import { SesConstruct } from '../constructs/ses-construct';
-import { SnsConstruct, TopicDetails, Topics } from '../constructs/sns-construct';
 import { QueueDetails, Queues, SqsConstruct } from '../constructs/sqs-construct';
 import { EasyGenomicsNestedStackProps } from '../types/back-end-stack';
 
 /**
- * Easy Genomics nested stack: lambdas, SNS, SQS, SES, IAM, route registration.
+ * Easy Genomics nested stack: lambdas, SQS, SES, IAM.
  *
  * NOTE: This stack does NOT own the easy-genomics DynamoDB tables. Tables are
  * created by the parent `EasyGenomicsApiStack` and injected here via
@@ -30,6 +28,10 @@ import { EasyGenomicsNestedStackProps } from '../types/back-end-stack';
  * IAM policy statements in this nested stack reference table ARNs by string
  * template (built from `props.namePrefix`), so they continue to work
  * regardless of which stack physically owns the table resources.
+ *
+ * Async work is published directly to FIFO SQS queues (no SNS hop). Each
+ * former SNS→SQS pair was 1:1 with no fan-out, so collapsing them saves
+ * Topic + TopicPolicy + Subscription resources per queue.
  */
 export class EasyGenomicsNestedStack extends NestedStack {
   readonly props: EasyGenomicsNestedStackProps;
@@ -37,7 +39,6 @@ export class EasyGenomicsNestedStack extends NestedStack {
   iam: IamConstruct;
   lambda: LambdaConstruct;
   ses: SesConstruct;
-  sns: SnsConstruct;
   sqs: SqsConstruct;
   /**
    * DLQ for the laboratory-run DynamoDB Stream subscriber. Held as a class field so
@@ -50,21 +51,6 @@ export class EasyGenomicsNestedStack extends NestedStack {
     super(scope, id);
     this.props = props;
 
-    // The enforceSSL option for sns topics is currently broken, that may get fixed in the
-    // future. In the meantime we will apply a policy enforcing ssl in the policies section.
-    this.sns = new SnsConstruct(this, `${this.props.constructNamespace}-sns`, {
-      namePrefix: this.props.namePrefix,
-      topics: <Topics>{
-        ['organization-deletion-topic']: <TopicDetails>{ fifo: true, enforceSSL: true },
-        ['laboratory-deletion-topic']: <TopicDetails>{ fifo: true, enforceSSL: true },
-        ['user-deletion-topic']: <TopicDetails>{ fifo: true, enforceSSL: true },
-        ['laboratory-run-update-topic']: <TopicDetails>{ fifo: true, enforceSSL: true },
-        ['laboratory-run-failure-classification-topic']: <TopicDetails>{ fifo: true, enforceSSL: true },
-        ['user-invite-topic']: <TopicDetails>{ fifo: true, enforceSSL: true },
-        ['folder-download-topic']: <TopicDetails>{ fifo: true, enforceSSL: true },
-      },
-    });
-
     this.sqs = new SqsConstruct(this, `${this.props.constructNamespace}-sqs`, {
       namePrefix: this.props.namePrefix,
       envType: this.props.envType,
@@ -73,28 +59,24 @@ export class EasyGenomicsNestedStack extends NestedStack {
           fifo: true,
           retentionPeriod: Duration.days(1),
           visibilityTimeout: Duration.minutes(15),
-          snsTopics: [this.sns.snsTopics.get('organization-deletion-topic')],
           enforceSSL: true,
         },
         ['laboratory-management-queue']: <QueueDetails>{
           fifo: true,
           retentionPeriod: Duration.days(1),
           visibilityTimeout: Duration.minutes(15),
-          snsTopics: [this.sns.snsTopics.get('laboratory-deletion-topic')],
           enforceSSL: true,
         },
         ['user-management-queue']: <QueueDetails>{
           fifo: true,
           retentionPeriod: Duration.days(1),
           visibilityTimeout: Duration.minutes(15),
-          snsTopics: [this.sns.snsTopics.get('user-deletion-topic')],
           enforceSSL: true,
         },
         ['laboratory-run-update-queue']: <QueueDetails>{
           fifo: true,
           retentionPeriod: Duration.days(1),
           visibilityTimeout: Duration.minutes(15),
-          snsTopics: [this.sns.snsTopics.get('laboratory-run-update-topic')],
           enforceSSL: true,
         },
         // Failure classification consumer. Visibility timeout is generous (5 min) to
@@ -104,21 +86,18 @@ export class EasyGenomicsNestedStack extends NestedStack {
           fifo: true,
           retentionPeriod: Duration.days(1),
           visibilityTimeout: Duration.minutes(5),
-          snsTopics: [this.sns.snsTopics.get('laboratory-run-failure-classification-topic')],
           enforceSSL: true,
         },
         ['user-invite-queue']: <QueueDetails>{
           fifo: true,
           retentionPeriod: Duration.days(1),
           visibilityTimeout: Duration.minutes(15),
-          snsTopics: [this.sns.snsTopics.get('user-invite-topic')],
           enforceSSL: true,
         },
         ['folder-download-queue']: <QueueDetails>{
           fifo: true,
           retentionPeriod: Duration.days(1),
           visibilityTimeout: Duration.minutes(15),
-          snsTopics: [this.sns.snsTopics.get('folder-download-topic')],
           enforceSSL: true,
         },
       },
@@ -173,7 +152,7 @@ export class EasyGenomicsNestedStack extends NestedStack {
         },
         '/easy-genomics/user/create-bulk-user-invitation-requests': {
           environment: {
-            SNS_USER_INVITE_TOPIC: this.sns.snsTopics.get('user-invite-topic')?.topicArn || '',
+            SQS_USER_INVITE_QUEUE_URL: this.sqs.sqsQueues.get('user-invite-queue')?.queueUrl || '',
           },
         },
         '/easy-genomics/laboratory/user/add-bulk-laboratory-users': {
@@ -185,7 +164,6 @@ export class EasyGenomicsNestedStack extends NestedStack {
             COGNITO_USER_POOL_CLIENT_ID: this.props.userPoolClient?.userPoolClientId!,
             COGNITO_USER_POOL_ID: this.props.userPool?.userPoolId!,
             JWT_SECRET_KEY: this.props.jwtSecretKey,
-            SNS_USER_INVITE_TOPIC: this.sns.snsTopics.get('user-invite-topic')?.topicArn || '',
           },
         },
         '/easy-genomics/user/confirm-user-invitation-request': {
@@ -217,14 +195,11 @@ export class EasyGenomicsNestedStack extends NestedStack {
             COGNITO_USER_POOL_CLIENT_ID: this.props.userPoolClient?.userPoolClientId!,
             COGNITO_USER_POOL_ID: this.props.userPool?.userPoolId!,
             JWT_SECRET_KEY: this.props.jwtSecretKey,
-            SNS_USER_DELETION_TOPIC: this.sns.snsTopics.get('user-deletion-topic')?.topicArn || '',
+            SQS_USER_DELETION_QUEUE_URL: this.sqs.sqsQueues.get('user-management-queue')?.queueUrl || '',
           },
         },
         '/easy-genomics/user/process-delete-user': {
           events: [new SqsEventSource(this.sqs.sqsQueues.get('user-management-queue')!, { batchSize: 1 })],
-          environment: {
-            SNS_USER_DELETION_TOPIC: this.sns.snsTopics.get('user-deletion-topic')?.topicArn || '',
-          },
         },
         '/easy-genomics/organization/create-organization': {
           environment: {
@@ -238,14 +213,12 @@ export class EasyGenomicsNestedStack extends NestedStack {
         },
         '/easy-genomics/organization/delete-organization': {
           environment: {
-            SNS_ORGANIZATION_DELETION_TOPIC: this.sns.snsTopics.get('organization-deletion-topic')?.topicArn || '',
+            SQS_ORGANIZATION_DELETION_QUEUE_URL:
+              this.sqs.sqsQueues.get('organization-management-queue')?.queueUrl || '',
           },
         },
         '/easy-genomics/organization/process-delete-organization': {
           events: [new SqsEventSource(this.sqs.sqsQueues.get('organization-management-queue')!, { batchSize: 1 })],
-          environment: {
-            SNS_ORGANIZATION_DELETION_TOPIC: this.sns.snsTopics.get('organization-deletion-topic')?.topicArn || '',
-          },
         },
         '/easy-genomics/laboratory/create-laboratory': {
           environment: {
@@ -259,32 +232,28 @@ export class EasyGenomicsNestedStack extends NestedStack {
         },
         '/easy-genomics/laboratory/delete-laboratory': {
           environment: {
-            SNS_LABORATORY_DELETION_TOPIC: this.sns.snsTopics.get('laboratory-deletion-topic')?.topicArn || '',
+            SQS_LABORATORY_DELETION_QUEUE_URL: this.sqs.sqsQueues.get('laboratory-management-queue')?.queueUrl || '',
           },
         },
         '/easy-genomics/laboratory/process-delete-laboratory': {
           events: [new SqsEventSource(this.sqs.sqsQueues.get('laboratory-management-queue')!, { batchSize: 1 })],
-          environment: {
-            SNS_LABORATORY_DELETION_TOPIC: this.sns.snsTopics.get('laboratory-deletion-topic')?.topicArn || '',
-          },
         },
         '/easy-genomics/laboratory/run/create-laboratory-run': {
           environment: {
-            SNS_LABORATORY_RUN_UPDATE_TOPIC: this.sns.snsTopics.get('laboratory-run-update-topic')?.topicArn || '',
+            SQS_LABORATORY_RUN_UPDATE_QUEUE_URL: this.sqs.sqsQueues.get('laboratory-run-update-queue')?.queueUrl || '',
           },
         },
         '/easy-genomics/laboratory/run/update-laboratory-run': {
           environment: {
-            SNS_LABORATORY_RUN_UPDATE_TOPIC: this.sns.snsTopics.get('laboratory-run-update-topic')?.topicArn || '',
+            SQS_LABORATORY_RUN_UPDATE_QUEUE_URL: this.sqs.sqsQueues.get('laboratory-run-update-queue')?.queueUrl || '',
           },
         },
         '/easy-genomics/laboratory/run/process-update-laboratory-run': {
           events: [new SqsEventSource(this.sqs.sqsQueues.get('laboratory-run-update-queue')!, { batchSize: 5 })],
           environment: {
             SEQERA_API_BASE_URL: this.props.seqeraApiBaseUrl,
-            SNS_LABORATORY_RUN_UPDATE_TOPIC: this.sns.snsTopics.get('laboratory-run-update-topic')?.topicArn || '',
-            SNS_LABORATORY_RUN_FAILURE_CLASSIFICATION_TOPIC:
-              this.sns.snsTopics.get('laboratory-run-failure-classification-topic')?.topicArn || '',
+            SQS_LABORATORY_RUN_FAILURE_CLASSIFICATION_QUEUE_URL:
+              this.sqs.sqsQueues.get('laboratory-run-failure-classification-queue')?.queueUrl || '',
           },
         },
         // Async classifier consumer for FAILED runs. Idempotent (skips runs that already
@@ -324,7 +293,7 @@ export class EasyGenomicsNestedStack extends NestedStack {
         },
         '/easy-genomics/laboratory/run/request-laboratory-run-status-check': {
           environment: {
-            SNS_LABORATORY_RUN_UPDATE_TOPIC: this.sns.snsTopics.get('laboratory-run-update-topic')?.topicArn || '',
+            SQS_LABORATORY_RUN_UPDATE_QUEUE_URL: this.sqs.sqsQueues.get('laboratory-run-update-queue')?.queueUrl || '',
           },
         },
         '/easy-genomics/organization/workflow-access/list-workflow-catalog': {
@@ -336,7 +305,7 @@ export class EasyGenomicsNestedStack extends NestedStack {
         },
         '/easy-genomics/file/request-folder-download-job': {
           environment: {
-            SNS_FOLDER_DOWNLOAD_TOPIC: this.sns.snsTopics.get('folder-download-topic')?.topicArn || '',
+            SQS_FOLDER_DOWNLOAD_QUEUE_URL: this.sqs.sqsQueues.get('folder-download-queue')?.queueUrl || '',
           },
         },
         '/easy-genomics/file/process-folder-download-job': {
@@ -427,24 +396,6 @@ export class EasyGenomicsNestedStack extends NestedStack {
 
   // Easy Genomics specific IAM policies
   private setupIamPolicies = () => {
-    // Currently the enforceSSL option for SNS topics is broken
-    // We have to apply the policy ourselves.
-    this.sns.snsTopics.forEach((snsTopic: Topic) => {
-      snsTopic.addToResourcePolicy(
-        new PolicyStatement({
-          resources: [`${snsTopic.topicArn}`],
-          actions: ['sns:Publish'],
-          conditions: {
-            StringEquals: {
-              'aws:SecureTransport': false,
-            },
-          },
-          effect: Effect.DENY,
-          principals: [new StarPrincipal()],
-        }),
-      );
-    });
-
     // /easy-genomics/organization/create-organization
     this.iam.addPolicyStatements('/easy-genomics/organization/create-organization', [
       new PolicyStatement({
@@ -527,8 +478,8 @@ export class EasyGenomicsNestedStack extends NestedStack {
         effect: Effect.ALLOW,
       }),
       new PolicyStatement({
-        resources: [`${this.sns.snsTopics.get('organization-deletion-topic')?.topicArn || ''}`],
-        actions: ['sns:Publish'],
+        resources: [`${this.sqs.sqsQueues.get('organization-management-queue')?.queueArn || ''}`],
+        actions: ['sqs:SendMessage'],
         effect: Effect.ALLOW,
       }),
     ]);
@@ -821,8 +772,8 @@ export class EasyGenomicsNestedStack extends NestedStack {
         effect: Effect.ALLOW,
       }),
       new PolicyStatement({
-        resources: [`${this.sns.snsTopics.get('laboratory-deletion-topic')?.topicArn || ''}`],
-        actions: ['sns:Publish'],
+        resources: [`${this.sqs.sqsQueues.get('laboratory-management-queue')?.queueArn || ''}`],
+        actions: ['sqs:SendMessage'],
         effect: Effect.ALLOW,
       }),
     ]);
@@ -1103,8 +1054,8 @@ export class EasyGenomicsNestedStack extends NestedStack {
         effect: Effect.ALLOW,
       }),
       new PolicyStatement({
-        resources: [`${this.sns.snsTopics.get('user-deletion-topic')?.topicArn || ''}`],
-        actions: ['sns:Publish'],
+        resources: [`${this.sqs.sqsQueues.get('user-management-queue')?.queueArn || ''}`],
+        actions: ['sqs:SendMessage'],
         effect: Effect.ALLOW,
       }),
     ]);
@@ -1168,8 +1119,8 @@ export class EasyGenomicsNestedStack extends NestedStack {
         effect: Effect.ALLOW,
       }),
       new PolicyStatement({
-        resources: [`${this.sns.snsTopics.get('laboratory-run-update-topic')?.topicArn || ''}`],
-        actions: ['sns:Publish'],
+        resources: [`${this.sqs.sqsQueues.get('laboratory-run-update-queue')?.queueArn || ''}`],
+        actions: ['sqs:SendMessage'],
         effect: Effect.ALLOW,
       }),
     ]);
@@ -1253,8 +1204,8 @@ export class EasyGenomicsNestedStack extends NestedStack {
         effect: Effect.ALLOW,
       }),
       new PolicyStatement({
-        resources: [`${this.sns.snsTopics.get('laboratory-run-update-topic')?.topicArn || ''}`],
-        actions: ['sns:Publish'],
+        resources: [`${this.sqs.sqsQueues.get('laboratory-run-update-queue')?.queueArn || ''}`],
+        actions: ['sqs:SendMessage'],
         effect: Effect.ALLOW,
       }),
     ]);
@@ -1310,8 +1261,8 @@ export class EasyGenomicsNestedStack extends NestedStack {
         effect: Effect.ALLOW,
       }),
       new PolicyStatement({
-        resources: [`${this.sns.snsTopics.get('laboratory-run-update-topic')?.topicArn || ''}`],
-        actions: ['sns:Publish'],
+        resources: [`${this.sqs.sqsQueues.get('laboratory-run-update-queue')?.queueArn || ''}`],
+        actions: ['sqs:SendMessage'],
         effect: Effect.ALLOW,
       }),
       dataTaggingUsagePropagationStatement,
@@ -1343,13 +1294,13 @@ export class EasyGenomicsNestedStack extends NestedStack {
         effect: Effect.ALLOW,
       }),
       new PolicyStatement({
-        resources: [`${this.sns.snsTopics.get('laboratory-run-update-topic')?.topicArn || ''}`],
-        actions: ['sns:Publish'],
+        resources: [`${this.sqs.sqsQueues.get('laboratory-run-update-queue')?.queueArn || ''}`],
+        actions: ['sqs:SendMessage'],
         effect: Effect.ALLOW,
       }),
       new PolicyStatement({
-        resources: [`${this.sns.snsTopics.get('laboratory-run-failure-classification-topic')?.topicArn || ''}`],
-        actions: ['sns:Publish'],
+        resources: [`${this.sqs.sqsQueues.get('laboratory-run-failure-classification-queue')?.queueArn || ''}`],
+        actions: ['sqs:SendMessage'],
         effect: Effect.ALLOW,
       }),
       new PolicyStatement({
@@ -1526,8 +1477,8 @@ export class EasyGenomicsNestedStack extends NestedStack {
         effect: Effect.ALLOW,
       }),
       new PolicyStatement({
-        resources: [`${this.sns.snsTopics.get('user-invite-topic')?.topicArn || ''}`],
-        actions: ['sns:Publish'],
+        resources: [`${this.sqs.sqsQueues.get('user-invite-queue')?.queueArn || ''}`],
+        actions: ['sqs:SendMessage'],
         effect: Effect.ALLOW,
       }),
     ]);
@@ -1768,8 +1719,8 @@ export class EasyGenomicsNestedStack extends NestedStack {
         effect: Effect.ALLOW,
       }),
       new PolicyStatement({
-        resources: [`${this.sns.snsTopics.get('folder-download-topic')?.topicArn || ''}`],
-        actions: ['sns:Publish'],
+        resources: [`${this.sqs.sqsQueues.get('folder-download-queue')?.queueArn || ''}`],
+        actions: ['sqs:SendMessage'],
         effect: Effect.ALLOW,
       }),
     ]);

--- a/packages/back-end/src/infra/stacks/log-retention-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/log-retention-nested-stack.ts
@@ -1,0 +1,45 @@
+import { NestedStack, NestedStackProps } from 'aws-cdk-lib';
+import { LogRetention, RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { Construct } from 'constructs';
+
+export interface LogRetentionNestedStackProps extends NestedStackProps {
+  /**
+   * Absolute CloudWatch log group names (e.g. `/aws/lambda/<functionName>`).
+   * Names must be deterministic so this stack can apply retention without
+   * taking a cross-stack reference to the Lambda functions themselves.
+   */
+  logGroupNames: string[];
+  retention?: RetentionDays;
+}
+
+/**
+ * Sibling nested stack that owns every `Custom::LogRetention` resource for a
+ * domain's Lambdas. Keeping these out of the route-heavy Easy Genomics nested
+ * stack is what makes the CloudFormation 500-resource budget feasible —
+ * Custom::LogRetention has no physical identity, so relocating them across
+ * templates is a pure delete/recreate with an idempotent PutRetentionPolicy.
+ */
+export class LogRetentionNestedStack extends NestedStack {
+  constructor(scope: Construct, id: string, props: LogRetentionNestedStackProps) {
+    super(scope, id, props);
+
+    const retention = props.retention ?? RetentionDays.ONE_DAY;
+    // Deduplicate in case multiple LambdaConstructs share a namespace.
+    const uniqueNames = [...new Set(props.logGroupNames)];
+
+    uniqueNames.forEach((logGroupName, index) => {
+      // Construct ids must be unique and reasonably short; index + a sanitized
+      // suffix keeps them stable across synths as long as logGroupNames order
+      // is stable (LambdaConstruct registers handlers in filesystem walk order).
+      const sanitized = logGroupName.replace(/[^A-Za-z0-9]/g, '').slice(-48);
+      new LogRetention(this, `lr${index}-${sanitized}`, {
+        logGroupName,
+        retention,
+        logRetentionRetryOptions: {
+          // Attempt to avoid LogRetention creation failure due to throttling
+          maxRetries: 10, // AWS default is 3
+        },
+      });
+    });
+  }
+}

--- a/packages/back-end/test/app/controllers/easy-genomics/file/request-folder-download-job.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/file/request-folder-download-job.lambda.test.ts
@@ -3,7 +3,7 @@ import { handler } from '../../../../../src/app/controllers/easy-genomics/file/r
 
 jest.mock('../../../../../src/app/services/easy-genomics/laboratory-service');
 jest.mock('../../../../../src/app/services/s3-service');
-jest.mock('../../../../../src/app/services/sns-service');
+jest.mock('../../../../../src/app/services/sqs-service');
 jest.mock('../../../../../src/app/utils/auth-utils');
 jest.mock('../../../../../src/app/utils/laboratory-s3-access-utils', () => ({
   assertLaboratoryHasS3BucketAccess: jest.fn().mockResolvedValue(undefined),
@@ -11,7 +11,7 @@ jest.mock('../../../../../src/app/utils/laboratory-s3-access-utils', () => ({
 
 import { LaboratoryService } from '../../../../../src/app/services/easy-genomics/laboratory-service';
 import { S3Service } from '../../../../../src/app/services/s3-service';
-import { SnsService } from '../../../../../src/app/services/sns-service';
+import { SqsService } from '../../../../../src/app/services/sqs-service';
 import {
   validateLaboratoryManagerAccess,
   validateLaboratoryTechnicianAccess,
@@ -72,7 +72,7 @@ describe('request-folder-download-job Lambda', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    process.env.SNS_FOLDER_DOWNLOAD_TOPIC = 'arn:aws:sns:us-east-1:123:folder-download-topic.fifo';
+    process.env.SQS_FOLDER_DOWNLOAD_QUEUE_URL = 'arn:aws:sns:us-east-1:123:folder-download-topic.fifo';
 
     mockValidateOrgAdmin = validateOrganizationAdminAccess as jest.MockedFunction<
       typeof validateOrganizationAdminAccess
@@ -114,9 +114,9 @@ describe('request-folder-download-job Lambda', () => {
       });
     });
 
-    const mockSnsServiceInstance = SnsService as jest.MockedClass<typeof SnsService>;
+    const mockSqsServiceInstance = SqsService as jest.MockedClass<typeof SqsService>;
     mockPublish = jest.fn();
-    mockSnsServiceInstance.prototype.publish = mockPublish;
+    mockSqsServiceInstance.prototype.sendMessage = mockPublish;
   });
 
   it('creates a folder download job when user is authorized', async () => {
@@ -206,7 +206,7 @@ describe('request-folder-download-job Lambda', () => {
   });
 
   it('returns an error when SNS topic env is missing', async () => {
-    delete process.env.SNS_FOLDER_DOWNLOAD_TOPIC;
+    delete process.env.SQS_FOLDER_DOWNLOAD_QUEUE_URL;
     mockValidateOrgAdmin.mockReturnValue(true);
     mockQueryByLaboratoryId.mockResolvedValue(mockLaboratory);
     mockPutObject.mockResolvedValue({});

--- a/packages/back-end/test/app/controllers/easy-genomics/laboratory/delete-laboratory.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/laboratory/delete-laboratory.lambda.test.ts
@@ -6,13 +6,13 @@ jest.mock('../../../../../src/app/services/easy-genomics/laboratory-service');
 jest.mock('../../../../../src/app/services/easy-genomics/laboratory-user-service');
 jest.mock('../../../../../src/app/services/easy-genomics/laboratory-run-service');
 jest.mock('../../../../../src/app/services/ssm-service');
-jest.mock('../../../../../src/app/services/sns-service');
+jest.mock('../../../../../src/app/services/sqs-service');
 jest.mock('../../../../../src/app/utils/auth-utils');
 
 import { LaboratoryRunService } from '../../../../../src/app/services/easy-genomics/laboratory-run-service';
 import { LaboratoryService } from '../../../../../src/app/services/easy-genomics/laboratory-service';
 import { LaboratoryUserService } from '../../../../../src/app/services/easy-genomics/laboratory-user-service';
-import { SnsService } from '../../../../../src/app/services/sns-service';
+import { SqsService } from '../../../../../src/app/services/sqs-service';
 import { SsmService } from '../../../../../src/app/services/ssm-service';
 import { validateOrganizationAdminAccess } from '../../../../../src/app/utils/auth-utils';
 
@@ -21,7 +21,7 @@ describe('delete-laboratory.lambda', () => {
   let mockLabUserService: jest.MockedClass<typeof LaboratoryUserService>;
   let mockLabRunService: jest.MockedClass<typeof LaboratoryRunService>;
   let mockSsmService: jest.MockedClass<typeof SsmService>;
-  let mockSnsService: jest.MockedClass<typeof SnsService>;
+  let mockSqsService: jest.MockedClass<typeof SqsService>;
   let mockValidateOrgAdmin: jest.MockedFunction<typeof validateOrganizationAdminAccess>;
 
   const createEvent = (id: string | undefined, overrides: Partial<APIGatewayProxyWithCognitoAuthorizerEvent> = {}) =>
@@ -71,17 +71,17 @@ describe('delete-laboratory.lambda', () => {
     mockLabUserService = LaboratoryUserService as jest.MockedClass<typeof LaboratoryUserService>;
     mockLabRunService = LaboratoryRunService as jest.MockedClass<typeof LaboratoryRunService>;
     mockSsmService = SsmService as jest.MockedClass<typeof SsmService>;
-    mockSnsService = SnsService as jest.MockedClass<typeof SnsService>;
+    mockSqsService = SqsService as jest.MockedClass<typeof SqsService>;
     mockValidateOrgAdmin = validateOrganizationAdminAccess as any;
 
     mockValidateOrgAdmin.mockReturnValue(true);
-    process.env.SNS_LABORATORY_DELETION_TOPIC = 'arn:aws:sns:region:acct:lab-deletion';
+    process.env.SQS_LABORATORY_DELETION_QUEUE_URL = 'arn:aws:sns:region:acct:lab-deletion';
 
     mockLabService.prototype.queryByLaboratoryId = jest.fn();
     mockLabService.prototype.delete = jest.fn();
     mockLabUserService.prototype.queryByLaboratoryId = jest.fn();
     mockLabRunService.prototype.queryByLaboratoryId = jest.fn();
-    mockSnsService.prototype.publish = jest.fn();
+    mockSqsService.prototype.sendMessage = jest.fn();
     mockSsmService.prototype.deleteParameter = jest.fn();
   });
 
@@ -115,7 +115,7 @@ describe('delete-laboratory.lambda', () => {
     (mockLabRunService.prototype.queryByLaboratoryId as jest.Mock).mockResolvedValue([
       { LaboratoryId: 'lab-1', RunId: 'run-1' },
     ]);
-    (mockSnsService.prototype.publish as jest.Mock).mockResolvedValue({});
+    (mockSqsService.prototype.sendMessage as jest.Mock).mockResolvedValue({});
     (mockLabService.prototype.delete as jest.Mock).mockResolvedValue(true);
     (mockSsmService.prototype.deleteParameter as jest.Mock).mockResolvedValue({});
 
@@ -124,7 +124,7 @@ describe('delete-laboratory.lambda', () => {
     expect(result.statusCode).toBe(200);
     const body = JSON.parse(result.body);
     expect(body.Status).toBe('Success');
-    expect(mockSnsService.prototype.publish).toHaveBeenCalled();
+    expect(mockSqsService.prototype.sendMessage).toHaveBeenCalled();
     expect(mockLabService.prototype.delete).toHaveBeenCalled();
     expect(mockSsmService.prototype.deleteParameter).toHaveBeenCalled();
   });

--- a/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/create-laboratory-run.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/create-laboratory-run.lambda.test.ts
@@ -16,13 +16,13 @@ jest.mock('../../../../../../src/app/services/easy-genomics/run-cost-estimation-
 jest.mock('../../../../../../src/app/services/easy-genomics/run-input-profile-service', () => ({
   buildRunInputProfile: (...args: unknown[]) => mockBuildRunInputProfile(...args),
 }));
-jest.mock('../../../../../../src/app/services/sns-service');
+jest.mock('../../../../../../src/app/services/sqs-service');
 jest.mock('../../../../../../src/app/utils/auth-utils');
 
 import { handler } from '../../../../../../src/app/controllers/easy-genomics/laboratory/run/create-laboratory-run.lambda';
 import { LaboratoryRunService } from '../../../../../../src/app/services/easy-genomics/laboratory-run-service';
 import { LaboratoryService } from '../../../../../../src/app/services/easy-genomics/laboratory-service';
-import { SnsService } from '../../../../../../src/app/services/sns-service';
+import { SqsService } from '../../../../../../src/app/services/sqs-service';
 import {
   validateOrganizationAdminAccess,
   validateLaboratoryManagerAccess,
@@ -34,7 +34,7 @@ describe('create-laboratory-run.lambda', () => {
   const RUN_ID = '00000000-0000-0000-0000-000000000004';
   let mockRunService: jest.MockedClass<typeof LaboratoryRunService>;
   let mockLabService: jest.MockedClass<typeof LaboratoryService>;
-  let mockSnsService: jest.MockedClass<typeof SnsService>;
+  let mockSqsService: jest.MockedClass<typeof SqsService>;
   let mockValidateOrgAdmin: jest.MockedFunction<typeof validateOrganizationAdminAccess>;
   let mockValidateLabManager: jest.MockedFunction<typeof validateLaboratoryManagerAccess>;
   let mockValidateLabTechnician: jest.MockedFunction<typeof validateLaboratoryTechnicianAccess>;
@@ -100,7 +100,7 @@ describe('create-laboratory-run.lambda', () => {
     jest.clearAllMocks();
     mockRunService = LaboratoryRunService as jest.MockedClass<typeof LaboratoryRunService>;
     mockLabService = LaboratoryService as jest.MockedClass<typeof LaboratoryService>;
-    mockSnsService = SnsService as jest.MockedClass<typeof SnsService>;
+    mockSqsService = SqsService as jest.MockedClass<typeof SqsService>;
     mockValidateOrgAdmin = validateOrganizationAdminAccess as any;
     mockValidateLabManager = validateLaboratoryManagerAccess as any;
     mockValidateLabTechnician = validateLaboratoryTechnicianAccess as any;
@@ -112,7 +112,7 @@ describe('create-laboratory-run.lambda', () => {
     mockLabService.prototype.queryByLaboratoryId = jest.fn();
     mockRunService.prototype.add = jest.fn();
     mockRunService.prototype.update = jest.fn().mockImplementation(async (r) => r);
-    mockSnsService.prototype.publish = jest.fn();
+    mockSqsService.prototype.sendMessage = jest.fn();
     mockBuildRunInputProfile.mockResolvedValue({
       SampleCount: 0,
       InputFileCount: 0,
@@ -130,7 +130,7 @@ describe('create-laboratory-run.lambda', () => {
     });
     mockToPreRunCostEstimate.mockReturnValue(undefined);
 
-    process.env.SNS_LABORATORY_RUN_UPDATE_TOPIC = 'arn:aws:sns:region:acct:lab-run-update';
+    process.env.SQS_LABORATORY_RUN_UPDATE_QUEUE_URL = 'arn:aws:sns:region:acct:lab-run-update';
   });
 
   it('creates a laboratory run for an existing lab and queues status check when ExternalRunId is present', async () => {
@@ -154,7 +154,7 @@ describe('create-laboratory-run.lambda', () => {
     expect(body.RunId).toBe(RUN_ID);
     expect(mockLabService.prototype.queryByLaboratoryId).toHaveBeenCalledWith(LAB_ID);
     expect(mockRunService.prototype.add).toHaveBeenCalled();
-    expect(mockSnsService.prototype.publish).toHaveBeenCalled();
+    expect(mockSqsService.prototype.sendMessage).toHaveBeenCalled();
   });
 
   it('passes WorkflowVersionName through to laboratory run add when provided', async () => {
@@ -254,7 +254,7 @@ describe('create-laboratory-run.lambda', () => {
     const result = await handler(createEvent(body), createContext(), () => {});
 
     expect(result.statusCode).toBe(200);
-    expect(mockSnsService.prototype.publish).not.toHaveBeenCalled();
+    expect(mockSqsService.prototype.sendMessage).not.toHaveBeenCalled();
   });
 
   it('rejects invalid request body', async () => {

--- a/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.test.ts
@@ -14,7 +14,7 @@ jest.mock('../../../../../../src/app/services/easy-genomics/laboratory-service')
 jest.mock('../../../../../../src/app/services/easy-genomics/laboratory-run-service');
 jest.mock('../../../../../../src/app/services/easy-genomics/run-cost-capture-service');
 jest.mock('../../../../../../src/app/services/ssm-service');
-jest.mock('../../../../../../src/app/services/sns-service');
+jest.mock('../../../../../../src/app/services/sqs-service');
 jest.mock('../../../../../../src/app/services/omics-lab-factory');
 jest.mock('../../../../../../src/app/utils/rest-api-utils');
 
@@ -22,7 +22,7 @@ import { LaboratoryRunService } from '../../../../../../src/app/services/easy-ge
 import { LaboratoryService } from '../../../../../../src/app/services/easy-genomics/laboratory-service';
 import { captureRunCostOutcome } from '../../../../../../src/app/services/easy-genomics/run-cost-capture-service';
 import { createOmicsServiceForLab } from '../../../../../../src/app/services/omics-lab-factory';
-import { SnsService } from '../../../../../../src/app/services/sns-service';
+import { SqsService } from '../../../../../../src/app/services/sqs-service';
 import { SsmService } from '../../../../../../src/app/services/ssm-service';
 import { getNextFlowApiQueryParameters, httpRequest } from '../../../../../../src/app/utils/rest-api-utils';
 
@@ -30,7 +30,7 @@ describe('process-update-laboratory-run.lambda', () => {
   let mockLabService: jest.MockedClass<typeof LaboratoryService>;
   let mockRunService: jest.MockedClass<typeof LaboratoryRunService>;
   let mockSsmService: jest.MockedClass<typeof SsmService>;
-  let mockSnsService: jest.MockedClass<typeof SnsService>;
+  let mockSqsService: jest.MockedClass<typeof SqsService>;
 
   let mockQueryByRunId: jest.Mock;
   let mockUpdateRun: jest.Mock;
@@ -68,7 +68,7 @@ describe('process-update-laboratory-run.lambda', () => {
     mockLabService = LaboratoryService as jest.MockedClass<typeof LaboratoryService>;
     mockRunService = LaboratoryRunService as jest.MockedClass<typeof LaboratoryRunService>;
     mockSsmService = SsmService as jest.MockedClass<typeof SsmService>;
-    mockSnsService = SnsService as jest.MockedClass<typeof SnsService>;
+    mockSqsService = SqsService as jest.MockedClass<typeof SqsService>;
 
     mockQueryByRunId = jest.fn();
     mockUpdateWithAttributeRemoval = jest.fn();
@@ -85,7 +85,7 @@ describe('process-update-laboratory-run.lambda', () => {
     mockRunService.prototype.updateWithAttributeRemoval = mockUpdateWithAttributeRemoval;
     mockLabService.prototype.queryByLaboratoryId = mockQueryByLaboratoryId;
     mockSsmService.prototype.getParameter = mockGetParameter;
-    mockSnsService.prototype.publish = mockPublish;
+    mockSqsService.prototype.sendMessage = mockPublish;
     (createOmicsServiceForLab as jest.Mock).mockResolvedValue({
       getRun: mockGetRun,
       // Default: progress fetch fails (best-effort). Tests that need task progress mock this explicitly.
@@ -642,7 +642,7 @@ describe('process-update-laboratory-run.lambda', () => {
   });
 
   it('safePublishForClassification: publishes to SNS when run transitions to FAILED and FailureOwner is unset', async () => {
-    process.env.SNS_LABORATORY_RUN_FAILURE_CLASSIFICATION_TOPIC = 'arn:aws:sns:us-east-1:123:classify.fifo';
+    process.env.SQS_LABORATORY_RUN_FAILURE_CLASSIFICATION_QUEUE_URL = 'arn:aws:sns:us-east-1:123:classify.fifo';
 
     mockQueryByRunId.mockResolvedValue({
       RunId: 'run-1',
@@ -660,14 +660,14 @@ describe('process-update-laboratory-run.lambda', () => {
 
     expect(mockPublish).toHaveBeenCalledWith(
       expect.objectContaining({
-        TopicArn: 'arn:aws:sns:us-east-1:123:classify.fifo',
+        QueueUrl: 'arn:aws:sns:us-east-1:123:classify.fifo',
         MessageGroupId: 'classify-laboratory-run-run-1',
       }),
     );
   });
 
   it('safePublishForClassification: skips publish when FailureOwner is already set', async () => {
-    process.env.SNS_LABORATORY_RUN_FAILURE_CLASSIFICATION_TOPIC = 'arn:aws:sns:us-east-1:123:classify.fifo';
+    process.env.SQS_LABORATORY_RUN_FAILURE_CLASSIFICATION_QUEUE_URL = 'arn:aws:sns:us-east-1:123:classify.fifo';
 
     mockQueryByRunId.mockResolvedValue({
       RunId: 'run-1',
@@ -688,7 +688,7 @@ describe('process-update-laboratory-run.lambda', () => {
   });
 
   it('safePublishForClassification: skips publish when topic ARN env var is unset', async () => {
-    delete process.env.SNS_LABORATORY_RUN_FAILURE_CLASSIFICATION_TOPIC;
+    delete process.env.SQS_LABORATORY_RUN_FAILURE_CLASSIFICATION_QUEUE_URL;
 
     mockQueryByRunId.mockResolvedValue({
       RunId: 'run-1',
@@ -708,7 +708,7 @@ describe('process-update-laboratory-run.lambda', () => {
   });
 
   it('safePublishForClassification: swallows SNS errors so the status-check pipeline completes', async () => {
-    process.env.SNS_LABORATORY_RUN_FAILURE_CLASSIFICATION_TOPIC = 'arn:aws:sns:us-east-1:123:classify.fifo';
+    process.env.SQS_LABORATORY_RUN_FAILURE_CLASSIFICATION_QUEUE_URL = 'arn:aws:sns:us-east-1:123:classify.fifo';
     mockPublish.mockRejectedValue(new Error('SNS unavailable'));
 
     mockQueryByRunId.mockResolvedValue({

--- a/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/request-laboratory-run-status-check.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/request-laboratory-run-status-check.lambda.test.ts
@@ -3,12 +3,12 @@ import { handler } from '../../../../../../src/app/controllers/easy-genomics/lab
 
 jest.mock('../../../../../../src/app/services/easy-genomics/laboratory-run-service');
 jest.mock('../../../../../../src/app/services/easy-genomics/laboratory-service');
-jest.mock('../../../../../../src/app/services/sns-service');
+jest.mock('../../../../../../src/app/services/sqs-service');
 jest.mock('../../../../../../src/app/utils/auth-utils');
 
 import { LaboratoryRunService } from '../../../../../../src/app/services/easy-genomics/laboratory-run-service';
 import { LaboratoryService } from '../../../../../../src/app/services/easy-genomics/laboratory-service';
-import { SnsService } from '../../../../../../src/app/services/sns-service';
+import { SqsService } from '../../../../../../src/app/services/sqs-service';
 import {
   validateLaboratoryManagerAccess,
   validateLaboratoryTechnicianAccess,
@@ -18,7 +18,7 @@ import {
 describe('request-laboratory-run-status-check.lambda', () => {
   let mockRunService: jest.MockedClass<typeof LaboratoryRunService>;
   let mockLabService: jest.MockedClass<typeof LaboratoryService>;
-  let mockSnsService: jest.MockedClass<typeof SnsService>;
+  let mockSqsService: jest.MockedClass<typeof SqsService>;
   let mockValidateOrgAdmin: jest.MockedFunction<typeof validateOrganizationAdminAccess>;
   let mockValidateLabManager: jest.MockedFunction<typeof validateLaboratoryManagerAccess>;
   let mockValidateLabTechnician: jest.MockedFunction<typeof validateLaboratoryTechnicianAccess>;
@@ -72,7 +72,7 @@ describe('request-laboratory-run-status-check.lambda', () => {
     jest.clearAllMocks();
     mockRunService = LaboratoryRunService as jest.MockedClass<typeof LaboratoryRunService>;
     mockLabService = LaboratoryService as jest.MockedClass<typeof LaboratoryService>;
-    mockSnsService = SnsService as jest.MockedClass<typeof SnsService>;
+    mockSqsService = SqsService as jest.MockedClass<typeof SqsService>;
     mockValidateOrgAdmin = validateOrganizationAdminAccess as any;
     mockValidateLabManager = validateLaboratoryManagerAccess as any;
     mockValidateLabTechnician = validateLaboratoryTechnicianAccess as any;
@@ -83,9 +83,9 @@ describe('request-laboratory-run-status-check.lambda', () => {
 
     mockLabService.prototype.queryByLaboratoryId = jest.fn();
     mockRunService.prototype.queryByRunId = jest.fn();
-    mockSnsService.prototype.publish = jest.fn();
+    mockSqsService.prototype.sendMessage = jest.fn();
 
-    process.env.SNS_LABORATORY_RUN_UPDATE_TOPIC = 'arn:aws:sns:region:acct:lab-run-update';
+    process.env.SQS_LABORATORY_RUN_UPDATE_QUEUE_URL = 'arn:aws:sns:region:acct:lab-run-update';
   });
 
   it('returns 400 when laboratoryId query parameter is missing', async () => {
@@ -174,6 +174,6 @@ describe('request-laboratory-run-status-check.lambda', () => {
     expect(result.statusCode).toBe(200);
     const body = JSON.parse(result.body);
     expect(body.Count).toBe(2);
-    expect(mockSnsService.prototype.publish).toHaveBeenCalledTimes(2);
+    expect(mockSqsService.prototype.sendMessage).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/update-laboratory-run.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/update-laboratory-run.lambda.test.ts
@@ -3,14 +3,14 @@ import { handler } from '../../../../../../src/app/controllers/easy-genomics/lab
 
 jest.mock('../../../../../../src/app/services/easy-genomics/laboratory-run-service');
 jest.mock('../../../../../../src/app/services/easy-genomics/laboratory-service');
-jest.mock('../../../../../../src/app/services/sns-service');
+jest.mock('../../../../../../src/app/services/sqs-service');
 jest.mock('../../../../../../src/app/utils/auth-utils');
 
 import { LaboratoryDataTaggingService } from '../../../../../../src/app/services/easy-genomics/laboratory-data-tagging-service';
 
 import { LaboratoryRunService } from '../../../../../../src/app/services/easy-genomics/laboratory-run-service';
 import { LaboratoryService } from '../../../../../../src/app/services/easy-genomics/laboratory-service';
-import { SnsService } from '../../../../../../src/app/services/sns-service';
+import { SqsService } from '../../../../../../src/app/services/sqs-service';
 import {
   validateLaboratoryManagerAccess,
   validateLaboratoryTechnicianAccess,
@@ -23,7 +23,7 @@ describe('update-laboratory-run.lambda', () => {
 
   let mockRunService: jest.MockedClass<typeof LaboratoryRunService>;
   let mockLabService: jest.MockedClass<typeof LaboratoryService>;
-  let mockSnsService: jest.MockedClass<typeof SnsService>;
+  let mockSqsService: jest.MockedClass<typeof SqsService>;
   let mockValidateOrgAdmin: jest.MockedFunction<typeof validateOrganizationAdminAccess>;
   let mockValidateLabManager: jest.MockedFunction<typeof validateLaboratoryManagerAccess>;
   let mockValidateLabTechnician: jest.MockedFunction<typeof validateLaboratoryTechnicianAccess>;
@@ -89,7 +89,7 @@ describe('update-laboratory-run.lambda', () => {
     jest.clearAllMocks();
     mockRunService = LaboratoryRunService as jest.MockedClass<typeof LaboratoryRunService>;
     mockLabService = LaboratoryService as jest.MockedClass<typeof LaboratoryService>;
-    mockSnsService = SnsService as jest.MockedClass<typeof SnsService>;
+    mockSqsService = SqsService as jest.MockedClass<typeof SqsService>;
     mockValidateOrgAdmin = validateOrganizationAdminAccess as any;
     mockValidateLabManager = validateLaboratoryManagerAccess as any;
     mockValidateLabTechnician = validateLaboratoryTechnicianAccess as any;
@@ -106,7 +106,7 @@ describe('update-laboratory-run.lambda', () => {
     mockRunService.prototype.queryByRunId = mockQueryByRunId;
     mockRunService.prototype.update = mockUpdateRun;
     mockLabService.prototype.queryByLaboratoryId = mockQueryByLaboratoryId;
-    mockSnsService.prototype.publish = mockPublish;
+    mockSqsService.prototype.sendMessage = mockPublish;
 
     mockQueryByLaboratoryId.mockResolvedValue({
       LaboratoryId: LAB_ID,
@@ -114,7 +114,7 @@ describe('update-laboratory-run.lambda', () => {
       RunRetentionMonths: 0,
     });
 
-    process.env.SNS_LABORATORY_RUN_UPDATE_TOPIC = 'arn:aws:sns:region:acct:lab-run-update';
+    process.env.SQS_LABORATORY_RUN_UPDATE_QUEUE_URL = 'arn:aws:sns:region:acct:lab-run-update';
 
     propagateExpiresSpy = jest
       .spyOn(LaboratoryDataTaggingService.prototype, 'updateRunUsageExpiresAt')
@@ -185,7 +185,7 @@ describe('update-laboratory-run.lambda', () => {
     const body = JSON.parse(result.body);
     expect(body.Status).toBe('RUNNING');
     expect(mockRunService.prototype.update).toHaveBeenCalled();
-    expect(mockSnsService.prototype.publish).toHaveBeenCalled();
+    expect(mockSqsService.prototype.sendMessage).toHaveBeenCalled();
     expect(mockUpdateRun).toHaveBeenCalled();
     expect(mockPublish).toHaveBeenCalled();
   });

--- a/packages/back-end/test/app/controllers/easy-genomics/user/create-bulk-user-invitation-requests.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/user/create-bulk-user-invitation-requests.lambda.test.ts
@@ -3,11 +3,11 @@ import { APIGatewayProxyResult, APIGatewayProxyWithCognitoAuthorizerEvent } from
 import { handler } from '../../../../../src/app/controllers/easy-genomics/user/create-bulk-user-invitation-requests.lambda';
 
 jest.mock('../../../../../src/app/services/easy-genomics/organization-service');
-jest.mock('../../../../../src/app/services/sns-service');
+jest.mock('../../../../../src/app/services/sqs-service');
 jest.mock('../../../../../src/app/utils/auth-utils');
 
 import { OrganizationService } from '../../../../../src/app/services/easy-genomics/organization-service';
-import { SnsService } from '../../../../../src/app/services/sns-service';
+import { SqsService } from '../../../../../src/app/services/sqs-service';
 import { validateSystemAdminAccess, validateOrganizationAdminAccess } from '../../../../../src/app/utils/auth-utils';
 
 const ORG_ID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
@@ -37,14 +37,14 @@ describe('create-bulk-user-invitation-requests Lambda', () => {
   let mockValidateSysAdmin: jest.MockedFunction<typeof validateSystemAdminAccess>;
   let mockValidateOrgAdmin: jest.MockedFunction<typeof validateOrganizationAdminAccess>;
   let mockOrgGet: jest.Mock;
-  let mockSnsPublish: jest.Mock;
+  let mockSqsSendMessage: jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(console, 'log').mockImplementation(() => {});
     jest.spyOn(console, 'error').mockImplementation(() => {});
 
-    process.env.SNS_USER_INVITE_TOPIC = 'arn:aws:sns:us-east-1:123456789012:test-topic.fifo';
+    process.env.SQS_USER_INVITE_QUEUE_URL = 'arn:aws:sns:us-east-1:123456789012:test-topic.fifo';
 
     mockValidateSysAdmin = validateSystemAdminAccess as jest.MockedFunction<typeof validateSystemAdminAccess>;
     mockValidateOrgAdmin = validateOrganizationAdminAccess as jest.MockedFunction<
@@ -55,9 +55,9 @@ describe('create-bulk-user-invitation-requests Lambda', () => {
     mockOrgGet = jest.fn();
     MockOrgService.prototype.get = mockOrgGet;
 
-    const MockSnsService = SnsService as jest.MockedClass<typeof SnsService>;
-    mockSnsPublish = jest.fn();
-    MockSnsService.prototype.publish = mockSnsPublish;
+    const MockSqsService = SqsService as jest.MockedClass<typeof SqsService>;
+    mockSqsSendMessage = jest.fn();
+    MockSqsService.prototype.sendMessage = mockSqsSendMessage;
   });
 
   it('returns EG-102 when the request body fails Zod validation', async () => {
@@ -98,7 +98,7 @@ describe('create-bulk-user-invitation-requests Lambda', () => {
   it('publishes one SNS message per email and returns success', async () => {
     mockValidateSysAdmin.mockReturnValue(true);
     mockOrgGet.mockResolvedValue({ OrganizationId: ORG_ID });
-    mockSnsPublish.mockResolvedValue({});
+    mockSqsSendMessage.mockResolvedValue({});
 
     const emails = ['a@example.com', 'b@example.com'];
     const result = (await handler(
@@ -109,6 +109,6 @@ describe('create-bulk-user-invitation-requests Lambda', () => {
 
     expect(result.statusCode).toBe(200);
     expect(JSON.parse(result.body)).toEqual({ Status: 'success' });
-    expect(mockSnsPublish).toHaveBeenCalledTimes(emails.length);
+    expect(mockSqsSendMessage).toHaveBeenCalledTimes(emails.length);
   });
 });

--- a/packages/back-end/test/infra/stacks/easy-genomics-nested-stack.test.ts
+++ b/packages/back-end/test/infra/stacks/easy-genomics-nested-stack.test.ts
@@ -27,6 +27,7 @@ jest.mock('../../../src/infra/constructs/iam-construct', () => ({
 jest.mock('../../../src/infra/constructs/lambda-construct', () => ({
   LambdaConstruct: jest.fn().mockImplementation(() => ({
     lambdaFunctions: new Map<string, unknown>(),
+    logGroupNames: [],
   })),
 }));
 
@@ -34,28 +35,19 @@ jest.mock('../../../src/infra/constructs/ses-construct', () => ({
   SesConstruct: jest.fn().mockImplementation(() => ({})),
 }));
 
-jest.mock('../../../src/infra/constructs/sns-construct', () => ({
-  SnsConstruct: jest.fn().mockImplementation(() => ({
-    snsTopics: new Map<string, any>([
-      ['organization-deletion-topic', { topicArn: 'arn:aws:sns:org', addToResourcePolicy: jest.fn() }],
-      ['laboratory-deletion-topic', { topicArn: 'arn:aws:sns:lab', addToResourcePolicy: jest.fn() }],
-      ['user-deletion-topic', { topicArn: 'arn:aws:sns:user', addToResourcePolicy: jest.fn() }],
-      ['laboratory-run-update-topic', { topicArn: 'arn:aws:sns:run', addToResourcePolicy: jest.fn() }],
-      ['user-invite-topic', { topicArn: 'arn:aws:sns:invite', addToResourcePolicy: jest.fn() }],
-      ['folder-download-topic', { topicArn: 'arn:aws:sns:folder-download', addToResourcePolicy: jest.fn() }],
-    ]),
-  })),
-}));
-
 jest.mock('../../../src/infra/constructs/sqs-construct', () => ({
   SqsConstruct: jest.fn().mockImplementation(() => ({
     sqsQueues: new Map<string, any>([
-      ['organization-management-queue', {}],
-      ['laboratory-management-queue', {}],
-      ['user-management-queue', {}],
-      ['laboratory-run-update-queue', {}],
-      ['user-invite-queue', {}],
-      ['folder-download-queue', {}],
+      ['organization-management-queue', { queueUrl: 'https://sqs/org', queueArn: 'arn:aws:sqs:org' }],
+      ['laboratory-management-queue', { queueUrl: 'https://sqs/lab', queueArn: 'arn:aws:sqs:lab' }],
+      ['user-management-queue', { queueUrl: 'https://sqs/user', queueArn: 'arn:aws:sqs:user' }],
+      ['laboratory-run-update-queue', { queueUrl: 'https://sqs/run', queueArn: 'arn:aws:sqs:run' }],
+      ['user-invite-queue', { queueUrl: 'https://sqs/invite', queueArn: 'arn:aws:sqs:invite' }],
+      [
+        'laboratory-run-failure-classification-queue',
+        { queueUrl: 'https://sqs/classify', queueArn: 'arn:aws:sqs:classify' },
+      ],
+      ['folder-download-queue', { queueUrl: 'https://sqs/folder', queueArn: 'arn:aws:sqs:folder' }],
     ]),
   })),
 }));


### PR DESCRIPTION
## Title*
Reduce Easy Genomics nested stack from 459 to 235 CloudFormation resources (EGV-236)

## Type of Change*
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
The synth-time stack-resource-budget guardrail was failing: the Easy Genomics
nested stack hit 459 resources (fail threshold 450, CloudFormation hard limit
500). ~88% of the template was per-handler overhead — every controller Lambda
emitted 4 resources (Function, ServiceRole, DefaultPolicy, Custom::LogRetention).

This PR cuts the stack to 235 resources (47% of the hard limit) via three
changes, deliberately chosen so **no physically-named resource moves between
stacks** — no `cdk import` runbook or manual migration is required:

1. **Inline IAM policies** (`lambda-construct.ts`): each handler now gets an
   explicit `Role` with its endpoint policy embedded via `inlinePolicies`,
   plus `AWSLambdaBasicExecutionRole` / `AWSXRayDaemonWriteAccess` managed
   policies. Handlers without event sources receive `role.withoutPolicyUpdates()`
   so CDK's Tracing.ACTIVE grant cannot recreate a DefaultPolicy; the 8
   event-source handlers keep a mutable role so SQS/DynamoDB stream grants
   still land. Removes ~92 `AWS::IAM::Policy` resources with identical
   effective permissions. cdk-nag suppression paths repointed accordingly.
2. **Log retention relocated** (`log-retention-nested-stack.ts`): all
   `Custom::LogRetention` resources move to sibling nested stacks under
   `EasyGenomicsApiStack` and `BackEndStack`, targeting the deterministic
   `/aws/lambda/<functionName>` names (no cross-stack references). Retention
   behaviour (1 day) is unchanged; `PutRetentionPolicy` is idempotent.
3. **SNS layer collapsed**: the seven SNS topics were each 1:1 with a single
   SQS FIFO queue (no fan-out). Publishers now send directly to the queues
   via `SqsService.sendMessage` (`SQS_*_QUEUE_URL` env vars); consumers use
   `parseSqsJsonBody`, which accepts both raw payloads and legacy SNS
   envelopes so in-flight messages survive a rolling deploy. Removes 21
   Topic/TopicPolicy/Subscription resources and the manual SSL-deny topic
   policy workaround.

Guardrail thresholds are intentionally unchanged (warn 400 / fail 450).

## Testing*
- `cdk synth` passes the resource budget guardrail; per-stack counts:
  easy-genomics nested stack 235/500, log-retention nested stack 104,
  platform log-retention nested stack 34.
- Template inspection confirms the nested stack now contains 100 roles /
  100 functions / 8 policies (event-source handlers only), zero SNS and zero
  `Custom::LogRetention` resources, and per-handler permission statements
  unchanged.
- 121 unit tests across the 14 affected suites pass (publishers, consumers,
  nested-stack wiring, resource-budget guardrail).

## Impact
- No API, data, or physical resource name changes; Lambda role swaps are
  in-place updates.
- The seven SNS topics will be deleted on deploy; anything external
  subscribing to them (none known) would break. Future fan-out would need
  the topic layer reinstated.
- Old log groups keep their existing retention; the relocated LogRetention
  resources re-apply 1-day retention idempotently.
- Frees headroom for ~45 more endpoints before the warn threshold.

## Additional Information
- The in-flight SNS-envelope compatibility in `parseSqsJsonBody` can be
  removed in a follow-up once all environments have deployed this change.
- Splitting the nested stack by sub-domain remains the long-term relief
  valve but requires a stack-refactor playbook due to explicit
  `functionName`s, so it was deliberately avoided here.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.